### PR TITLE
Change of tactics for dependency injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,6 @@ npm-shrinkwrap.json
 # See: build-service-container.sh
 package-json.tar
 
-server.key
-server.crt
+*.key
+*.crt
 .DS_Store

--- a/modules-js/hapi-next/src/hapi-next.ts
+++ b/modules-js/hapi-next/src/hapi-next.ts
@@ -1,6 +1,11 @@
 import url from 'url';
 import next from 'next';
 import { ServerRoute } from 'hapi';
+import { IncomingMessage } from 'http';
+
+export interface ExtendedIncomingMessage extends IncomingMessage {
+  payload: any;
+}
 
 /**
  * Makes a Hapi route object to render the Next app from the given module at the
@@ -62,7 +67,7 @@ export function makeRoutesForNextApp(
 
         // Pass any Hapi payload along so we can handle form POSTs in
         // getInitialProps if we want to.
-        (req as any).payload = request.payload;
+        (req as ExtendedIncomingMessage).payload = request.payload;
 
         // Our actual pages are mounted at their expected paths (e.g.
         // /commissions/apply in the commissions app, not /apply) so we don’t

--- a/modules-js/next-client-common/src/next-client-common.ts
+++ b/modules-js/next-client-common/src/next-client-common.ts
@@ -1,12 +1,19 @@
 import fetch from 'isomorphic-fetch';
 import getConfig from 'next/config';
-import { IncomingMessage } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 
+export { default as RouterListener } from './RouterListener';
 export * from './RouterListener';
 
 export const API_KEY_CONFIG_KEY = 'graphqlApiKey';
 export const HAPI_INJECT_CONFIG_KEY = 'graphqlHapiInject';
 export const GRAPHQL_PATH_KEY = 'graphqlPath';
+
+export interface NextContext<Req> {
+  query: { [key: string]: string };
+  req?: Req;
+  resp?: ServerResponse;
+}
 
 export interface PublicRuntimeConfig {
   [API_KEY_CONFIG_KEY]: string;
@@ -188,7 +195,7 @@ export type FetchGraphql = (
 
 export function makeFetchGraphql(
   runtimeConfig: RuntimeConfig,
-  parentRequest: IncomingMessage | undefined
+  parentRequest?: IncomingMessage
 ): FetchGraphql {
   if ((process as any).browser) {
     return clientFetchGraphql.bind(null, runtimeConfig);

--- a/services-js/access-boston/src/pages/_app.tsx
+++ b/services-js/access-boston/src/pages/_app.tsx
@@ -3,59 +3,114 @@ import App, { Container } from 'next/app';
 import Router from 'next/router';
 import getConfig from 'next/config';
 import cookies from 'next-cookies';
-
 import { hydrate } from 'react-emotion';
 
-import CrumbContext from '../client/CrumbContext';
-import RouterListener from '@cityofboston/next-client-common/build/RouterListener';
 import {
   FetchGraphql,
   makeFetchGraphql,
+  RouterListener,
+  NextContext,
 } from '@cityofboston/next-client-common';
 
-export interface AppDependencies {
+import { ExtendedIncomingMessage } from '@cityofboston/hapi-next';
+
+import CrumbContext from '../client/CrumbContext';
+
+/**
+ * Our App’s getInitialProps automatically calls the page’s getInitialProps with
+ * an instance of this class as the second argument, after the Next context.
+ */
+export interface GetInitialPropsDependencies {
   fetchGraphql: FetchGraphql;
+}
+
+export type GetInitialProps<T> = (
+  cxt: NextContext<ExtendedIncomingMessage>,
+  deps: GetInitialPropsDependencies
+) => T | Promise<T>;
+
+/**
+ * These props are automatically given to any Pages in the app. While magically
+ * providing Props out of nowhere is a bit hard to follow, this pattern seems to
+ * have the best combination of allowing Pages to be explicit about their
+ * dependencies for testing purposes while avoiding too much boilerplate of
+ * wrapper components and Context.Consumer render props.
+ *
+ * To use this:
+ *
+ * interface InitialProps {foo: string; bar: string[];
+ * }
+ *
+ * interface Props extends InitialProps, Pick<PageDependencies, 'fetchGraphql'>
+ * {}
+ *
+ * class MyPage extends React.Component<Props> {static getInitialProps:
+ *   GetInitialProps<InitialProps> = async (ctx, initialDeps) => {
+ *     ...
+ *   }
+ *
+ *   handleAction: () => {this.props.fetchGraphql(…);
+ *   }
+ * }
+ */
+export interface PageDependencies {
   routerListener: RouterListener;
+  fetchGraphql: FetchGraphql;
 }
 
 interface InitialProps {
   pageProps: any;
-  crumb: string;
-  appDependencies: AppDependencies;
+  serverCrumb: string;
 }
 
 interface Props extends InitialProps {
   Component: any;
 }
 
+interface State {
+  /** We have to keep the crumb in state because after the initial server-side
+   * render, getInitialProps is unable to read it off of the cookies. */
+  crumb: string;
+}
+
 /**
- * Custom app wrapper. Sets up global dependencies and passes them in as a
- * second argument to getInitialProps for our pages.
+ * Custom app wrapper for setting up global dependencies:
+ *
+ *  - GetInitialPropsDependencies are passed as a second argument to getInitialProps
+ *  - PageDependencies are spread as props for the page
  */
 export default class AccessBostonApp extends App {
-  props: Props;
+  // TypeScript doesn't know that App already has a props member.
+  protected props: Props;
+  protected state: State;
+
+  private pageDependencies: PageDependencies;
 
   static async getInitialProps({ Component, ctx }): Promise<InitialProps> {
-    const appDependencies: AppDependencies = {
+    const initialPageDependencies: GetInitialPropsDependencies = {
       fetchGraphql: makeFetchGraphql(getConfig(), ctx.req),
-      routerListener: new RouterListener(),
     };
 
-    // crumb is our XSRF token from the Hapi plugin
-    const { crumb } = cookies(ctx);
+    // Crumb is our XSRF token from the Hapi plugin. It's only available on the
+    // server.
+    const { crumb } = ctx.req ? cookies(ctx) : { crumb: '' };
 
     const pageProps = Component.getInitialProps
-      ? await Component.getInitialProps(ctx, appDependencies)
+      ? await Component.getInitialProps(ctx, initialPageDependencies)
       : {};
 
-    return { pageProps, appDependencies, crumb: crumb || '' };
+    return {
+      pageProps,
+      serverCrumb: crumb || '',
+    };
   }
 
   constructor(props: Props) {
     super(props);
 
     // We're a little hacky here because TypeScript doesn't have type
-    // information about App and doesn't know it's a component.
+    // information about App and doesn't know it's a component and that the
+    // super call above actually does this.
     this.props = props;
 
     // Adds server generated styles to emotion cache.
@@ -63,25 +118,35 @@ export default class AccessBostonApp extends App {
     if (typeof window !== 'undefined') {
       hydrate((window as any).__NEXT_DATA__.ids);
     }
+
+    this.state = {
+      crumb: this.props.serverCrumb,
+    };
+
+    this.pageDependencies = {
+      routerListener: new RouterListener(),
+      fetchGraphql: makeFetchGraphql(getConfig()),
+    };
   }
 
   componentDidMount() {
-    const { routerListener } = this.props.appDependencies;
+    const { routerListener } = this.pageDependencies;
     routerListener.attach(Router, (window as any).ga);
   }
 
   componentWillUnmount() {
-    const { routerListener } = this.props.appDependencies;
+    const { routerListener } = this.pageDependencies;
     routerListener.detach();
   }
 
   render() {
-    const { Component, pageProps, crumb } = this.props;
+    const { Component, pageProps } = this.props;
+    const { crumb } = this.state;
 
     return (
       <CrumbContext.Provider value={crumb}>
         <Container>
-          <Component {...pageProps} />
+          <Component {...this.pageDependencies} {...pageProps} />
         </Container>
       </CrumbContext.Provider>
     );

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -14,21 +14,21 @@ import fetchAccountAndApps, {
   Account,
   Apps,
 } from '../client/graphql/fetch-account-and-apps';
-import { AppDependencies } from './_app';
+import { GetInitialPropsDependencies, GetInitialProps } from './_app';
 import { MAIN_CLASS } from '../client/styles';
 
-export enum Message {
+export enum FlashMessage {
   CHANGE_PASSWORD_SUCCESS = 'password',
 }
 
-const MESSAGE_STRINGS = {
-  [Message.CHANGE_PASSWORD_SUCCESS]: 'Your password has been changed!',
+const FLASH_MESSAGE_STRINGS = {
+  [FlashMessage.CHANGE_PASSWORD_SUCCESS]: 'Your password has been changed!',
 };
 
 interface Props {
   account: Account;
   apps: Apps;
-  message?: Message | null;
+  flashMessage?: FlashMessage;
 }
 
 const APP_ROW_STYLE = css({
@@ -37,15 +37,15 @@ const APP_ROW_STYLE = css({
 });
 
 export default class IndexPage extends React.Component<Props> {
-  static async getInitialProps(
+  static getInitialProps: GetInitialProps<Props> = async (
     { query },
-    { fetchGraphql }: AppDependencies
-  ): Promise<Props> {
+    { fetchGraphql }: GetInitialPropsDependencies
+  ): Promise<Props> => {
     return {
-      message: query.message || null,
+      flashMessage: query.message as FlashMessage | undefined,
       ...(await fetchAccountAndApps(fetchGraphql)),
     };
-  }
+  };
 
   state = {
     accountMenuOpen: false,
@@ -54,7 +54,7 @@ export default class IndexPage extends React.Component<Props> {
   render() {
     const {
       account,
-      message,
+      flashMessage,
       apps: { categories },
     } = this.props;
 
@@ -71,10 +71,10 @@ export default class IndexPage extends React.Component<Props> {
         <AccessBostonHeader account={account} />
 
         <div className={MAIN_CLASS}>
-          {message && (
+          {flashMessage && (
             <div className="b--g">
               <div className="t--intro p-a300 m-b300">
-                {MESSAGE_STRINGS[message]}
+                {FLASH_MESSAGE_STRINGS[flashMessage]}
               </div>
             </div>
           )}
@@ -117,7 +117,7 @@ export default class IndexPage extends React.Component<Props> {
     );
   }
 
-  renderAppList(apps) {
+  private renderAppList(apps) {
     return (
       <ul className="ul m-v500">
         {apps.map(({ title, url, description }) => (
@@ -136,7 +136,7 @@ export default class IndexPage extends React.Component<Props> {
     );
   }
 
-  renderAppIcons(apps) {
+  private renderAppIcons(apps) {
     return (
       <div className="g">
         {apps.map(({ title, url, iconUrl }) => (

--- a/services-js/access-boston/src/stories/IndexPage.stories.tsx
+++ b/services-js/access-boston/src/stories/IndexPage.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import IndexPage, { Message } from '../pages/index';
+import IndexPage, { FlashMessage } from '../pages/index';
 import { Account, Apps } from '../client/graphql/fetch-account-and-apps';
 
 const ACCOUNT: Account = {
@@ -76,6 +76,6 @@ storiesOf('IndexPage', module)
     <IndexPage
       account={ACCOUNT}
       apps={APPS}
-      message={Message.CHANGE_PASSWORD_SUCCESS}
+      flashMessage={FlashMessage.CHANGE_PASSWORD_SUCCESS}
     />
   ));


### PR DESCRIPTION
Fix for getInitialProps trying to return non-serializable
dependencies.

Spreads PageDependencies in _app.tsx and uses Pick<> to make getting
them typesafe.