### PR TITLE
Refactor of Access Boston authentication

### DIFF
--- a/modules-js/hapi-next/src/hapi-next.ts
+++ b/modules-js/hapi-next/src/hapi-next.ts
@@ -60,21 +60,7 @@ export function makeRoutesForNextApp(
     {
       path: `${pathPrefix}{p*}`,
       method: ['GET', 'POST'],
-      handler: async (request, h) => {
-        const {
-          raw: { req, res },
-        } = request;
-
-        // Pass any Hapi payload along so we can handle form POSTs in
-        // getInitialProps if we want to.
-        (req as ExtendedIncomingMessage).payload = request.payload;
-
-        // Our actual pages are mounted at their expected paths (e.g.
-        // /commissions/apply in the commissions app, not /apply) so we don’t
-        // need to do any URL transforming.
-        await requestHandler(req, res);
-        return h.close;
-      },
+      handler: makeNextHandler(app),
       options: pageRouteOptions,
     },
     {
@@ -94,4 +80,24 @@ export function makeRoutesForNextApp(
   ];
 
   return routes;
+}
+
+export function makeNextHandler(app: next.Server) {
+  const requestHandler = app.getRequestHandler();
+
+  return async (request, h) => {
+    const {
+      raw: { req, res },
+    } = request;
+
+    // Pass any Hapi payload along so we can handle form POSTs in
+    // getInitialProps if we want to.
+    (req as ExtendedIncomingMessage).payload = request.payload;
+
+    // Our actual pages are mounted at their expected paths (e.g.
+    // /commissions/apply in the commissions app, not /apply) so we don’t
+    // need to do any URL transforming.
+    await requestHandler(req, res);
+    return h.close;
+  };
 }

--- a/services-js/access-boston/.gitignore
+++ b/services-js/access-boston/.gitignore
@@ -1,4 +1,5 @@
 /saml-metadata.xml
+/saml-forgot-metadata.xml
 service-provider.crt
 service-provider.key
 /apps.yaml

--- a/services-js/access-boston/src/client/AccessBostonHeader.tsx
+++ b/services-js/access-boston/src/client/AccessBostonHeader.tsx
@@ -33,12 +33,12 @@ const ACCESS_BOSTON_TITLE_STYLE = css({
 });
 
 interface Props {
-  account: Account;
+  account?: Account;
 }
 
 export default class AccessBostonHeader extends React.Component<Props> {
   render() {
-    const { employeeId } = this.props.account;
+    const { account } = this.props;
 
     return (
       <CrumbContext.Consumer>
@@ -49,13 +49,15 @@ export default class AccessBostonHeader extends React.Component<Props> {
                 <a style={{ color: 'inherit' }}>Access Boston</a>
               </Link>
             </h1>
-            <div className={`${HEADER_RIGHT_STYLE}`}>
-              <span style={{ marginRight: '1em' }}>{employeeId}</span>
-              <form action="/logout" method="POST">
-                <input type="hidden" name="crumb" value={crumb} />
-                <button className="btn btn--sm btn--100">Logout</button>
-              </form>
-            </div>
+            {account && (
+              <div className={`${HEADER_RIGHT_STYLE}`}>
+                <span style={{ marginRight: '1em' }}>{account.employeeId}</span>
+                <form action="/logout" method="POST">
+                  <input type="hidden" name="crumb" value={crumb} />
+                  <button className="btn btn--sm btn--100">Logout</button>
+                </form>
+              </div>
+            )}
           </div>
         )}
       </CrumbContext.Consumer>

--- a/services-js/access-boston/src/lib/validation.ts
+++ b/services-js/access-boston/src/lib/validation.ts
@@ -29,8 +29,7 @@ export function analyzePassword(password: string) {
   };
 }
 
-export const changePasswordSchema = yup.object().shape({
-  password: yup.string().required('Your current password is required'),
+const NEW_PASSWORD_SHAPE = {
   newPassword: yup
     .string()
     .test(
@@ -61,4 +60,13 @@ export const changePasswordSchema = yup.object().shape({
       [yup.ref('newPassword')],
       'The password confirmation does not match your new password'
     ),
+};
+
+export const changePasswordSchema = yup.object().shape({
+  password: yup.string().required('Your current password is required'),
+  ...NEW_PASSWORD_SHAPE,
+});
+
+export const forgotPasswordSchema = yup.object().shape({
+  ...NEW_PASSWORD_SHAPE,
 });

--- a/services-js/access-boston/src/pages/forgot.tsx
+++ b/services-js/access-boston/src/pages/forgot.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import Head from 'next/head';
+import { Formik, FormikProps } from 'formik';
+import { css } from 'emotion';
+
+import { SectionHeader, PUBLIC_CSS_URL } from '@cityofboston/react-fleet';
+
+import CrumbContext from '../client/CrumbContext';
+import AccessBostonHeader from '../client/AccessBostonHeader';
+import PasswordPolicy from '../client/PasswordPolicy';
+import TextInput from '../client/TextInput';
+
+import { forgotPasswordSchema } from '../lib/validation';
+
+import { MAIN_CLASS } from '../client/styles';
+
+const SUBMITTING_MODAL_STYLE = css({
+  paddingTop: 0,
+  maxWidth: 500,
+  top: '15%',
+  marginRight: 'auto',
+  marginLeft: 'auto',
+});
+
+interface InitialProps {
+  serverErrors: { [key: string]: string };
+}
+
+interface Props extends InitialProps {
+  testSubmittingModal?: boolean;
+}
+
+interface State {
+  showSubmittingModal: boolean;
+}
+
+interface FormValues {
+  newPassword: string;
+  confirmPassword: string;
+  crumb: string;
+}
+
+export default class ForgotPasswordPage extends React.Component<Props, State> {
+  static defaultProps = {
+    serverErrors: {},
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      showSubmittingModal: !!props.testSubmittingModal,
+    };
+  }
+
+  render() {
+    const { showSubmittingModal } = this.state;
+
+    return (
+      <CrumbContext.Consumer>
+        {crumb => {
+          const initialValues: FormValues = {
+            newPassword: '',
+            confirmPassword: '',
+            crumb,
+          };
+
+          return (
+            <>
+              <Head>
+                <link rel="stylesheet" href={PUBLIC_CSS_URL} />
+                <title>Access Boston: Forgot Password</title>
+              </Head>
+
+              <AccessBostonHeader />
+
+              <div className={MAIN_CLASS}>
+                <div className="b b-c b-c--hsm">
+                  <SectionHeader title="Forgot Password" />
+
+                  <Formik
+                    initialValues={initialValues}
+                    validationSchema={forgotPasswordSchema}
+                    onSubmit={() => {}}
+                    render={this.renderForm}
+                  />
+                </div>
+              </div>
+
+              {showSubmittingModal && this.renderSubmitting()}
+            </>
+          );
+        }}
+      </CrumbContext.Consumer>
+    );
+  }
+
+  private renderForm = ({
+    values,
+    errors,
+    touched,
+    handleBlur,
+    handleChange,
+    handleSubmit,
+    isSubmitting,
+    isValid,
+  }: FormikProps<FormValues>) => {
+    const { serverErrors } = this.props;
+
+    const commonPasswordProps = {
+      type: 'password',
+      required: true,
+      spellCheck: false,
+      autoFocus: false,
+      autoCapitalize: 'off',
+      autoCorrect: 'off',
+      onChange: handleChange,
+      onBlur: handleBlur,
+    };
+
+    // We show server errors (from the non-JS implementation), though if the
+    // field gets touched we hide those (this is unlikely, though, if JavaScript
+    // is off.) Otherwise, we show validation errors only if the form has been
+    // touched.
+    const lookupFormError = (key: keyof FormValues) =>
+      (!touched[key] && serverErrors[key]) ||
+      (touched[key] && (errors[key] as any));
+
+    return (
+      <form action="" method="POST" className="m-v500" onSubmit={handleSubmit}>
+        <input type="hidden" name="crumb" value={values.crumb} />
+
+        {/* "g--r" so that we can put the policy first on mobile */}
+        <div className="g g--r m-v200">
+          <div className="g--6 m-b500">
+            <PasswordPolicy
+              password={values.newPassword}
+              showFailedAsErrors={touched.newPassword}
+            />
+          </div>
+
+          <div className="g--6">
+            <TextInput
+              label="New Password"
+              error={lookupFormError('newPassword')}
+              name="newPassword"
+              autoComplete="new-password"
+              value={values.newPassword}
+              {...commonPasswordProps}
+            />
+
+            <TextInput
+              label="Confirm Password"
+              error={lookupFormError('confirmPassword')}
+              name="confirmPassword"
+              autoComplete="new-password"
+              value={values.confirmPassword}
+              {...commonPasswordProps}
+            />
+          </div>
+        </div>
+
+        {this.props.serverErrors.form && (
+          <>
+            <div className="t--info t--err m-b500">
+              There was a problem changing your password:{' '}
+              {this.props.serverErrors.form}
+            </div>
+
+            <div className="t--info t--err m-b500">
+              You can try again. If this keeps happening, please call the Help
+              Desk.
+            </div>
+          </>
+        )}
+
+        <button
+          type="submit"
+          className="btn"
+          disabled={(process as any).browser && (!isValid || isSubmitting)}
+        >
+          Reset Password
+        </button>
+      </form>
+    );
+  };
+
+  private renderSubmitting() {
+    return (
+      <div className="md">
+        <div className={`md-c br br-t400 ${SUBMITTING_MODAL_STYLE}`}>
+          <div className="md-b p-a300">
+            <div className="t--intro">Saving your new password…</div>
+            <div className="t--info m-t300">
+              Please be patient and don’t refresh your browser. This might take
+              a bit.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/services-js/access-boston/src/server/SessionAuth.ts
+++ b/services-js/access-boston/src/server/SessionAuth.ts
@@ -8,10 +8,12 @@ export interface Session {
 }
 
 export default class SessionAuth {
-  request: HapiRequest;
+  private request: HapiRequest;
+  private decoratorName: string;
 
-  constructor(request: HapiRequest) {
+  constructor(request: HapiRequest, decoratorName: string) {
     this.request = request;
+    this.decoratorName = decoratorName;
   }
 
   get(): Session {
@@ -25,10 +27,10 @@ export default class SessionAuth {
   }
 
   set(session: Session) {
-    (this.request as any).cookieAuth.set(session);
+    (this.request as any)[this.decoratorName].set(session);
   }
 
   clear() {
-    (this.request as any).cookieAuth.clear();
+    (this.request as any)[this.decoratorName].clear();
   }
 }

--- a/services-js/access-boston/src/server/access-boston.ts
+++ b/services-js/access-boston/src/server/access-boston.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { Server as HapiServer, RequestQuery } from 'hapi';
+import { Server as HapiServer } from 'hapi';
 import Crumb from 'crumb';
 import cookieAuthPlugin from 'hapi-auth-cookie';
 
@@ -26,7 +26,7 @@ import {
   headerKeysPlugin,
 } from '@cityofboston/hapi-common';
 
-import { makeRoutesForNextApp } from '@cityofboston/hapi-next';
+import { makeRoutesForNextApp, makeNextHandler } from '@cityofboston/hapi-next';
 
 import decryptEnv from '@cityofboston/srv-decrypt-env';
 
@@ -34,18 +34,13 @@ import graphqlSchema, { Context } from './graphql/schema';
 
 import IdentityIq from './services/IdentityIq';
 import IdentityIqFake from './services/IdentityIqFake';
-import SamlAuth, { makeSamlAuth } from './services/SamlAuth';
-import SamlAuthFake from './services/SamlAuthFake';
-import { makeAppsRegistry } from './services/AppsRegistry';
+import AppsRegistry, { makeAppsRegistry } from './services/AppsRegistry';
 
-import SessionAuth, { Session } from './SessionAuth';
+import { addLoginAuth, getLoginSessionAuth } from './login-auth';
+import { addForgotPasswordAuth } from './forgot-password-auth';
 
 const PATH_PREFIX = '';
-const METADATA_PATH = '/metadata.xml';
-const ASSERT_PATH = '/assert';
-
-const FORGOT_METADATA_PATH = '/metadata-forgot.xml';
-const FORGOT_ASSERT_PATH = '/assert-forgot';
+const FORGOT_PASSWORD_PATH = '/forgot';
 
 const dev = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
 
@@ -83,42 +78,6 @@ export async function makeServer(port) {
         process.env.NODE_ENV !== 'test'
       ));
 
-  const samlAuth: SamlAuth =
-    process.env.NODE_ENV === 'production' || process.env.SAML_IN_DEV
-      ? await makeSamlAuth(
-          {
-            metadataPath: './saml-metadata.xml',
-            serviceProviderCertPath: './service-provider.crt',
-            serviceProviderKeyPath: './service-provider.key',
-          },
-          {
-            metadataUrl: `https://${process.env.PUBLIC_HOST}${METADATA_PATH}`,
-            assertUrl: `https://${process.env.PUBLIC_HOST}${ASSERT_PATH}`,
-          },
-          process.env.SINGLE_LOGOUT_URL || ''
-        )
-      : (new SamlAuthFake(ASSERT_PATH, process.env.SAML_FAKE_USER_ID) as any);
-
-  const forgotPasswordSamlAuth: SamlAuth =
-    process.env.NODE_ENV === 'production' || process.env.SAML_IN_DEV
-      ? await makeSamlAuth(
-          {
-            metadataPath: './saml-metadata.xml',
-            serviceProviderCertPath: './service-provider-forgot.crt',
-            serviceProviderKeyPath: './service-provider-forgot.key',
-          },
-          {
-            metadataUrl: `https://${
-              process.env.PUBLIC_HOST
-            }${FORGOT_METADATA_PATH}`,
-            assertUrl: `https://${
-              process.env.PUBLIC_HOST
-            }${FORGOT_ASSERT_PATH}`,
-          },
-          process.env.SINGLE_LOGOUT_URL || ''
-        )
-      : (new SamlAuthFake(ASSERT_PATH, process.env.SAML_FAKE_USER_ID) as any);
-
   const identityIq: IdentityIq =
     process.env.NODE_ENV === 'production' || process.env.IDENTITYIQ_URL
       ? new IdentityIq(
@@ -128,135 +87,68 @@ export async function makeServer(port) {
         )
       : (new IdentityIqFake() as any);
 
-  // We don't turn on Next for test mode because it hangs Jest.
-  let nextApp;
-
-  if (process.env.NODE_ENV !== 'test') {
-    // We load the config ourselves so that we can modify the runtime configs
-    // from here.
-    const config = require('../../next.config.js');
-
-    config.publicRuntimeConfig = {
-      ...config.publicRuntimeConfig,
-      [GRAPHQL_PATH_KEY]: '/graphql',
-      [API_KEY_CONFIG_KEY]: process.env.WEB_API_KEY,
-    };
-
-    config.serverRuntimeConfig = {
-      [HAPI_INJECT_CONFIG_KEY]: server.inject.bind(server),
-      ...config.serverRuntimeConfig,
-    };
-
-    nextApp = next({
-      dev,
-      dir: 'src',
-      config,
-    });
-  } else {
-    nextApp = null;
-  }
-
   await server.register(acceptLanguagePlugin);
-  await server.register(cookieAuthPlugin);
   await server.register(Crumb);
 
-  // We start up the server in test, and we don’t want it logging.
+  // Required by both auth schemes
+  await server.register(cookieAuthPlugin);
+
+  await addLoginAuth(server, {
+    loginPath: '/login',
+    logoutPath: '/logout',
+    afterLoginUrl: '/',
+  });
+
+  await addForgotPasswordAuth(server, {
+    forgotPath: FORGOT_PASSWORD_PATH,
+  });
+
+  // If the server is running in test mode we don't want the logs to pollute the
+  // Jests output.
   if (process.env.NODE_ENV !== 'test') {
     await server.register(loggingPlugin);
   }
 
-  if (
-    process.env.NODE_ENV === 'production' &&
-    !process.env.SESSION_COOKIE_PASSWORD
-  ) {
-    throw new Error('Must set $SESSION_COOKIE_PASSWORD in production');
+  server.route(adminOkRoute);
+
+  await addGraphQl(server, appsRegistry, identityIq);
+
+  // We don't turn on Next for test mode because it hangs Jest.
+  if (process.env.NODE_ENV !== 'test') {
+    await addNext(server);
   }
 
+  return {
+    server,
+    startup: async () => {
+      await server.start();
+
+      console.log(
+        `> Ready on http${
+          process.env.USE_SSL ? 's' : ''
+        }://localhost:${port}${PATH_PREFIX}`
+      );
+
+      // Add more shutdown code here.
+      return () => Promise.all([server.stop()]);
+    },
+  };
+}
+
+async function addGraphQl(
+  server: HapiServer,
+  appsRegistry: AppsRegistry,
+  identityIq: IdentityIq
+) {
   if (process.env.NODE_ENV === 'production' && !process.env.API_KEYS) {
     throw new Error('Must set $API_KEYS in production');
   }
-
-  const cookiePassword =
-    process.env.SESSION_COOKIE_PASSWORD || 'iWIMwE69HJj9GQcHfCiu2TVyZoVxvYoU';
-
-  server.auth.strategy('session', 'cookie', {
-    password: cookiePassword,
-    cookie: 'sid',
-    redirectTo: '/login',
-    isSecure: process.env.NODE_ENV === 'production',
-    ttl: 60 * 60 * 1000,
-    keepAlive: true,
-  });
-
-  server.auth.default('session');
 
   await server.register({
     plugin: headerKeysPlugin,
     options: {
       header: 'X-API-KEY',
       keys: process.env.API_KEYS ? process.env.API_KEYS.split(',') : [],
-    },
-  });
-
-  server.route(adminOkRoute);
-
-  server.route({
-    path: METADATA_PATH,
-    method: 'GET',
-    options: {
-      auth: false,
-    },
-    handler: (_, h) =>
-      h.response(samlAuth.getMetadata()).type('application/xml'),
-  });
-
-  server.route({
-    path: FORGOT_METADATA_PATH,
-    method: 'GET',
-    options: {
-      auth: false,
-    },
-    handler: (_, h) =>
-      h.response(forgotPasswordSamlAuth.getMetadata()).type('application/xml'),
-  });
-
-  server.route({
-    path: '/login',
-    method: 'GET',
-    options: {
-      auth: { mode: 'try' },
-      plugins: { 'hapi-auth-cookie': { redirectTo: false } },
-    },
-    handler: async (_, h) => h.redirect(await samlAuth.makeLoginUrl()),
-  });
-
-  if (process.env.NODE_ENV !== 'production') {
-    server.route({
-      path: '/login-form',
-      method: 'GET',
-      options: {
-        auth: false,
-      },
-      handler: () =>
-        `<form action="/assert" method="POST"><input type="submit" value="Log In" /></form>`,
-    });
-  }
-
-  server.route({
-    path: '/logout',
-    method: 'POST',
-    handler: async (request, h) => {
-      const sessionAuth = new SessionAuth(request);
-      const session = sessionAuth.get();
-
-      // We clear our cookie when you hit this button, since it's better for us
-      // to be logged out on AccessBoston but logged in on the SSO side than
-      // the alternative.
-      sessionAuth.clear();
-
-      return h.redirect(
-        await samlAuth.makeLogoutUrl(session.nameId, session.sessionIndex)
-      );
     },
   });
 
@@ -275,8 +167,7 @@ export async function makeServer(port) {
       },
       graphqlOptions: request => {
         const context: Context = {
-          sessionAuth: new SessionAuth(request),
-          samlAuth,
+          sessionAuth: getLoginSessionAuth(request),
           appsRegistry,
           identityIq,
         };
@@ -302,116 +193,64 @@ export async function makeServer(port) {
       },
     },
   });
+}
 
-  server.route({
-    path: ASSERT_PATH,
-    method: 'POST',
-    options: {
-      auth: false,
-      plugins: {
-        crumb: false,
-      },
-    },
-    handler: async (request, h) => {
-      const assertResult = await samlAuth.handlePostAssert(
-        request.payload as string
-      );
+async function addNext(server: HapiServer) {
+  // We load the config ourselves so that we can modify the runtime configs
+  // from here.
+  const config = require('../../next.config.js');
 
-      if (assertResult.type !== 'login') {
-        throw new Error(
-          `Unexpected assert result in POST handler: ${assertResult.type}`
-        );
-      }
-
-      const { nameId, sessionIndex, groups } = assertResult;
-
-      new SessionAuth(request).set({
-        nameId,
-        sessionIndex,
-        groups,
-      });
-
-      return h.redirect('/');
-    },
-  });
-
-  // Used in logout requests and development
-  server.route({
-    path: ASSERT_PATH,
-    method: 'GET',
-    options: { auth: { mode: 'try' } },
-    handler: async (request, h) => {
-      const assertResult = await samlAuth.handleGetAssert(
-        request.query as RequestQuery
-      );
-
-      if (assertResult.type !== 'logout') {
-        throw new Error(
-          `Unexpected assert result in GET handler: ${assertResult.type}`
-        );
-      }
-
-      const session: Session = (request.auth.credentials as any) || {};
-      // Check to make sure this is the session we're getting rid of. We're
-      // tolerant of the session being clear already (which happens if we’re the
-      // ones who initiate logout)
-      if (
-        (session.nameId && session.nameId !== assertResult.nameId) ||
-        (session.sessionIndex &&
-          session.sessionIndex !== assertResult.sessionIndex)
-      ) {
-        console.debug(`Logout name ID or session index doesn’t match session`);
-        return h.redirect('/');
-      } else {
-        (request as any).cookieAuth.clear();
-        return h.redirect(assertResult.successUrl);
-      }
-    },
-  });
-
-  if (nextApp) {
-    server.route(
-      makeRoutesForNextApp(nextApp, '/', {
-        ext: {
-          onPostAuth: {
-            // We have to manually add the CSRF token because the Next helpers
-            // only work on raw http objects and don't write out Hapi’s "state"
-            // cookies.
-            method: (request, h) => {
-              if (!request.state['crumb']) {
-                const crumb = (server.plugins as any).crumb.generate(
-                  request,
-                  h
-                );
-                request.raw.res.setHeader(
-                  'Set-Cookie',
-                  `crumb=${crumb};HttpOnly`
-                );
-              }
-
-              return h.continue;
-            },
-          },
-        },
-      })
-    );
-  }
-
-  return {
-    server,
-    startup: async () => {
-      await Promise.all([server.start(), nextApp ? nextApp.prepare() : null]);
-
-      console.log(
-        `> Ready on http${
-          process.env.USE_SSL ? 's' : ''
-        }://localhost:${port}${PATH_PREFIX}`
-      );
-
-      // Add more shutdown code here.
-      return () => Promise.all([server.stop()]);
-    },
+  config.publicRuntimeConfig = {
+    ...config.publicRuntimeConfig,
+    [GRAPHQL_PATH_KEY]: '/graphql',
+    [API_KEY_CONFIG_KEY]: process.env.WEB_API_KEY,
   };
+
+  config.serverRuntimeConfig = {
+    [HAPI_INJECT_CONFIG_KEY]: server.inject.bind(server),
+    ...config.serverRuntimeConfig,
+  };
+
+  const nextApp = next({
+    dev,
+    dir: 'src',
+    config,
+  });
+
+  // We have to manually add the CSRF token because the Next helpers
+  // only work on raw http objects and don't write out Hapi’s "state"
+  // cookies.
+  const addCrumbCookie = (request, h) => {
+    if (!request.state['crumb']) {
+      const crumb = (server.plugins as any).crumb.generate(request, h);
+      request.raw.res.setHeader('Set-Cookie', `crumb=${crumb};HttpOnly`);
+    }
+
+    return h.continue;
+  };
+
+  // We have a special Next handler for the /forgot route that uses the
+  // "forgot-password" session auth rather than the default "login".
+  server.route({
+    method: ['GET', 'POST'],
+    path: FORGOT_PASSWORD_PATH,
+    options: {
+      auth: 'forgot-password',
+    },
+    handler: makeNextHandler(nextApp),
+  });
+
+  server.route(
+    makeRoutesForNextApp(nextApp, '/', {
+      ext: {
+        onPostAuth: {
+          method: addCrumbCookie,
+        },
+      },
+    })
+  );
+
+  await nextApp.prepare();
 }
 
 export default async function startServer() {

--- a/services-js/access-boston/src/server/forgot-password-auth.ts
+++ b/services-js/access-boston/src/server/forgot-password-auth.ts
@@ -1,0 +1,159 @@
+/* eslint no-console: 0 */
+
+import { Server as HapiServer } from 'hapi';
+import SamlAuth, { makeSamlAuth } from './services/SamlAuth';
+import SamlAuthFake from './services/SamlAuthFake';
+
+import SessionAuth from './SessionAuth';
+
+const FORGOT_METADATA_PATH = '/metadata-forgot.xml';
+const FORGOT_ASSERT_PATH = '/assert-forgot';
+const FORGOT_REDIRECT_PATH = '/forgot-redirect';
+const FAKE_FORGOT_LOGIN_FORM_PATH = '/fake-forgot-login-form';
+
+const FORGOT_COOKIE_AUTH_DECORATOR = 'forgotCookieAuth';
+
+interface Paths {
+  forgotPath: string;
+}
+
+/**
+ * Adds routes and handling for the separate "forgot password" SAML app.
+ *
+ * Forgot password is treated differently from normal login because you only
+ * auth with an MFA token. That difference means that the Ping configuration has
+ * to separate it as a different app.
+ *
+ * We use a different everything from normal login to reduce the chances that we
+ * "cross streams" and allow forgot password auth to authorize normal login
+ * operations and vice-versa.
+ */
+export async function addForgotPasswordAuth(
+  server: HapiServer,
+  { forgotPath }: Paths
+) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    !process.env.FORGOT_COOKIE_PASSWORD
+  ) {
+    throw new Error('Must set $FORGOT_COOKIE_PASSWORD in production');
+  }
+
+  server.auth.strategy('forgot-password', 'cookie', {
+    // Fallback password so this runs in dev / test w/o extra configuration.
+    password:
+      process.env.FORGOT_COOKIE_PASSWORD || 'mnNNmmjr9Xfe9rWWqatKK7zesS9vvhdz',
+    cookie: 'fsid',
+    redirectTo: FORGOT_REDIRECT_PATH,
+    isSecure: process.env.NODE_ENV === 'production',
+    ttl: 60 * 60 * 1000,
+    clearInvalid: true,
+    keepAlive: false,
+    requestDecoratorName: FORGOT_COOKIE_AUTH_DECORATOR,
+  });
+
+  // For the forgot password workflow, we use a separate SAML app because the
+  // backend auth setup has to require the MFA at all times for these logins.
+  let samlAuth: SamlAuth;
+
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.SAML_IN_DEV === 'true'
+  ) {
+    const publicHost = process.env.PUBLIC_HOST;
+    const metadataUrl = `https://${publicHost}${FORGOT_METADATA_PATH}`;
+    const assertUrl = `https://${publicHost}${FORGOT_ASSERT_PATH}`;
+
+    samlAuth = await makeSamlAuth(
+      {
+        metadataPath: './saml-forgot-metadata.xml',
+        serviceProviderCertPath: './service-provider-forgot.crt',
+        serviceProviderKeyPath: './service-provider-forgot.key',
+      },
+      {
+        metadataUrl,
+        assertUrl,
+      },
+      ''
+    );
+  } else {
+    samlAuth = new SamlAuthFake({
+      assertUrl: FORGOT_ASSERT_PATH,
+      loginFormUrl: FAKE_FORGOT_LOGIN_FORM_PATH,
+      userId: process.env.SAML_FAKE_USER_ID,
+    }) as any;
+  }
+
+  server.route({
+    path: FORGOT_METADATA_PATH,
+    method: 'GET',
+    options: { auth: false },
+    handler: (_, h) =>
+      h.response(samlAuth.getMetadata()).type('application/xml'),
+  });
+
+  // Same as above, just for the forgot password sessions.
+  server.route({
+    path: FORGOT_REDIRECT_PATH,
+    method: 'GET',
+    options: { auth: false },
+    handler: async (_, h) => h.redirect(await samlAuth.makeLoginUrl()),
+  });
+
+  // Fake login forms we can use in dev without needing the SAML SSO
+  // infrastructure configured.
+  if (process.env.NODE_ENV !== 'production') {
+    server.route({
+      path: FAKE_FORGOT_LOGIN_FORM_PATH,
+      method: 'GET',
+      options: { auth: false },
+      handler: () =>
+        `<form action="${FORGOT_ASSERT_PATH}" method="POST">
+          <input type="submit" value="Log In" />
+         </form>`,
+    });
+  }
+
+  server.route({
+    path: FORGOT_ASSERT_PATH,
+    method: 'POST',
+    options: {
+      auth: false,
+      plugins: {
+        crumb: false,
+      },
+    },
+    handler: async (request, h) => {
+      const assertResult = await samlAuth.handlePostAssert(
+        request.payload as string
+      );
+
+      if (assertResult.type !== 'login') {
+        throw new Error(
+          `Unexpected assert result in POST handler: ${assertResult.type}`
+        );
+      }
+
+      // TODO(finh): Will probably need to change this around for the different
+      // values we'll get from the separate login process.
+      const { nameId, sessionIndex, groups } = assertResult;
+
+      new SessionAuth(request, FORGOT_COOKIE_AUTH_DECORATOR).set({
+        nameId,
+        sessionIndex,
+        groups,
+      });
+
+      return h.redirect(forgotPath);
+    },
+  });
+
+  server.route({
+    path: FORGOT_ASSERT_PATH,
+    method: 'GET',
+    options: { auth: false },
+    handler: async () => {
+      throw new Error(`Unexpected GET request to ${FORGOT_ASSERT_PATH}`);
+    },
+  });
+}

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -14,7 +14,6 @@ import path from 'path';
 import { makeExecutableSchema } from 'graphql-tools';
 import { Resolvers } from '@cityofboston/graphql-typescript';
 import AppsRegistry from '../services/AppsRegistry';
-import SamlAuth from '../services/SamlAuth';
 import SessionAuth from '../SessionAuth';
 import IdentityIq, { LaunchedWorkflowResponse } from '../services/IdentityIq';
 
@@ -91,7 +90,6 @@ const schemaGraphql = fs.readFileSync(
 export interface Context {
   sessionAuth: SessionAuth;
   appsRegistry: AppsRegistry;
-  samlAuth: SamlAuth;
   identityIq: IdentityIq;
 }
 

--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -1,0 +1,209 @@
+/* eslint no-console: 0 */
+
+import {
+  Server as HapiServer,
+  Request as HapiRequest,
+  RequestQuery,
+} from 'hapi';
+
+import SamlAuth, { makeSamlAuth } from './services/SamlAuth';
+import SamlAuthFake from './services/SamlAuthFake';
+
+import SessionAuth, { Session } from './SessionAuth';
+
+const LOGIN_METADATA_PATH = '/metadata.xml';
+const LOGIN_ASSERT_PATH = '/assert';
+const FAKE_LOGIN_FORM_PATH = '/fake-login-form';
+const LOGIN_COOKIE_AUTH_DECORATOR = 'loginCookieAuth';
+
+interface Paths {
+  loginPath: string;
+  logoutPath: string;
+  afterLoginUrl: string;
+}
+
+/**
+ * Creates the SAML auth for the normal, login flow and adds it to the server.
+ * Includes handlers for redirecting to the SAML SSO endpoint and handling its
+ * responses.
+ */
+export async function addLoginAuth(
+  server: HapiServer,
+  { loginPath, logoutPath, afterLoginUrl }: Paths
+) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    !process.env.LOGIN_COOKIE_PASSWORD
+  ) {
+    throw new Error('Must set $LOGIN_COOKIE_PASSWORD in production');
+  }
+
+  server.auth.strategy('login', 'cookie', {
+    // Fallback password so this runs in dev / test w/o extra configuration.
+    password:
+      process.env.LOGIN_COOKIE_PASSWORD || 'iWIMwE69HJj9GQcHfCiu2TVyZoVxvYoU',
+    cookie: 'lsid',
+    redirectTo: loginPath,
+    isSecure: process.env.NODE_ENV === 'production',
+    ttl: 60 * 60 * 1000,
+    clearInvalid: true,
+    keepAlive: true,
+    requestDecoratorName: LOGIN_COOKIE_AUTH_DECORATOR,
+  });
+
+  server.auth.default('login');
+
+  let samlAuth: SamlAuth;
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.SAML_IN_DEV === 'true'
+  ) {
+    const publicHost = process.env.PUBLIC_HOST;
+    const metadataUrl = `https://${publicHost}${LOGIN_METADATA_PATH}`;
+    const assertUrl = `https://${publicHost}${LOGIN_ASSERT_PATH}`;
+
+    samlAuth = await makeSamlAuth(
+      {
+        metadataPath: './saml-metadata.xml',
+        serviceProviderCertPath: './service-provider.crt',
+        serviceProviderKeyPath: './service-provider.key',
+      },
+      {
+        metadataUrl,
+        assertUrl,
+      },
+      process.env.SINGLE_LOGOUT_URL || ''
+    );
+  } else {
+    samlAuth = new SamlAuthFake({
+      assertUrl: LOGIN_ASSERT_PATH,
+      loginFormUrl: FAKE_LOGIN_FORM_PATH,
+      userId: process.env.SAML_FAKE_USER_ID,
+    }) as any;
+  }
+
+  server.route({
+    path: LOGIN_METADATA_PATH,
+    method: 'GET',
+    options: { auth: false },
+    handler: (_, h) =>
+      h.response(samlAuth.getMetadata()).type('application/xml'),
+  });
+
+  // Our cookie auth strategy will redirect here, and this will redirect over to
+  // SAML to complete the SSO login flow.
+  server.route({
+    path: loginPath,
+    method: 'GET',
+    options: { auth: false },
+    handler: async (_, h) => h.redirect(await samlAuth.makeLoginUrl()),
+  });
+
+  // Fake login forms we can use in dev without needing the SAML SSO
+  // infrastructure configured.
+  if (process.env.NODE_ENV !== 'production') {
+    server.route({
+      path: FAKE_LOGIN_FORM_PATH,
+      method: 'GET',
+      options: {
+        auth: false,
+      },
+      handler: () =>
+        `<form action="${LOGIN_ASSERT_PATH}" method="POST">
+          <input type="submit" value="Log In" />
+        </form>`,
+    });
+  }
+
+  server.route({
+    path: logoutPath,
+    method: 'POST',
+    handler: async (request, h) => {
+      const sessionAuth = getLoginSessionAuth(request);
+      const session = sessionAuth.get();
+
+      // We clear our cookie when you hit this button, since it's better for us
+      // to be logged out on AccessBoston but logged in on the SSO side than
+      // the alternative.
+      sessionAuth.clear();
+
+      return h.redirect(
+        await samlAuth.makeLogoutUrl(session.nameId, session.sessionIndex)
+      );
+    },
+  });
+
+  server.route({
+    path: LOGIN_ASSERT_PATH,
+    method: 'POST',
+    options: {
+      auth: false,
+      plugins: {
+        crumb: false,
+      },
+    },
+    handler: async (request, h) => {
+      const assertResult = await samlAuth.handlePostAssert(
+        request.payload as string
+      );
+
+      if (assertResult.type !== 'login') {
+        throw new Error(
+          `Unexpected assert result in POST handler: ${assertResult.type}`
+        );
+      }
+
+      const { nameId, sessionIndex, groups } = assertResult;
+
+      const sessionAuth = getLoginSessionAuth(request);
+      sessionAuth.set({
+        nameId,
+        sessionIndex,
+        groups,
+      });
+
+      // TODO(finh): Can we get a destination URL from the assertion, rather
+      // than always go to the root?
+      return h.redirect(afterLoginUrl);
+    },
+  });
+
+  // Used in logout requests and development
+  server.route({
+    path: LOGIN_ASSERT_PATH,
+    method: 'GET',
+    // "try" because we want to look at the session if it's available, but
+    // we don't want to redirect to login if you're trying to log out.
+    options: { auth: { mode: 'try' } },
+    handler: async (request, h) => {
+      const assertResult = await samlAuth.handleGetAssert(
+        request.query as RequestQuery
+      );
+
+      if (assertResult.type !== 'logout') {
+        throw new Error(
+          `Unexpected assert result in GET handler: ${assertResult.type}`
+        );
+      }
+
+      const session: Session = (request.auth.credentials as any) || {};
+      // Check to make sure this is the session we're getting rid of. We're
+      // tolerant of the session being clear already (which happens if we’re the
+      // ones who initiate logout)
+      if (
+        session.nameId === assertResult.nameId &&
+        session.sessionIndex === assertResult.sessionIndex
+      ) {
+        (request as any)[LOGIN_COOKIE_AUTH_DECORATOR].clear();
+        return h.redirect(assertResult.successUrl);
+      } else {
+        console.debug(`Logout name ID or session index doesn’t match session`);
+        return h.redirect(afterLoginUrl);
+      }
+    },
+  });
+}
+
+export function getLoginSessionAuth(request: HapiRequest): SessionAuth {
+  return new SessionAuth(request, LOGIN_COOKIE_AUTH_DECORATOR);
+}

--- a/services-js/access-boston/src/server/services/SamlAuthFake.ts
+++ b/services-js/access-boston/src/server/services/SamlAuthFake.ts
@@ -4,13 +4,21 @@ import SamlAuth, {
   SamlLogoutRequestResult,
 } from './SamlAuth';
 
+export interface SamlAuthFakeOptions {
+  assertUrl: string;
+  loginFormUrl: string;
+  userId?: string;
+}
+
 export default class SamlAuthFake implements Required<SamlAuth> {
   private assertUrl: string;
+  private loginFormUrl: string;
   private userId: string;
 
-  constructor(assertUrl: string, userId: string = 'CON01234') {
+  constructor({ assertUrl, loginFormUrl, userId }: SamlAuthFakeOptions) {
     this.assertUrl = assertUrl;
-    this.userId = userId;
+    this.loginFormUrl = loginFormUrl;
+    this.userId = userId || 'CON01234';
   }
 
   getMetadata(): string {
@@ -18,7 +26,7 @@ export default class SamlAuthFake implements Required<SamlAuth> {
   }
 
   makeLoginUrl(): Promise<string> {
-    return Promise.resolve('/login-form');
+    return Promise.resolve(this.loginFormUrl);
   }
 
   makeLogoutUrl(): Promise<string> {

--- a/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import ForgotPasswordPage from '../pages/forgot';
+
+storiesOf('ForgotPasswordPage', module).add('default', () => (
+  <ForgotPasswordPage serverErrors={{}} />
+));

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -1002,6 +1002,235 @@ Array [
 ]
 `;
 
+exports[`Storyshots ForgotPasswordPage default 1`] = `
+Array [
+  <div
+    className="css-1gni7w7 p-a200"
+  >
+    <h1
+      className="css-e3scnp"
+    >
+      <a
+        href="/"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        Access Boston
+      </a>
+    </h1>
+  </div>,
+  <div
+    className="mn css-1jubgvi"
+  >
+    <div
+      className="b b-c b-c--hsm"
+    >
+      <div
+        className="sh"
+      >
+        <h2
+          className="sh-title"
+        >
+          Forgot Password
+        </h2>
+      </div>
+      <form
+        action=""
+        className="m-v500"
+        method="POST"
+        onSubmit={[Function]}
+      >
+        <input
+          name="crumb"
+          type="hidden"
+          value=""
+        />
+        <div
+          className="g g--r m-v200"
+        >
+          <div
+            className="g--6 m-b500"
+          >
+            <div
+              className="t--info m-b200"
+            >
+              New passwords must:
+            </div>
+            <ul
+              className="ul"
+              style={
+                Object {
+                  "lineHeight": 1.6,
+                }
+              }
+            >
+              <li
+                className=""
+              >
+                Be at least 10 characters long
+              </li>
+              <li
+                className=""
+              >
+                Use at least 3 of these:
+                <ul
+                  className="ul"
+                >
+                  <li
+                    className=""
+                  >
+                    A lowercase letter
+                  </li>
+                  <li
+                    className=""
+                  >
+                    An uppercase letter
+                  </li>
+                  <li
+                    className=""
+                  >
+                    A number
+                  </li>
+                  <li
+                    className=""
+                  >
+                    A special character
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="css-5qhwje"
+              >
+                Not have spaces
+              </li>
+              <li
+                className="css-5qhwje"
+              >
+                Not be longer than 32 characters
+              </li>
+            </ul>
+            <div
+              className="t--subinfo m-v300 m-b200"
+            >
+              Don’t use personal info, like your name or address. Your new password will have to be different than your last 5 passwords.
+            </div>
+          </div>
+          <div
+            className="g--6"
+          >
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-529028998"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                New Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="new-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-529028998"
+                name="newPassword"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--subinfo t--err m-t100"
+              >
+                 
+              </div>
+            </div>
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-2475388040"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                Confirm Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="new-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-2475388040"
+                name="confirmPassword"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--subinfo t--err m-t100"
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </div>
+        <button
+          className="btn"
+          disabled={undefined}
+          type="submit"
+        >
+          Reset Password
+        </button>
+      </form>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Storyshots IndexPage change password success 1`] = `
 Array [
   <div


### PR DESCRIPTION
Adds support for a second "forgot password" SAML app to handle the
authentication of forgot password requests.

Adds stand-in for Forgot Password form, but it’s not hooked up to any
functionality yet.

Factors out the Next.js route helper so that we can add separate
authentication for the "/forgot" route from the rest of the Next app’s
authentication.