### PR TITLE
Implementation of forgot password

### DIFF
--- a/modules-js/hapi-common/src/browser-auth-plugin.ts
+++ b/modules-js/hapi-common/src/browser-auth-plugin.ts
@@ -52,8 +52,7 @@ const browserAuthSchema = (
           .takeover()
           .redirect(settings.redirectTo);
       } else {
-        h.unauthenticated(Boom.unauthorized(null, 'yar-auth'));
-        return h.continue;
+        throw Boom.unauthorized(null, 'browser-auth');
       }
     },
   };

--- a/services-js/access-boston/src/client/AccessBostonHeader.tsx
+++ b/services-js/access-boston/src/client/AccessBostonHeader.tsx
@@ -34,28 +34,36 @@ const ACCESS_BOSTON_TITLE_STYLE = css({
 
 interface Props {
   account?: Account;
+  noLinks?: boolean;
 }
 
 export default class AccessBostonHeader extends React.Component<Props> {
   render() {
-    const { account } = this.props;
+    const { account, noLinks } = this.props;
 
     return (
       <CrumbContext.Consumer>
         {crumb => (
           <div className={`${HEADER_STYLE} p-a200`}>
             <h1 className={`${ACCESS_BOSTON_TITLE_STYLE}`}>
-              <Link href="/">
-                <a style={{ color: 'inherit' }}>Access Boston</a>
-              </Link>
+              {noLinks ? (
+                'Access Boston'
+              ) : (
+                <Link href="/">
+                  <a style={{ color: 'inherit' }}>Access Boston</a>
+                </Link>
+              )}
             </h1>
             {account && (
               <div className={`${HEADER_RIGHT_STYLE}`}>
                 <span style={{ marginRight: '1em' }}>{account.employeeId}</span>
-                <form action="/logout" method="POST">
-                  <input type="hidden" name="crumb" value={crumb} />
-                  <button className="btn btn--sm btn--100">Logout</button>
-                </form>
+
+                {!noLinks && (
+                  <form action="/logout" method="POST">
+                    <input type="hidden" name="crumb" value={crumb} />
+                    <button className="btn btn--sm btn--100">Logout</button>
+                  </form>
+                )}
               </div>
             )}
           </div>

--- a/services-js/access-boston/src/client/graphql/queries.d.ts
+++ b/services-js/access-boston/src/client/graphql/queries.d.ts
@@ -7,7 +7,7 @@ export enum WorkflowStatus {
   UNKNOWN = 'UNKNOWN',
 }
 
-export enum ChangePasswordError {
+export enum PasswordError {
   CURRENT_PASSWORD_WRONG = 'CURRENT_PASSWORD_WRONG',
   NEW_PASSWORDS_DONT_MATCH = 'NEW_PASSWORDS_DONT_MATCH',
   NEW_PASSWORD_POLICY_VIOLATION = 'NEW_PASSWORD_POLICY_VIOLATION',
@@ -24,7 +24,7 @@ export interface ChangePasswordMutation {
   changePassword: {
     caseId: string | null;
     status: WorkflowStatus;
-    error: ChangePasswordError | null;
+    error: PasswordError | null;
     messages: Array<string>;
   };
 }
@@ -51,5 +51,19 @@ export interface FetchAccountAndAppsQuery {
 export interface FetchAccountQuery {
   account: {
     employeeId: string;
+  };
+}
+
+export interface ResetPasswordMutationVariables {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+export interface ResetPasswordMutation {
+  resetPassword: {
+    caseId: string | null;
+    status: WorkflowStatus;
+    error: PasswordError | null;
+    messages: Array<string>;
   };
 }

--- a/services-js/access-boston/src/client/graphql/reset-password.ts
+++ b/services-js/access-boston/src/client/graphql/reset-password.ts
@@ -1,0 +1,33 @@
+import { FetchGraphql, gql } from '@cityofboston/next-client-common';
+import {
+  ResetPasswordMutation,
+  ResetPasswordMutationVariables,
+} from './queries';
+
+const QUERY = gql`
+  mutation ResetPassword($newPassword: String!, $confirmPassword: String!) {
+    resetPassword(
+      newPassword: $newPassword
+      confirmPassword: $confirmPassword
+    ) {
+      caseId
+      status
+      error
+      messages
+    }
+  }
+`;
+
+export default async function resetPassword(
+  fetchGraphql: FetchGraphql,
+  newPassword,
+  confirmPassword
+) {
+  const args: ResetPasswordMutationVariables = {
+    newPassword,
+    confirmPassword,
+  };
+
+  return ((await fetchGraphql(QUERY, args)) as ResetPasswordMutation)
+    .resetPassword;
+}

--- a/services-js/access-boston/src/client/styles.ts
+++ b/services-js/access-boston/src/client/styles.ts
@@ -8,3 +8,13 @@ const MAIN_STYLE = css({
 });
 
 export const MAIN_CLASS = `mn ${MAIN_STYLE}`;
+
+/** Useful HTML attributes for password fields. */
+export const DEFAULT_PASSWORD_ATTRIBUTES = {
+  type: 'password',
+  required: true,
+  spellCheck: false,
+  autoFocus: false,
+  autoCapitalize: 'off',
+  autoCorrect: 'off',
+};

--- a/services-js/access-boston/src/pages/change-password.tsx
+++ b/services-js/access-boston/src/pages/change-password.tsx
@@ -14,10 +14,10 @@ import TextInput from '../client/TextInput';
 
 import { changePasswordSchema } from '../lib/validation';
 
-import { MAIN_CLASS } from '../client/styles';
+import { MAIN_CLASS, DEFAULT_PASSWORD_ATTRIBUTES } from '../client/styles';
 import fetchAccount, { Account } from '../client/graphql/fetch-account';
 import changePassword from '../client/graphql/change-password';
-import { ChangePasswordError } from '../client/graphql/queries';
+import { PasswordError } from '../client/graphql/queries';
 
 import { FlashMessage } from './index';
 
@@ -196,12 +196,7 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
     const { serverErrors } = this.props;
 
     const commonPasswordProps = {
-      type: 'password',
-      required: true,
-      spellCheck: false,
-      autoFocus: false,
-      autoCapitalize: 'off',
-      autoCorrect: 'off',
+      ...DEFAULT_PASSWORD_ATTRIBUTES,
       onChange: handleChange,
       onBlur: handleBlur,
     };
@@ -312,7 +307,7 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
   }
 }
 
-function changePasswordErrorToFormErrors(error: ChangePasswordError | null) {
+function changePasswordErrorToFormErrors(error: PasswordError | null) {
   if (!error) {
     return {};
   }

--- a/services-js/access-boston/src/server/Session.ts
+++ b/services-js/access-boston/src/server/Session.ts
@@ -58,3 +58,34 @@ export function getSessionAuth(
 
   return request.yar.get(SESSION_AUTH_KEY);
 }
+
+export default class Session {
+  private request: HapiRequest;
+
+  // By making these optionally undefined we can use type checking to ensure
+  // that we're making auth checks in our resolvers. If you want to use one of
+  // these but it's undefined then it's time to throw a Forbidden error.
+  public readonly loginAuth: LoginAuth | undefined;
+  public readonly forgotPasswordAuth: ForgotPasswordAuth | undefined;
+
+  public readonly loginSession: LoginSession | undefined;
+
+  constructor(request: HapiRequest) {
+    this.request = request;
+
+    // TODO(finh): It may be a bit confusing to round-trip these credentials in
+    // and out of request.auth when they're already in the Yar session. Possibly
+    // clean that up?
+    const { isAuthenticated, credentials } = request.auth;
+    if (isAuthenticated && credentials) {
+      this.loginAuth = credentials.loginAuth;
+      this.forgotPasswordAuth = credentials.forgotPasswordAuth;
+    }
+
+    this.loginSession = request.yar.get(LOGIN_SESSION_KEY);
+  }
+
+  reset() {
+    this.request.yar.reset();
+  }
+}

--- a/services-js/access-boston/src/server/forgot-password-auth.ts
+++ b/services-js/access-boston/src/server/forgot-password-auth.ts
@@ -4,7 +4,7 @@ import { Server as HapiServer } from 'hapi';
 import SamlAuth, { makeSamlAuth } from './services/SamlAuth';
 import SamlAuthFake from './services/SamlAuthFake';
 import { BrowserAuthOptions } from '@cityofboston/hapi-common';
-import { getSessionAuth, setSessionAuth } from './sessions';
+import { getSessionAuth, setSessionAuth } from './Session';
 
 const FORGOT_METADATA_PATH = '/metadata-forgot.xml';
 const FORGOT_ASSERT_PATH = '/assert-forgot';

--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -1,10 +1,6 @@
 /* eslint no-console: 0 */
 
-import {
-  Server as HapiServer,
-  Request as HapiRequest,
-  RequestQuery,
-} from 'hapi';
+import { Server as HapiServer, RequestQuery } from 'hapi';
 
 import SamlAuth, { makeSamlAuth } from './services/SamlAuth';
 import SamlAuthFake from './services/SamlAuthFake';
@@ -15,7 +11,7 @@ import {
   setSessionAuth,
   getSessionAuth,
   LOGIN_SESSION_KEY,
-} from './sessions';
+} from './Session';
 
 import { BrowserAuthOptions } from '@cityofboston/hapi-common';
 
@@ -221,8 +217,4 @@ export async function addLoginAuth(
       return h.redirect(assertResult.successUrl);
     },
   });
-}
-
-export function getLoginSession(request: HapiRequest): LoginSession {
-  return request.yar.get(LOGIN_SESSION_KEY);
 }

--- a/services-js/access-boston/src/server/services/IdentityIqFake.ts
+++ b/services-js/access-boston/src/server/services/IdentityIqFake.ts
@@ -23,6 +23,10 @@ export default class IdentityIqFake implements Required<IdentityIq> {
     return this.loadFixture('LaunchWorkflow-ChangePassword-failure');
   }
 
+  async resetPassword(): Promise<LaunchedWorkflowResponse> {
+    return this.loadFixture('LaunchWorkflow-ChangePassword-failure');
+  }
+
   async fetchWorkflow(): Promise<LaunchedWorkflowResponse> {
     return this.loadFixture('LaunchWorkflow-ChangePassword-failure');
   }

--- a/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
@@ -2,7 +2,26 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import ForgotPasswordPage from '../pages/forgot';
+import { Account } from '../client/graphql/fetch-account';
 
-storiesOf('ForgotPasswordPage', module).add('default', () => (
-  <ForgotPasswordPage serverErrors={{}} />
-));
+const ACCOUNT: Account = {
+  employeeId: 'CON01234',
+};
+
+storiesOf('ForgotPasswordPage', module)
+  .add('default', () => (
+    <ForgotPasswordPage
+      account={ACCOUNT}
+      serverErrors={{}}
+      fetchGraphql={null as any}
+      showSuccessMessage={false}
+    />
+  ))
+  .add('success', () => (
+    <ForgotPasswordPage
+      account={ACCOUNT}
+      serverErrors={{}}
+      fetchGraphql={null as any}
+      showSuccessMessage
+    />
+  ));

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -1010,17 +1010,7 @@ Array [
     <h1
       className="css-e3scnp"
     >
-      <a
-        href="/"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "inherit",
-          }
-        }
-      >
-        Access Boston
-      </a>
+      Access Boston
     </h1>
   </div>,
   <div
@@ -1048,6 +1038,12 @@ Array [
           name="crumb"
           type="hidden"
           value=""
+        />
+        <input
+          autoComplete="username"
+          name="username"
+          type="hidden"
+          value="CON01234"
         />
         <div
           className="g g--r m-v200"
@@ -1226,6 +1222,52 @@ Array [
           Reset Password
         </button>
       </form>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Storyshots ForgotPasswordPage success 1`] = `
+Array [
+  <div
+    className="css-1gni7w7 p-a200"
+  >
+    <h1
+      className="css-e3scnp"
+    >
+      Access Boston
+    </h1>
+  </div>,
+  <div
+    className="mn css-1jubgvi"
+  >
+    <div
+      className="b b-c b-c--hsm"
+    >
+      <div
+        className="sh m-b300"
+      >
+        <h2
+          className="sh-title"
+        >
+          Reset successful!
+        </h2>
+      </div>
+      <div
+        className="t--intro"
+      >
+        Your password change has gone through. Log in now with your new password.
+      </div>
+      <div
+        className="m-v500"
+      >
+        <a
+          className="btn"
+          href="/login"
+        >
+          Log in
+        </a>
+      </div>
     </div>
   </div>,
 ]


### PR DESCRIPTION
 - Converts Session into a proper object to expose resetting it to the
   forgot password mutation.
 - Changes GraphQL auth to allow for forgot password auth while keeping
   the authentication sources partitioned.
 - Adds GraphQL mutation for resetting the password.
 - Updates the forgot password page to send a GraphQL query and to show
   a success message.
 - Factors some HTML attributes out of change password for less
   duplication.