### PR TITLE
Fixes Slack deploy notification footer

### DIFF
--- a/modules-js/deploy-tools/src/helpers.ts
+++ b/modules-js/deploy-tools/src/helpers.ts
@@ -396,6 +396,7 @@ export async function waitForDeployment(
 }
 
 export async function postToSlack(
+  scriptPath: string,
   stage: 'start' | 'error' | 'complete' | 's3-complete',
   error?: string
 ) {
@@ -418,7 +419,7 @@ export async function postToSlack(
     const travisUrl = `https://travis-ci.org/${
       process.env.TRAVIS_REPO_SLUG
     }/builds/${process.env.TRAVIS_BUILD_ID}`;
-    const footer = 'travis-service-deploy.ts';
+    const footer = path.basename(scriptPath);
     const footerIcon = 'https://twemoji.maxcdn.com/2/72x72/1f380.png';
 
     const webhook = new IncomingWebhook(webhookUrl);

--- a/modules-js/deploy-tools/src/travis-s3-apps-deploy.ts
+++ b/modules-js/deploy-tools/src/travis-s3-apps-deploy.ts
@@ -20,7 +20,7 @@ const bucketEnvironment = environment === 'production' ? 'prod' : 'staging';
 const bucket = `cob-digital-apps-${bucketEnvironment}-static`;
 
 (async function() {
-  await postToSlack('start');
+  await postToSlack(__filename, 'start');
 
   console.error(BANNER);
 
@@ -50,7 +50,7 @@ const bucket = `cob-digital-apps-${bucketEnvironment}-static`;
   await uploadToS3(buildDirPath, bucket, serviceName);
   console.error();
 
-  await postToSlack('s3-complete');
+  await postToSlack(__filename, 's3-complete');
 
   console.error(`💅 Successfully uploaded ${serviceName} to ${bucket}.`);
 })().catch(e => {

--- a/modules-js/deploy-tools/src/travis-service-deploy.ts
+++ b/modules-js/deploy-tools/src/travis-service-deploy.ts
@@ -38,7 +38,7 @@ const workspaceDir = isolatedDocker ? '.' : path.resolve('../..');
 const cacheTag = 'latest';
 
 (async function() {
-  await postToSlack('start');
+  await postToSlack(__filename, 'start');
 
   const repository = await getRepository(environment, serviceName);
 
@@ -192,7 +192,7 @@ const cacheTag = 'latest';
     console.error();
   }
 
-  await postToSlack('complete');
+  await postToSlack(__filename, 'complete');
 
   console.error(
     `💅 Successfully deployed ${serviceName}${


### PR DESCRIPTION
Previous footer was hard-coded to "travis-service-deploy.ts". This
change makes it work for "travis-s3-apps-deploy.ts" as well.