### PR TITLE
Start of Access Boston registration flow

### DIFF
--- a/services-js/access-boston/src/client/AccessBostonHeader.stories.tsx
+++ b/services-js/access-boston/src/client/AccessBostonHeader.stories.tsx
@@ -6,6 +6,9 @@ import { Account } from './graphql/fetch-account';
 
 const ACCOUNT: Account = {
   employeeId: 'CON01234',
+  registered: true,
+  needsMfaDevice: false,
+  needsNewPassword: false,
 };
 
 storiesOf('AccessBostonHeader', module).add('default', () => (

--- a/services-js/access-boston/src/client/PasswordPolicy.tsx
+++ b/services-js/access-boston/src/client/PasswordPolicy.tsx
@@ -64,7 +64,9 @@ export default function PasswordPolicy({
 
   return (
     <>
-      <div className="t--info m-b200">New passwords must:</div>
+      <div className="txt-l m-b200" style={{ marginTop: 1 }}>
+        New passwords must:
+      </div>
 
       <ul className="ul" style={{ lineHeight: 1.6 }}>
         <li className={longEnough ? OK_PASSWORD_ROW : failedClassName}>

--- a/services-js/access-boston/src/client/auth-helpers.ts
+++ b/services-js/access-boston/src/client/auth-helpers.ts
@@ -1,0 +1,27 @@
+import { Account } from './graphql/fetch-account';
+
+/**
+ * Throw this type of error out of getInitialProps to have the App component do
+ * a redirect rather than render the page. Works both client- and server-side.
+ */
+export class RedirectError extends Error {
+  url: string;
+
+  constructor(url: string) {
+    super();
+
+    this.url = url;
+  }
+}
+
+/**
+ * Ensures that the account has been registered. If not, throws a
+ * a RedirectError to the registration flow.
+ *
+ * Expected to be called from getInitialProps in page components.
+ */
+export function requireRegistration(account: Account) {
+  if (!account.registered) {
+    throw new RedirectError('/register');
+  }
+}

--- a/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
@@ -8,6 +8,9 @@ const QUERY = gql`
   query FetchAccountAndApps {
     account {
       employeeId
+      registered
+      needsMfaDevice
+      needsNewPassword
     }
 
     apps {

--- a/services-js/access-boston/src/client/graphql/fetch-account.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account.ts
@@ -7,6 +7,9 @@ const QUERY = gql`
   query FetchAccount {
     account {
       employeeId
+      registered
+      needsMfaDevice
+      needsNewPassword
     }
   }
 `;

--- a/services-js/access-boston/src/client/graphql/queries.d.ts
+++ b/services-js/access-boston/src/client/graphql/queries.d.ts
@@ -31,6 +31,9 @@ export interface ChangePasswordVariables {
 
 export interface FetchAccountAndApps_account {
   employeeId: string;
+  registered: boolean;
+  needsMfaDevice: boolean;
+  needsNewPassword: boolean;
 }
 
 export interface FetchAccountAndApps_apps_categories_apps {
@@ -65,6 +68,9 @@ export interface FetchAccountAndApps {
 
 export interface FetchAccount_account {
   employeeId: string;
+  registered: boolean;
+  needsMfaDevice: boolean;
+  needsNewPassword: boolean;
 }
 
 export interface FetchAccount {

--- a/services-js/access-boston/src/integration/registration-flow.testcafe.ts
+++ b/services-js/access-boston/src/integration/registration-flow.testcafe.ts
@@ -1,0 +1,41 @@
+import { Selector } from 'testcafe';
+
+import LoginFormModel from './LoginFormModel';
+import PasswordPageModel from './PasswordPageModel';
+import { fixtureUrl } from './testcafe-helpers';
+import PageModel from './PageModel';
+
+// Starting at "/" will give us a redirect to "/register" once the frontend
+// realizes that the user hasn’t been registered.
+fixture('New User Registration').page(fixtureUrl('/'));
+
+test('Registration with new password and MFA', async t => {
+  const loginPage = new LoginFormModel();
+  // "NEW" makes the fake give us a user that needs to go through registation.
+  await loginPage.logIn(t, 'NEW02141');
+
+  const registerPage = new PageModel();
+  await t
+    .expect(registerPage.sectionHeader.innerText)
+    .contains('WELCOME TO ACCESS BOSTON!');
+
+  await t.click(Selector('.btn').withText('SET PASSWORD'));
+
+  const passwordPage = new PasswordPageModel();
+  await t
+    .typeText(passwordPage.currentPasswordField, 'correct-password', {
+      replace: true,
+    })
+    .typeText(passwordPage.newPasswordField, 'newPassword2018', {
+      replace: true,
+    })
+    .typeText(passwordPage.confirmPasswordField, 'newPassword2018', {
+      replace: true,
+    })
+    .click(passwordPage.submitButton);
+
+  // TODO(finh): Implement MFA device registration
+  await t
+    .expect(Selector('body').innerText)
+    .contains('This page could not be found');
+});

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -16,6 +16,7 @@ import fetchAccountAndApps, {
 } from '../client/graphql/fetch-account-and-apps';
 import { GetInitialPropsDependencies, GetInitialProps } from './_app';
 import { MAIN_CLASS } from '../client/styles';
+import { requireRegistration } from '../client/auth-helpers';
 
 export enum FlashMessage {
   CHANGE_PASSWORD_SUCCESS = 'password',
@@ -41,14 +42,15 @@ export default class IndexPage extends React.Component<Props> {
     { query },
     { fetchGraphql }: GetInitialPropsDependencies
   ): Promise<Props> => {
+    const { account, apps } = await fetchAccountAndApps(fetchGraphql);
+
+    requireRegistration(account);
+
     return {
       flashMessage: query.message as FlashMessage | undefined,
-      ...(await fetchAccountAndApps(fetchGraphql)),
+      account,
+      apps,
     };
-  };
-
-  state = {
-    accountMenuOpen: false,
   };
 
   render() {

--- a/services-js/access-boston/src/pages/register.tsx
+++ b/services-js/access-boston/src/pages/register.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+
+import { SectionHeader, PUBLIC_CSS_URL } from '@cityofboston/react-fleet';
+
+import AccessBostonHeader from '../client/AccessBostonHeader';
+import { GetInitialPropsDependencies, GetInitialProps } from './_app';
+import fetchAccount, { Account } from '../client/graphql/fetch-account';
+import { MAIN_CLASS } from '../client/styles';
+import { RedirectError } from '../client/auth-helpers';
+
+interface Props {
+  account: Account;
+}
+
+export default class RegisterPage extends React.Component<Props> {
+  static getInitialProps: GetInitialProps<Props> = async (
+    _ctx,
+    { fetchGraphql }: GetInitialPropsDependencies
+  ): Promise<Props> => {
+    const account = await fetchAccount(fetchGraphql);
+
+    if (account.registered) {
+      throw new RedirectError('/');
+    }
+
+    return {
+      account,
+    };
+  };
+
+  render() {
+    const { account } = this.props;
+
+    return (
+      <>
+        <Head>
+          <link rel="stylesheet" href={PUBLIC_CSS_URL} />
+          <title>Access Boston: Registration</title>
+        </Head>
+
+        <AccessBostonHeader account={account} />
+
+        <div className={MAIN_CLASS}>
+          <div className="b b-c b-c--hsm">
+            <SectionHeader title="Welcome to Access Boston!" />
+
+            <div className="t--intro m-v500">
+              Access Boston is the new place to log into your City of Boston
+              employee account.
+            </div>
+
+            <div style={{ textAlign: 'right' }}>
+              <span className="t--info" style={{ paddingRight: '1em' }}>
+                Next step:
+              </span>{' '}
+              {account.needsNewPassword ? (
+                <Link href="/change-password">
+                  <a className="btn">Set Password</a>
+                </Link>
+              ) : (
+                <Link href="/mfa">
+                  <a className="btn">Add MFA Device</a>
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/services-js/access-boston/src/server/Session.ts
+++ b/services-js/access-boston/src/server/Session.ts
@@ -28,6 +28,8 @@ declare module 'hapi' {
 export interface LoginSession {
   type: 'login';
   groups: string[];
+  needsNewPassword: boolean;
+  needsMfaDevice: boolean;
 }
 
 export type SessionAuth = LoginAuth | ForgotPasswordAuth;

--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -149,7 +149,13 @@ export async function addLoginAuth(
         );
       }
 
-      const { nameId, sessionIndex, groups } = assertResult;
+      const {
+        nameId,
+        sessionIndex,
+        groups,
+        needsMfaDevice,
+        needsNewPassword,
+      } = assertResult;
 
       // This will be read by the validate method above when doing authentication.
       const loginAuth: LoginAuth = {
@@ -163,6 +169,8 @@ export async function addLoginAuth(
       const session: LoginSession = {
         type: 'login',
         groups,
+        needsNewPassword,
+        needsMfaDevice,
       };
 
       request.yar.set(LOGIN_SESSION_KEY, session);

--- a/services-js/access-boston/src/server/services/SamlAuth.ts
+++ b/services-js/access-boston/src/server/services/SamlAuth.ts
@@ -48,6 +48,8 @@ export interface SamlLoginResult {
   nameId: string;
   sessionIndex: string;
   groups: string[];
+  needsNewPassword: boolean;
+  needsMfaDevice: boolean;
 }
 
 export interface SamlLogoutRequestResult {
@@ -272,6 +274,10 @@ export default class SamlAuth {
           nameId: saml.user.name_id,
           sessionIndex: saml.user.session_index,
           groups: parseGroupsAttribute(saml.user.attributes.groups || []),
+          // TODO(finh): Switch these to the real values once IAM is able to
+          // send that data in the assertion.
+          needsNewPassword: false,
+          needsMfaDevice: false,
         };
       case 'logout_request':
         return {

--- a/services-js/access-boston/src/server/services/SamlAuthFake.ts
+++ b/services-js/access-boston/src/server/services/SamlAuthFake.ts
@@ -37,19 +37,25 @@ export default class SamlAuthFake implements Required<SamlAuth> {
 
   handlePostAssert(body: string): Promise<SamlAssertResult> {
     const payload = querystring.parse(body.trim());
+    const userId = Array.isArray(payload.userId)
+      ? payload.userId[0]
+      : payload.userId;
+
+    const isNewUser = userId.startsWith('NEW');
 
     const result: SamlLoginResult = {
       type: 'login',
-      nameId: Array.isArray(payload.userId)
-        ? payload.userId[0]
-        : payload.userId,
+      nameId: userId,
       sessionIndex: 'session',
       groups: [
         'COB-Group-TestGrp01',
         'SG_AB_IAM_TEAM',
         'SG_AB_SERVICEDESK_USERS',
       ],
+      needsNewPassword: isNewUser,
+      needsMfaDevice: isNewUser,
     };
+
     return Promise.resolve(result);
   }
 

--- a/services-js/access-boston/src/stories/ChangePasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ChangePasswordPage.stories.tsx
@@ -6,6 +6,9 @@ import { Account } from '../client/graphql/fetch-account';
 
 const ACCOUNT: Account = {
   employeeId: 'CON01234',
+  registered: true,
+  needsMfaDevice: false,
+  needsNewPassword: false,
 };
 
 storiesOf('ChangePasswordPage', module)
@@ -16,6 +19,14 @@ storiesOf('ChangePasswordPage', module)
       fetchGraphql={null as any}
     />
   ))
+  .add('first time registration', () => (
+    <ChangePasswordPage
+      account={{ ...ACCOUNT, registered: false, needsNewPassword: true }}
+      serverErrors={{}}
+      fetchGraphql={null as any}
+    />
+  ))
+
   .add('submitting', () => (
     <ChangePasswordPage
       account={ACCOUNT}

--- a/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
@@ -6,6 +6,9 @@ import { Account } from '../client/graphql/fetch-account';
 
 const ACCOUNT: Account = {
   employeeId: 'CON01234',
+  registered: true,
+  needsMfaDevice: false,
+  needsNewPassword: false,
 };
 
 storiesOf('ForgotPasswordPage', module)

--- a/services-js/access-boston/src/stories/IndexPage.stories.tsx
+++ b/services-js/access-boston/src/stories/IndexPage.stories.tsx
@@ -6,6 +6,9 @@ import { Account, Apps } from '../client/graphql/fetch-account-and-apps';
 
 const ACCOUNT: Account = {
   employeeId: 'CON01234',
+  registered: true,
+  needsMfaDevice: false,
+  needsNewPassword: false,
 };
 
 const APPS: Apps = {

--- a/services-js/access-boston/src/stories/RegisterPage.stories.tsx
+++ b/services-js/access-boston/src/stories/RegisterPage.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import RegisterPage from '../pages/register';
+
+storiesOf('RegisterPage', module).add('needs password and MFA', () => (
+  <RegisterPage
+    account={{
+      employeeId: 'CON01234',
+      registered: false,
+      needsMfaDevice: true,
+      needsNewPassword: true,
+    }}
+  />
+));

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -138,7 +138,12 @@ Array [
             className="g--6 m-b500"
           >
             <div
-              className="t--info m-b200"
+              className="txt-l m-b200"
+              style={
+                Object {
+                  "marginTop": 1,
+                }
+              }
             >
               New passwords must:
             </div>
@@ -359,6 +364,343 @@ Array [
 ]
 `;
 
+exports[`Storyshots ChangePasswordPage first time registration 1`] = `
+Array [
+  <div
+    className="css-1gni7w7 p-a200"
+  >
+    <h1
+      className="css-e3scnp"
+    >
+      <a
+        href="/"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        Access Boston
+      </a>
+    </h1>
+    <div
+      className="css-n9ftlz"
+    >
+      <span
+        style={
+          Object {
+            "marginRight": "1em",
+          }
+        }
+      >
+        CON01234
+      </span>
+      <form
+        action="/logout"
+        method="POST"
+      >
+        <input
+          name="crumb"
+          type="hidden"
+          value=""
+        />
+        <button
+          className="btn btn--sm btn--100"
+        >
+          Logout
+        </button>
+      </form>
+    </div>
+  </div>,
+  <div
+    className="mn css-1jubgvi"
+  >
+    <div
+      className="b b-c b-c--hsm"
+    >
+      <div
+        className="sh m-b300"
+      >
+        <h2
+          className="sh-title"
+        >
+          Make a New Password
+        </h2>
+      </div>
+      <p
+        className="t--info m-t500 m-v300"
+      >
+        You’ll need to create a new, secure password to set up your Access Boston account.
+      </p>
+      <p
+        className="t--info m-v300"
+      >
+        This password will be good for a
+         
+        <strong>
+          whole year
+        </strong>
+        , though you can change it any time you like.
+      </p>
+    </div>
+    <div
+      className="m-b500 b--g"
+    >
+      <div
+        className="b b-c b-c--hsm"
+      >
+        <form
+          action=""
+          className="m-v500"
+          method="POST"
+          onSubmit={[Function]}
+        >
+          <input
+            name="crumb"
+            type="hidden"
+            value=""
+          />
+          <input
+            autoComplete="username"
+            name="username"
+            type="hidden"
+            value="CON01234"
+          />
+          <div
+            className="g g--r m-v200"
+          >
+            <div
+              className="g--6 m-b500"
+            >
+              <div
+                className="txt-l m-b200"
+                style={
+                  Object {
+                    "marginTop": 1,
+                  }
+                }
+              >
+                New passwords must:
+              </div>
+              <ul
+                className="ul"
+                style={
+                  Object {
+                    "lineHeight": 1.6,
+                  }
+                }
+              >
+                <li
+                  className=""
+                >
+                  Be at least 10 characters long
+                </li>
+                <li
+                  className=""
+                >
+                  Use at least 3 of these:
+                  <ul
+                    className="ul"
+                  >
+                    <li
+                      className=""
+                    >
+                      A lowercase letter
+                    </li>
+                    <li
+                      className=""
+                    >
+                      An uppercase letter
+                    </li>
+                    <li
+                      className=""
+                    >
+                      A number
+                    </li>
+                    <li
+                      className=""
+                    >
+                      A special character
+                    </li>
+                  </ul>
+                </li>
+                <li
+                  className="css-5qhwje"
+                >
+                  Not have spaces
+                </li>
+                <li
+                  className="css-5qhwje"
+                >
+                  Not be longer than 32 characters
+                </li>
+              </ul>
+              <div
+                className="t--subinfo m-v300 m-b200"
+              >
+                Don’t use personal info, like your name or address. Your new password will have to be different than your last 5 passwords.
+              </div>
+            </div>
+            <div
+              className="g--6"
+            >
+              <div
+                className="txt"
+                style={
+                  Object {
+                    "marginBottom": "0.5rem",
+                  }
+                }
+              >
+                <label
+                  className="txt-l"
+                  htmlFor="input-2099349523"
+                  style={
+                    Object {
+                      "marginTop": 0,
+                    }
+                  }
+                >
+                  Current Password
+                  <span
+                    aria-hidden="true"
+                    className="t--req"
+                  >
+                     
+                    Required
+                  </span>
+                </label>
+                <input
+                  autoCapitalize="off"
+                  autoComplete="current-password"
+                  autoCorrect="off"
+                  autoFocus={false}
+                  className=" txt-f "
+                  id="input-2099349523"
+                  name="password"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  required={true}
+                  spellCheck={false}
+                  type="password"
+                  value=""
+                />
+                <div
+                  className="t--subinfo t--err m-t100"
+                >
+                   
+                </div>
+              </div>
+              <div
+                className="txt"
+                style={
+                  Object {
+                    "marginBottom": "0.5rem",
+                  }
+                }
+              >
+                <label
+                  className="txt-l"
+                  htmlFor="input-529028998"
+                  style={
+                    Object {
+                      "marginTop": 0,
+                    }
+                  }
+                >
+                  New Password
+                  <span
+                    aria-hidden="true"
+                    className="t--req"
+                  >
+                     
+                    Required
+                  </span>
+                </label>
+                <input
+                  autoCapitalize="off"
+                  autoComplete="new-password"
+                  autoCorrect="off"
+                  autoFocus={false}
+                  className=" txt-f "
+                  id="input-529028998"
+                  name="newPassword"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  required={true}
+                  spellCheck={false}
+                  type="password"
+                  value=""
+                />
+                <div
+                  className="t--subinfo t--err m-t100"
+                >
+                   
+                </div>
+              </div>
+              <div
+                className="txt"
+                style={
+                  Object {
+                    "marginBottom": "0.5rem",
+                  }
+                }
+              >
+                <label
+                  className="txt-l"
+                  htmlFor="input-2475388040"
+                  style={
+                    Object {
+                      "marginTop": 0,
+                    }
+                  }
+                >
+                  Confirm Password
+                  <span
+                    aria-hidden="true"
+                    className="t--req"
+                  >
+                     
+                    Required
+                  </span>
+                </label>
+                <input
+                  autoCapitalize="off"
+                  autoComplete="new-password"
+                  autoCorrect="off"
+                  autoFocus={false}
+                  className=" txt-f "
+                  id="input-2475388040"
+                  name="confirmPassword"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  required={true}
+                  spellCheck={false}
+                  type="password"
+                  value=""
+                />
+                <div
+                  className="t--subinfo t--err m-t100"
+                >
+                   
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            className="btn"
+            type="submit"
+          >
+            Set new password
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Storyshots ChangePasswordPage server errors 1`] = `
 Array [
   <div
@@ -447,7 +789,12 @@ Array [
             className="g--6 m-b500"
           >
             <div
-              className="t--info m-b200"
+              className="txt-l m-b200"
+              style={
+                Object {
+                  "marginTop": 1,
+                }
+              }
             >
               New passwords must:
             </div>
@@ -756,7 +1103,12 @@ Array [
             className="g--6 m-b500"
           >
             <div
-              className="t--info m-b200"
+              className="txt-l m-b200"
+              style={
+                Object {
+                  "marginTop": 1,
+                }
+              }
             >
               New passwords must:
             </div>
@@ -1049,7 +1401,12 @@ Array [
             className="g--6 m-b500"
           >
             <div
-              className="t--info m-b200"
+              className="txt-l m-b200"
+              style={
+                Object {
+                  "marginTop": 1,
+                }
+              }
             >
               New passwords must:
             </div>
@@ -1871,7 +2228,12 @@ Array [
 exports[`Storyshots PasswordPolicy blank 1`] = `
 Array [
   <div
-    className="t--info m-b200"
+    className="txt-l m-b200"
+    style={
+      Object {
+        "marginTop": 1,
+      }
+    }
   >
     New passwords must:
   </div>,
@@ -1939,7 +2301,12 @@ Array [
 exports[`Storyshots PasswordPolicy complex enough 1`] = `
 Array [
   <div
-    className="t--info m-b200"
+    className="txt-l m-b200"
+    style={
+      Object {
+        "marginTop": 1,
+      }
+    }
   >
     New passwords must:
   </div>,
@@ -2007,7 +2374,12 @@ Array [
 exports[`Storyshots PasswordPolicy failed are errors 1`] = `
 Array [
   <div
-    className="t--info m-b200"
+    className="txt-l m-b200"
+    style={
+      Object {
+        "marginTop": 1,
+      }
+    }
   >
     New passwords must:
   </div>,
@@ -2075,7 +2447,12 @@ Array [
 exports[`Storyshots PasswordPolicy long enough 1`] = `
 Array [
   <div
-    className="t--info m-b200"
+    className="txt-l m-b200"
+    style={
+      Object {
+        "marginTop": 1,
+      }
+    }
   >
     New passwords must:
   </div>,
@@ -2143,7 +2520,12 @@ Array [
 exports[`Storyshots PasswordPolicy spaces error 1`] = `
 Array [
   <div
-    className="t--info m-b200"
+    className="txt-l m-b200"
+    style={
+      Object {
+        "marginTop": 1,
+      }
+    }
   >
     New passwords must:
   </div>,
@@ -2204,6 +2586,106 @@ Array [
     className="t--subinfo m-v300 m-b200"
   >
     Don’t use personal info, like your name or address. Your new password will have to be different than your last 5 passwords.
+  </div>,
+]
+`;
+
+exports[`Storyshots RegisterPage needs password and MFA 1`] = `
+Array [
+  <div
+    className="css-1gni7w7 p-a200"
+  >
+    <h1
+      className="css-e3scnp"
+    >
+      <a
+        href="/"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        Access Boston
+      </a>
+    </h1>
+    <div
+      className="css-n9ftlz"
+    >
+      <span
+        style={
+          Object {
+            "marginRight": "1em",
+          }
+        }
+      >
+        CON01234
+      </span>
+      <form
+        action="/logout"
+        method="POST"
+      >
+        <input
+          name="crumb"
+          type="hidden"
+          value=""
+        />
+        <button
+          className="btn btn--sm btn--100"
+        >
+          Logout
+        </button>
+      </form>
+    </div>
+  </div>,
+  <div
+    className="mn css-1jubgvi"
+  >
+    <div
+      className="b b-c b-c--hsm"
+    >
+      <div
+        className="sh m-b300"
+      >
+        <h2
+          className="sh-title"
+        >
+          Welcome to Access Boston!
+        </h2>
+      </div>
+      <div
+        className="t--intro m-v500"
+      >
+        Access Boston is the new place to log into your City of Boston employee account.
+      </div>
+      <div
+        style={
+          Object {
+            "textAlign": "right",
+          }
+        }
+      >
+        <span
+          className="t--info"
+          style={
+            Object {
+              "paddingRight": "1em",
+            }
+          }
+        >
+          Next step:
+        </span>
+         
+        <a
+          className="btn"
+          href="/change-password"
+          onClick={[Function]}
+        >
+          Set Password
+        </a>
+      </div>
+    </div>
   </div>,
 ]
 `;


### PR DESCRIPTION
 - Adds new flags to session for whether the user needs a new password
   or needs MFA signup
 - Adds those flags to the GraphQL Account type
 - Creates a starter "Register" page that links to change password
 - Modifies Change Password to have a "new password" mode with different
   titles and explanatory text

Does not implement any aspect of MFA registration right now.