### PR TITLE
Fixes when SAML assertion has empty attributes

### DIFF
--- a/services-js/access-boston/package.json
+++ b/services-js/access-boston/package.json
@@ -47,6 +47,7 @@
     "graphql-tools": "^3.0.0",
     "hapi": "^17.4.0",
     "hapi-accept-language2": "^2.0.3",
+    "hapi-dev-errors": "^3.0.1",
     "java-properties": "^0.2.10",
     "js-yaml": "^3.12.0",
     "jws": "^3.1.5",

--- a/services-js/access-boston/src/server/access-boston.ts
+++ b/services-js/access-boston/src/server/access-boston.ts
@@ -8,6 +8,7 @@ import Crumb from 'crumb';
 import yar from 'yar';
 import cleanup from 'node-cleanup';
 import acceptLanguagePlugin from 'hapi-accept-language2';
+import hapiDevErrors from 'hapi-dev-errors';
 import next from 'next';
 
 // https://github.com/apollographql/apollo-server/issues/927
@@ -100,6 +101,18 @@ export async function makeServer(port) {
 
   await server.register(acceptLanguagePlugin);
   await server.register(Crumb);
+
+  await server.register({
+    plugin: hapiDevErrors,
+    options: {
+      // AWS_S3_CONFIG_URL is a hack to see if we’re running in staging, since
+      // we don’t expose that as an env variable otherwise.
+      showErrors:
+        dev ||
+        (process.env.NODE_ENV === 'production' &&
+          (process.env.AWS_S3_CONFIG_URL || '').includes('staging')),
+    },
+  });
 
   if (
     process.env.NODE_ENV === 'production' &&

--- a/services-js/access-boston/src/server/services/SamlAuth.ts
+++ b/services-js/access-boston/src/server/services/SamlAuth.ts
@@ -24,8 +24,8 @@ interface SamlAuthAssertion {
     session_index: string;
     attributes: {
       groups?: string[];
-      FirstName: string[];
-      LastName: string[];
+      FirstName?: string[];
+      LastName?: string[];
       email?: string[];
     };
   };
@@ -282,8 +282,8 @@ export default class SamlAuth {
           type: 'login',
           nameId: user.name_id,
           sessionIndex: user.session_index,
-          firstName: attributes.FirstName[0] || '',
-          lastName: attributes.LastName[0] || '',
+          firstName: (attributes.FirstName && attributes.FirstName[0]) || '',
+          lastName: (attributes.LastName && attributes.LastName[0]) || '',
           email: (attributes.email && attributes.email[0]) || '',
           groups: parseGroupsAttribute(attributes.groups || []),
           // TODO(finh): Switch these to the real values once IAM is able to

--- a/yarn.lock
+++ b/yarn.lock
@@ -9165,6 +9165,14 @@ hapi-accept-language2@^2.0.3:
   dependencies:
     accept-language-parser "^1.4.1"
 
+hapi-dev-errors@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hapi-dev-errors/-/hapi-dev-errors-3.0.1.tgz#30561d75a4c084050faf79ea17fcdd0637c17f89"
+  dependencies:
+    hoek "~5.0.3"
+    youch "~2.0.8"
+    youch-terminal "~1.0.0"
+
 hapi@^17.4.0:
   version "17.4.0"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-17.4.0.tgz#c56c0ec3b8d678cc941bdb943bcbddc4107e838b"
@@ -9418,6 +9426,10 @@ hoek@4.2.x, hoek@4.x.x:
 hoek@5.x.x:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
+
+hoek@~5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.4.tgz#0f7fa270a1cafeb364a4b2ddfaa33f864e4157da"
 
 hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
@@ -13657,7 +13669,7 @@ multipipe@^1.0.2:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
 
-mustache@^2.1.1, mustache@^2.1.2, mustache@^2.2.1:
+mustache@^2.1.1, mustache@^2.1.2, mustache@^2.2.1, mustache@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
 
@@ -17598,6 +17610,10 @@ stable@~0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
 
+stack-trace@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
 stack-trace@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
@@ -20383,6 +20399,20 @@ yargs@~3.27.0:
 yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
+
+youch-terminal@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/youch-terminal/-/youch-terminal-1.0.0.tgz#03e2096ee360ef915816e62ea9ec94a6ff094d9e"
+  dependencies:
+    chalk "^2.3.0"
+
+youch@~2.0.8:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/youch/-/youch-2.0.9.tgz#12b709b4ffcf523cb0c21d0a71606fdb115eb73a"
+  dependencies:
+    cookie "^0.3.1"
+    mustache "^2.3.1"
+    stack-trace "0.0.10"
 
 yup@0.26.6:
   version "0.26.6"


### PR DESCRIPTION
For forgot password, there’s no first name, last name, or email address.

Also adds hapi-dev-errors so that when errors come up we see a shiny
error page / stack trace rather than the default 500 JSON response.