### PR TITLE
Access Boston SAML tweaks

### DIFF
--- a/services-js/access-boston/src/pages/register.tsx
+++ b/services-js/access-boston/src/pages/register.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
+import getConfig from 'next/config';
 
 import { SectionHeader, PUBLIC_CSS_URL } from '@cityofboston/react-fleet';
 
@@ -32,6 +33,11 @@ export default class RegisterPage extends React.Component<Props> {
 
   render() {
     const { account } = this.props;
+
+    const { publicRuntimeConfig } = getConfig() || { publicRuntimeConfig: {} };
+    const logoutImgSrc = `https://${
+      publicRuntimeConfig.PING_HOST
+    }/ext/idplogout`;
 
     return (
       <>
@@ -65,6 +71,8 @@ export default class RegisterPage extends React.Component<Props> {
                 </Link>
               )}
             </div>
+
+            <img src={logoutImgSrc} alt="" width="1" height="1" />
           </div>
         </div>
       </>

--- a/services-js/access-boston/src/server/access-boston.ts
+++ b/services-js/access-boston/src/server/access-boston.ts
@@ -263,6 +263,7 @@ async function addNext(server: HapiServer) {
     ...config.publicRuntimeConfig,
     [GRAPHQL_PATH_KEY]: '/graphql',
     [API_KEY_CONFIG_KEY]: process.env.WEB_API_KEY,
+    PING_HOST: process.env.PING_HOST,
   };
 
   config.serverRuntimeConfig = {

--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -68,7 +68,9 @@ export async function addLoginAuth(
         metadataUrl,
         assertUrl,
       },
-      process.env.SINGLE_LOGOUT_URL || ''
+      process.env.PING_HOST
+        ? `https://${process.env.PING_HOST}/idp/startSLO.ping`
+        : ''
     );
   } else {
     samlAuth = new SamlAuthFake({

--- a/services-js/access-boston/src/server/services/SamlAuth.ts
+++ b/services-js/access-boston/src/server/services/SamlAuth.ts
@@ -27,6 +27,8 @@ interface SamlAuthAssertion {
       FirstName?: string[];
       LastName?: string[];
       email?: string[];
+      changePasswordRequired?: string[];
+      mfaRegistrationRequired?: string[];
     };
   };
 }
@@ -286,10 +288,8 @@ export default class SamlAuth {
           lastName: (attributes.LastName && attributes.LastName[0]) || '',
           email: (attributes.email && attributes.email[0]) || '',
           groups: parseGroupsAttribute(attributes.groups || []),
-          // TODO(finh): Switch these to the real values once IAM is able to
-          // send that data in the assertion.
-          needsNewPassword: false,
-          needsMfaDevice: false,
+          needsNewPassword: attributeIsTrue(attributes.changePasswordRequired),
+          needsMfaDevice: attributeIsTrue(attributes.mfaRegistrationRequired),
         };
       }
       case 'logout_request':
@@ -367,3 +367,6 @@ export function parseGroupsAttribute(groupsAttribute: string[]): string[] {
     })
     .filter(s => !!s);
 }
+
+const attributeIsTrue = (attr: string[] | undefined): boolean =>
+  !!(attr && attr[0] && attr[0].toLowerCase() === 'true');

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -3371,6 +3371,12 @@ Array [
           Set Password
         </a>
       </div>
+      <img
+        alt=""
+        height="1"
+        src="https://undefined/ext/idplogout"
+        width="1"
+      />
     </div>
   </div>,
 ]


### PR DESCRIPTION
  - Uses new attributes for determining registration status
  - Uses <img> to log out of Ping session at the start of registration