### PR TITLE
Adds "size" to device verification modal’s input

### DIFF
--- a/services-js/access-boston/src/client/device-verification/DeviceVerificationModal.tsx
+++ b/services-js/access-boston/src/client/device-verification/DeviceVerificationModal.tsx
@@ -37,7 +37,6 @@ const VERIFICATION_CODE_ROW_STYLE = css({
 });
 
 const VERIFICATION_CODE_INPUT_STYLE = css({
-  flexGrow: 1,
   fontSize: '30px',
   letterSpacing: '3px',
   fontFamily: SANS,
@@ -170,6 +169,7 @@ export default class DeviceVerificationModal extends React.Component<Props> {
             name="code"
             value={code}
             maxLength={6}
+            size={6}
             pattern="[0-9]*"
             onChange={handleChange}
             className={VERIFICATION_CODE_INPUT_STYLE}
@@ -178,7 +178,6 @@ export default class DeviceVerificationModal extends React.Component<Props> {
             renderInputFunc={({ inputEl }) => (
               <div className={VERIFICATION_CODE_ROW_STYLE}>
                 {inputEl}
-
                 <button
                   type="button"
                   className="btn"

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -3240,12 +3240,13 @@ Array [
             >
               <input
                 autoFocus={true}
-                className="css-1e1yraf txt-f "
+                className="css-15p77ot txt-f "
                 id="input-3718645000"
                 maxLength={6}
                 name="code"
                 onChange={[Function]}
                 pattern="[0-9]*"
+                size={6}
                 type="text"
                 value=""
               />
@@ -3962,12 +3963,13 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationModal checking the code 1`
           >
             <input
               autoFocus={true}
-              className="css-1e1yraf txt-f "
+              className="css-15p77ot txt-f "
               id="input-3718645000"
               maxLength={6}
               name="code"
               onChange={[Function]}
               pattern="[0-9]*"
+              size={6}
               type="text"
               value="133789"
             />
@@ -4063,12 +4065,13 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationModal incorrect code 1`] =
           >
             <input
               autoFocus={true}
-              className="css-1e1yraf txt-f "
+              className="css-15p77ot txt-f "
               id="input-3718645000"
               maxLength={6}
               name="code"
               onChange={[Function]}
               pattern="[0-9]*"
+              size={6}
               type="text"
               value=""
             />
@@ -4237,12 +4240,13 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationModal waiting for SMS code
           >
             <input
               autoFocus={true}
-              className="css-1e1yraf txt-f "
+              className="css-15p77ot txt-f "
               id="input-3718645000"
               maxLength={6}
               name="code"
               onChange={[Function]}
               pattern="[0-9]*"
+              size={6}
               type="text"
               value=""
             />
@@ -4338,12 +4342,13 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationModal waiting for email co
           >
             <input
               autoFocus={true}
-              className="css-1e1yraf txt-f "
+              className="css-15p77ot txt-f "
               id="input-3718645000"
               maxLength={6}
               name="code"
               onChange={[Function]}
               pattern="[0-9]*"
+              size={6}
               type="text"
               value="133789"
             />
@@ -4440,12 +4445,13 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationModal waiting for voice co
           >
             <input
               autoFocus={true}
-              className="css-1e1yraf txt-f "
+              className="css-15p77ot txt-f "
               id="input-3718645000"
               maxLength={6}
               name="code"
               onChange={[Function]}
               pattern="[0-9]*"
+              size={6}
               type="text"
               value=""
             />


### PR DESCRIPTION
Keeps Firefox from using the input’s default "size" when calculating a
width for flexbox, which caused the button to render over the edge of
the modal.