### PR TITLE
Adds a BrowserCompatibility component

### DIFF
--- a/modules-js/react-fleet/package.json
+++ b/modules-js/react-fleet/package.json
@@ -24,14 +24,15 @@
     "preset": "@cityofboston/config-jest-babel"
   },
   "dependencies": {
+  },
+  "peerDependencies": {
+    "@babel/runtime": "7.0.0",
+    "detect-browser": "^3.0.1",
     "emotion": "9.2.10",
     "prop-types": "^15.6.0",
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "string-hash": "^1.1.3"
-  },
-  "peerDependencies": {
-    "@babel/runtime": "7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0",
@@ -60,12 +61,18 @@
     "cheerio": "^1.0.0-rc.2",
     "concurrently": "^3.5.1",
     "cross-env": "^5.1.5",
+    "detect-browser": "^3.0.1",
+    "emotion": "9.2.10",
     "fs-extra": "^5.0.0",
     "jest": "23.6.0",
     "node-fetch": "^1.6.9",
+    "prop-types": "^15.6.0",
     "raw-loader": "^0.5.1",
+    "react": "16.5.2",
+    "react-dom": "16.5.2",
     "rimraf": "^2.6.2",
     "rollup": "^0.60.1",
+    "string-hash": "^1.1.3",
     "ts-node": "^6.0.3",
     "typescript": "^3.0.0"
   }

--- a/modules-js/react-fleet/rollup.config.js
+++ b/modules-js/react-fleet/rollup.config.js
@@ -1,4 +1,9 @@
-const EXTERNALS = ['react', 'emotion', 'string-hash'];
+// Rollup won’t package libraries in. It’s up to the bundlers (e.g. Webpack) to
+// resolve these libraries when building the apps. Since we’re in a monorepo,
+// the libraries will be available without the apps having to add the
+// dependencies themselves. Nevertheless, these should be added as both
+// peerDependencies and devDependencies in package.json, since we’re pedantic.
+const EXTERNALS = ['react', 'emotion', 'string-hash', 'detect-browser'];
 
 export default {
   input: 'build/react-fleet.js',

--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -1,5 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/CompatibilityWarning no script 1`] = `
+Array [
+  <input
+    className="bwarning-cb"
+    defaultChecked={true}
+    id="compat-warning-0"
+    type="checkbox"
+  />,
+  <div
+    className="bwarning-b"
+  >
+    <label
+      className="bwarning-x"
+      htmlFor="compat-warning-0"
+    >
+      x
+    </label>
+    <h3
+      className="txt-l txt-l--mt000"
+    >
+      Browser Warning
+    </h3>
+    You have JavaScript turned off in your browser. This site won’t work right without it.
+  </div>,
+]
+`;
+
+exports[`Storyshots Components/CompatibilityWarning old browser 1`] = `
+Array [
+  <input
+    className="bwarning-cb"
+    defaultChecked={true}
+    id="compat-warning-1"
+    type="checkbox"
+  />,
+  <div
+    className="bwarning-b"
+  >
+    <label
+      className="bwarning-x"
+      htmlFor="compat-warning-1"
+    >
+      x
+    </label>
+    <h3
+      className="txt-l txt-l--mt000"
+    >
+      Browser Warning
+    </h3>
+    <div>
+      Your web browser is a little out-of-date. This site may not look or work right.
+    </div>
+    <div
+      className="m-t100"
+    >
+      We recommend using the latest version of Chrome, Firefox, IE Edge, or Safari.
+    </div>
+  </div>,
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+              (function() {
+                var id = \\"compat-warning-1\\";
+                var cookieName = \\"compat-warning\\";
+
+                var getCookie = function(name) {
+                  var value = \\"; \\" + document.cookie;
+                  var parts = value.split(\\"; \\" + name + \\"=\\");
+                  if (parts.length == 2) return parts.pop().split(\\";\\").shift();
+                };
+
+                var checkbox = document.getElementById(id);
+                if (!checkbox) {
+                  return;
+                }
+
+                if (getCookie(cookieName)) {
+                  checkbox.checked = false;
+                }
+
+                checkbox.onChange = function() {
+                  document.cookie = 'compat-warning=1; expires=Fri, 09 Nov 2018 14:47:00 GMT';
+                }
+              })();
+            ",
+      }
+    }
+    type="text/javascript"
+  />,
+]
+`;
+
 exports[`Storyshots Components/Footer custom attributes 1`] = `
 <footer
   className="ft br br-a300"

--- a/modules-js/react-fleet/src/components/CompatibilityWarning.stories.tsx
+++ b/modules-js/react-fleet/src/components/CompatibilityWarning.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { CompatibilityWarningContent, Message } from './CompatibilityWarning';
+
+storiesOf('Components/CompatibilityWarning', module)
+  .add('no script', () => (
+    <CompatibilityWarningContent message={Message.NO_SCRIPT} />
+  ))
+  .add('old browser', () => (
+    <CompatibilityWarningContent message={Message.OLD_BROWSER} />
+  ));

--- a/modules-js/react-fleet/src/components/CompatibilityWarning.tsx
+++ b/modules-js/react-fleet/src/components/CompatibilityWarning.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { detect, parseUserAgent } from 'detect-browser';
+
+export enum Message {
+  NO_SCRIPT,
+  OLD_BROWSER,
+}
+
+export interface Props {
+  userAgent: string;
+}
+
+/**
+ * Place this component on the page to show browser compatibility warnings.
+ *
+ * This component needs to be able to run purely server-side, with any
+ * client-side JS handled outside of React. That’s because old browsers
+ * potentially won’t be able to start up the app JS at all.
+ *
+ * If you’re using Next, a good place for this is just after <Main /> in
+ * _document.tsx.
+ */
+export default function CompatibilityWarning({ userAgent }: Props) {
+  let oldBrowser = false;
+
+  // Safety in case the version is odd or anything unexpected happens. We don't
+  // want the browser check to crash the app.
+  try {
+    const { name, version } = userAgent ? parseUserAgent(userAgent) : detect();
+    const versionMajor = parseInt(version.split('.')[0]);
+
+    // Right now we just warn old IE. We could add other browsers, such as old
+    // iOS, if we want.
+    oldBrowser = name === 'ie' && versionMajor < 11;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+
+  return (
+    <>
+      <noscript>
+        <CompatibilityWarningContent message={Message.NO_SCRIPT} />
+      </noscript>
+
+      {oldBrowser && (
+        <CompatibilityWarningContent message={Message.OLD_BROWSER} />
+      )}
+    </>
+  );
+}
+
+interface ContentProps {
+  message: Message;
+}
+
+/**
+ * Exported so we can run stories over the different possibilities.
+ */
+export function CompatibilityWarningContent({ message }: ContentProps) {
+  let text;
+
+  switch (message) {
+    case Message.NO_SCRIPT:
+      text = (
+        <>
+          You have JavaScript turned off in your browser. This site won’t work
+          right without it.
+        </>
+      );
+      break;
+
+    case Message.OLD_BROWSER:
+      text = (
+        <>
+          <div>
+            Your web browser is a little out-of-date. This site may not look or
+            work right.
+          </div>
+
+          <div className="m-t100">
+            We recommend using the latest version of Chrome, Firefox, IE Edge,
+            or Safari.
+          </div>
+        </>
+      );
+      break;
+  }
+
+  const checkboxId = `compat-warning-${message}`;
+
+  // We use a cookie to allow users to hide at least the "old browser" warning.
+  // (The no-JS warning sticks around since we don’t have JS to hide it.)
+  const cookieName = 'compat-warning';
+  const cookieExpirationDate = new Date();
+  cookieExpirationDate.setDate(cookieExpirationDate.getDate() + 30);
+
+  // We use a fixed value for test so that Snapshots can be consistent.
+  const cookieExpirationDateString =
+    process.env.NODE_ENV === 'test'
+      ? 'Fri, 09 Nov 2018 14:47:00 GMT'
+      : cookieExpirationDate.toUTCString();
+
+  return (
+    <>
+      <input
+        id={checkboxId}
+        type="checkbox"
+        className="bwarning-cb"
+        defaultChecked
+      />
+
+      <div className="bwarning-b">
+        <label htmlFor={checkboxId} className="bwarning-x">
+          {/* We use an “x” rather than a unicode symbol for better browser support. */}
+          x
+        </label>
+
+        <h3 className="txt-l txt-l--mt000">Browser Warning</h3>
+        {text}
+      </div>
+
+      {message !== Message.NO_SCRIPT && (
+        // We use a <script> tag because the React app won't necessarily start
+        // on older browsers.
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                var id = "${checkboxId}";
+                var cookieName = "${cookieName}";
+
+                var getCookie = function(name) {
+                  var value = "; " + document.cookie;
+                  var parts = value.split("; " + name + "=");
+                  if (parts.length == 2) return parts.pop().split(";").shift();
+                };
+
+                var checkbox = document.getElementById(id);
+                if (!checkbox) {
+                  return;
+                }
+
+                if (getCookie(cookieName)) {
+                  checkbox.checked = false;
+                }
+
+                checkbox.onChange = function() {
+                  document.cookie = '${cookieName}=1; expires=${cookieExpirationDateString}';
+                }
+              })();
+            `,
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/modules-js/react-fleet/src/react-fleet.ts
+++ b/modules-js/react-fleet/src/react-fleet.ts
@@ -5,6 +5,9 @@ export { default as Menu } from './components/Menu';
 export { default as Header } from './components/Header';
 export { default as Footer } from './components/Footer';
 export { default as AppLayout } from './layouts/AppLayout';
+export {
+  default as CompatibilityWarning,
+} from './components/CompatibilityWarning';
 
 export { default as Checkbox } from './form-elements/inputs/Checkbox';
 export { default as FileInput } from './form-elements/inputs/FileInput';

--- a/services-js/access-boston/src/pages/_document.tsx
+++ b/services-js/access-boston/src/pages/_document.tsx
@@ -2,15 +2,18 @@ import Document, { Head, Main, NextScript } from 'next/document';
 import { extractCritical } from 'emotion-server';
 
 import { makeNProgressStyle } from '@cityofboston/next-client-common';
+import { CompatibilityWarning } from '@cityofboston/react-fleet';
+
 import { HEADER_HEIGHT } from '../client/styles';
 
 export default class MyDocument extends Document {
   props: any;
 
-  static getInitialProps({ renderPage }) {
+  static getInitialProps({ renderPage, req }) {
     const page = renderPage();
     const styles = extractCritical(page.html);
-    return { ...page, ...styles };
+    const userAgent = req.headers['user-agent'];
+    return { ...page, ...styles, userAgent };
   }
 
   constructor(props) {
@@ -23,6 +26,8 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    const { userAgent } = this.props;
+
     return (
       <html>
         <Head>
@@ -42,6 +47,7 @@ export default class MyDocument extends Document {
 
         <body>
           <Main />
+          <CompatibilityWarning userAgent={userAgent} />
           <NextScript />
         </body>
       </html>

--- a/templates/js-browser-module/template/package.json
+++ b/templates/js-browser-module/template/package.json
@@ -22,7 +22,9 @@
     "preset": "@cityofboston/config-jest-babel"
   },
   "peerDependencies": {
-    "@babel/runtime": "7.0.0"
+    "@babel/runtime": "7.0.0",
+    "emotion": "9.2.10",
+    "react": "16.5.2"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0",
@@ -35,7 +37,9 @@
     "babel-core": "^7.0.0-0",
     "concurrently": "^3.5.1",
     "cross-env": "^5.1.5",
+    "emotion": "9.2.10",
     "jest": "23.6.0",
+    "react": "16.5.2",
     "rimraf": "^2.6.2",
     "rollup": "^0.60.1",
     "typescript": "^3.0.0"

--- a/templates/js-browser-module/template/rollup.config.js
+++ b/templates/js-browser-module/template/rollup.config.js
@@ -1,4 +1,9 @@
-const EXTERNALS = ['react'];
+// Rollup won’t package libraries in. It’s up to the bundlers (e.g. Webpack) to
+// resolve these libraries when building the apps. Since we’re in a monorepo,
+// the libraries will be available without the apps having to add the
+// dependencies themselves. Nevertheless, these should be added as both
+// peerDependencies and devDependencies in package.json, since we’re pedantic.
+const EXTERNALS = ['react', 'emotion'];
 
 export default {
   input: 'build/{{name}}.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6469,6 +6469,10 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-browser@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-3.0.1.tgz#39beead014347a8a2be1f3c4cb30a0aef2127c44"
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"


### PR DESCRIPTION
This component warns against non-JavaScript and also old versions of IE.

Also updates docs for Rollup externals to get a clearer picture of what
it’s about and why it works in our case.