### PR TITLE
Network reliability fixes

### DIFF
--- a/services-js/access-boston/src/client/HelpContactInfo.tsx
+++ b/services-js/access-boston/src/client/HelpContactInfo.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function HelpContactInfo() {
+  return (
+    <ul className="ul t--s300 lh--400">
+      <li>
+        DoIT Service Desk<br />
+        <a href="tel:6176357378">(617) 635-7378</a>
+      </li>
+      <li>
+        BPS Technology Help Desk Support<br />
+        <a href="tel:6176359200">(617) 635-9200</a>
+      </li>
+    </ul>
+  );
+}

--- a/services-js/access-boston/src/pages/change-password.tsx
+++ b/services-js/access-boston/src/pages/change-password.tsx
@@ -5,7 +5,6 @@ import { Formik, FormikProps } from 'formik';
 
 import { SectionHeader, PUBLIC_CSS_URL } from '@cityofboston/react-fleet';
 
-import CrumbContext from '../client/CrumbContext';
 import AccessBostonHeader from '../client/AccessBostonHeader';
 import PasswordPolicy from '../client/PasswordPolicy';
 import TextInput from '../client/TextInput';
@@ -26,6 +25,7 @@ import {
   PageDependencies,
 } from './_app';
 import RedirectForm from '../client/RedirectForm';
+import HelpContactInfo from '../client/HelpContactInfo';
 
 interface InitialProps {
   account: Account;
@@ -33,11 +33,13 @@ interface InitialProps {
 
 interface Props extends InitialProps, Pick<PageDependencies, 'fetchGraphql'> {
   testSubmittingModal?: boolean;
+  testNetworkError?: boolean;
   hasTemporaryPassword?: boolean;
 }
 
 interface State {
   showSubmittingModal: boolean;
+  showNetworkError: boolean;
 }
 
 interface FormValues {
@@ -45,7 +47,6 @@ interface FormValues {
   password: string;
   newPassword: string;
   confirmPassword: string;
-  crumb: string;
 }
 
 function successUrl(account): string {
@@ -59,10 +60,8 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
     _ctx,
     { fetchGraphql }: GetInitialPropsDependencies
   ) => {
-    const account = await fetchAccount(fetchGraphql);
-
     return {
-      account,
+      account: await fetchAccount(fetchGraphql),
     };
   };
 
@@ -73,6 +72,7 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
 
     this.state = {
       showSubmittingModal: !!props.testSubmittingModal,
+      showNetworkError: !!props.testNetworkError,
     };
   }
 
@@ -82,7 +82,7 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
   ) => {
     const { account } = this.props;
 
-    this.setState({ showSubmittingModal: true });
+    this.setState({ showSubmittingModal: true, showNetworkError: false });
 
     try {
       const { status, error } = await changePassword(
@@ -113,8 +113,11 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
           }
           break;
       }
-    } finally {
+
       this.setState({ showSubmittingModal: false });
+    } catch {
+      this.setState({ showNetworkError: true });
+    } finally {
       setSubmitting(false);
     }
   };
@@ -125,77 +128,70 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
 
     const setNewPassword = account.needsNewPassword;
 
+    const initialValues: FormValues = {
+      username: account.employeeId,
+      password: '',
+      newPassword: '',
+      confirmPassword: '',
+    };
+
     return (
-      <CrumbContext.Consumer>
-        {crumb => {
-          const initialValues: FormValues = {
-            username: account.employeeId,
-            password: '',
-            newPassword: '',
-            confirmPassword: '',
-            crumb,
-          };
+      <>
+        <Head>
+          <link rel="stylesheet" href={PUBLIC_CSS_URL} />
+          <title>Access Boston: Change Password</title>
+        </Head>
 
-          return (
-            <>
-              <Head>
-                <link rel="stylesheet" href={PUBLIC_CSS_URL} />
-                <title>Access Boston: Change Password</title>
-              </Head>
+        <AccessBostonHeader account={account} />
 
-              <AccessBostonHeader account={account} />
+        <div className={MAIN_CLASS}>
+          <div className="b b-c b-c--hsm">
+            <SectionHeader
+              title={
+                account.needsNewPassword
+                  ? 'Create a New Password'
+                  : 'Change Password'
+              }
+            />
 
-              <div className={MAIN_CLASS}>
-                <div className="b b-c b-c--hsm">
-                  <SectionHeader
-                    title={
-                      account.needsNewPassword
-                        ? 'Create a New Password'
-                        : 'Change Password'
-                    }
-                  />
+            {setNewPassword && (
+              <>
+                <p className="t--s400 lh--400">
+                  You’ll need a new password for Access Boston. We’ve changed
+                  the requirements for passwords to make sure that they’re
+                  strong enough.
+                </p>
 
-                  {setNewPassword && (
-                    <>
-                      <p className="t--s400 lh--400">
-                        You’ll need a new password for Access Boston. We’ve
-                        changed the requirements for passwords to make sure that
-                        they’re strong enough.
-                      </p>
+                <p className="t--s400 lh--400">
+                  You’ll use this password when logging in to Access Boston
+                  websites like The Hub. If you work in City Hall or for BPS
+                  you’ll also use it for your desktop computer.
+                </p>
 
-                      <p className="t--s400 lh--400">
-                        You’ll use this password when logging in to Access
-                        Boston websites like The Hub. If you work in City Hall
-                        or for BPS you’ll also use it for your desktop computer.
-                      </p>
+                {hasTemporaryPassword && (
+                  <p className="t--s400 lh--400">
+                    Please look for an email from us with your temporary
+                    password.
+                  </p>
+                )}
 
-                      {hasTemporaryPassword && (
-                        <p className="t--s400 lh--400">
-                          Please look for an email from us with your temporary
-                          password.
-                        </p>
-                      )}
+                <hr className="hr hr--sq" />
+              </>
+            )}
 
-                      <hr className="hr hr--sq" />
-                    </>
-                  )}
+            <Formik
+              initialValues={initialValues}
+              validationSchema={changePasswordSchema}
+              onSubmit={this.handleSubmit}
+              render={this.renderForm}
+            />
+          </div>
+        </div>
 
-                  <Formik
-                    initialValues={initialValues}
-                    validationSchema={changePasswordSchema}
-                    onSubmit={this.handleSubmit}
-                    render={this.renderForm}
-                  />
-                </div>
-              </div>
+        {showSubmittingModal && this.renderSubmitting()}
 
-              {showSubmittingModal && this.renderSubmitting()}
-
-              <RedirectForm path="done" ref={this.doneRedirectRef} />
-            </>
-          );
-        }}
-      </CrumbContext.Consumer>
+        <RedirectForm path="done" ref={this.doneRedirectRef} />
+      </>
     );
   }
 
@@ -226,8 +222,6 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
 
     return (
       <form action="" method="POST" className="m-v500" onSubmit={handleSubmit}>
-        <input type="hidden" name="crumb" value={values.crumb} />
-
         {/*
           This is here for the benefit of password managers, so they can pick
           up the username associated with the change of password.
@@ -235,10 +229,15 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
           See: https://www.chromium.org/developers/design-documents/create-amazing-password-forms
         */}
         <input
-          type="hidden"
+          type="text"
           name="username"
+          style={{
+            position: 'absolute',
+            visibility: 'hidden',
+          }}
           autoComplete="username"
           value={values.username}
+          readOnly
         />
 
         {/* "g--r" so that we can put the policy first on mobile */}
@@ -284,9 +283,7 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
               <button
                 type="submit"
                 className="btn"
-                disabled={
-                  (process as any).browser && (!isValid || isSubmitting)
-                }
+                disabled={!isValid || isSubmitting}
               >
                 {account.needsNewPassword
                   ? 'Set new password'
@@ -300,13 +297,45 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
   };
 
   private renderSubmitting() {
+    const { showNetworkError } = this.state;
+
     return (
       <StatusModal>
-        <div className="t--intro">Saving your new password…</div>
-        <div className="t--info m-t300">
-          Please be patient and don’t refresh your browser. This might take a
-          bit.
-        </div>
+        {!showNetworkError && (
+          <>
+            <div className="t--intro">Saving your new password…</div>
+            <div className="t--info m-t300">
+              Please be patient and don’t refresh your browser. This might take
+              a bit.
+            </div>
+          </>
+        )}
+        {showNetworkError && (
+          <>
+            <div className="t--intro t--err">There was a network problem</div>
+            <div className="t--info m-v300">
+              Your password was probably not changed. If this keeps happening,
+              please get in touch:
+            </div>
+
+            <HelpContactInfo />
+
+            <div className="ta-r">
+              <button
+                type="button"
+                className="btn"
+                onClick={() =>
+                  this.setState({
+                    showSubmittingModal: false,
+                    showNetworkError: false,
+                  })
+                }
+              >
+                Try Again
+              </button>
+            </div>
+          </>
+        )}
       </StatusModal>
     );
   }

--- a/services-js/access-boston/src/pages/register.tsx
+++ b/services-js/access-boston/src/pages/register.tsx
@@ -10,6 +10,7 @@ import { GetInitialPropsDependencies, GetInitialProps } from './_app';
 import fetchAccount, { Account } from '../client/graphql/fetch-account';
 import { MAIN_CLASS } from '../client/styles';
 import { RedirectError } from '../client/auth-helpers';
+import HelpContactInfo from '../client/HelpContactInfo';
 
 interface Props {
   account: Account;
@@ -103,16 +104,7 @@ export default class RegisterPage extends React.Component<Props> {
                   If you need extra help, give us a call:
                 </div>
 
-                <ul className="ul t--s300 lh--400">
-                  <li>
-                    DoIT Service Desk<br />
-                    <a href="tel:6176357378">(617) 635-7378</a>
-                  </li>
-                  <li>
-                    BPS Technology Help Desk Support<br />
-                    <a href="tel:6176359200">(617) 635-9200</a>
-                  </li>
-                </ul>
+                <HelpContactInfo />
               </div>
             </div>
 

--- a/services-js/access-boston/src/server/services/SamlAuth.ts
+++ b/services-js/access-boston/src/server/services/SamlAuth.ts
@@ -314,6 +314,9 @@ export default class SamlAuth {
         { request_body: body },
         (err, saml: SamlAssertion) => {
           if (err) {
+            // eslint-disable-next-line no-console
+            console.debug('SAML assert error', body);
+
             reject(err);
             return;
           }
@@ -337,6 +340,8 @@ export default class SamlAuth {
         { request_body: query },
         (err, saml: SamlAssertion) => {
           if (err) {
+            // eslint-disable-next-line no-console
+            console.debug('SAML assert error', query);
             reject(err);
             return;
           }

--- a/services-js/access-boston/src/stories/ChangePasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ChangePasswordPage.stories.tsx
@@ -35,4 +35,12 @@ storiesOf('ChangePasswordPage', module)
       fetchGraphql={null as any}
       testSubmittingModal
     />
+  ))
+  .add('network error', () => (
+    <ChangePasswordPage
+      account={ACCOUNT}
+      fetchGraphql={null as any}
+      testSubmittingModal
+      testNetworkError
+    />
   ));

--- a/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
@@ -21,4 +21,13 @@ storiesOf('ForgotPasswordPage', module)
       fetchGraphql={null as any}
       testSuccessMessage
     />
+  ))
+
+  .add('network error', () => (
+    <ForgotPasswordPage
+      account={ACCOUNT}
+      fetchGraphql={null as any}
+      testSubmittingModal
+      testNetworkError
+    />
   ));

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -121,14 +121,16 @@ Array [
         onSubmit={[Function]}
       >
         <input
-          name="crumb"
-          type="hidden"
-          value=""
-        />
-        <input
           autoComplete="username"
           name="username"
-          type="hidden"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
           value="CON01234"
         />
         <div
@@ -355,6 +357,7 @@ Array [
             >
               <button
                 className="btn"
+                disabled={true}
                 type="submit"
               >
                 Change Password
@@ -462,14 +465,16 @@ Array [
         onSubmit={[Function]}
       >
         <input
-          name="crumb"
-          type="hidden"
-          value=""
-        />
-        <input
           autoComplete="username"
           name="username"
-          type="hidden"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
           value="CON01234"
         />
         <div
@@ -696,6 +701,7 @@ Array [
             >
               <button
                 className="btn"
+                disabled={true}
                 type="submit"
               >
                 Set new password
@@ -808,14 +814,16 @@ Array [
         onSubmit={[Function]}
       >
         <input
-          name="crumb"
-          type="hidden"
-          value=""
-        />
-        <input
           autoComplete="username"
           name="username"
-          type="hidden"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
           value="CON01234"
         />
         <div
@@ -1042,6 +1050,7 @@ Array [
             >
               <button
                 className="btn"
+                disabled={true}
                 type="submit"
               >
                 Set new password
@@ -1065,7 +1074,7 @@ Array [
 ]
 `;
 
-exports[`Storyshots ChangePasswordPage submitting 1`] = `
+exports[`Storyshots ChangePasswordPage network error 1`] = `
 Array [
   <div
     className="css-1gni7w7 p-a200"
@@ -1136,14 +1145,16 @@ Array [
         onSubmit={[Function]}
       >
         <input
-          name="crumb"
-          type="hidden"
-          value=""
-        />
-        <input
           autoComplete="username"
           name="username"
-          type="hidden"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
           value="CON01234"
         />
         <div
@@ -1370,6 +1381,393 @@ Array [
             >
               <button
                 className="btn"
+                disabled={true}
+                type="submit"
+              >
+                Change Password
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>,
+  <div
+    className="md"
+  >
+    <div
+      className="md-c br br-t400 css-1y2scv5"
+    >
+      <div
+        className="md-b p-a300"
+      >
+        <div
+          className="t--intro t--err"
+        >
+          There was a network problem
+        </div>
+        <div
+          className="t--info m-v300"
+        >
+          Your password was probably not changed. If this keeps happening, please get in touch:
+        </div>
+        <ul
+          className="ul t--s300 lh--400"
+        >
+          <li>
+            DoIT Service Desk
+            <br />
+            <a
+              href="tel:6176357378"
+            >
+              (617) 635-7378
+            </a>
+          </li>
+          <li>
+            BPS Technology Help Desk Support
+            <br />
+            <a
+              href="tel:6176359200"
+            >
+              (617) 635-9200
+            </a>
+          </li>
+        </ul>
+        <div
+          className="ta-r"
+        >
+          <button
+            className="btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <form
+    action="done"
+    method="POST"
+  >
+    <input
+      name="crumb"
+      type="hidden"
+      value=""
+    />
+  </form>,
+]
+`;
+
+exports[`Storyshots ChangePasswordPage submitting 1`] = `
+Array [
+  <div
+    className="css-1gni7w7 p-a200"
+  >
+    <h1
+      className="css-e3scnp"
+    >
+      <a
+        href="/"
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        Access Boston
+      </a>
+    </h1>
+    <div
+      className="css-n9ftlz"
+    >
+      <span
+        style={
+          Object {
+            "marginRight": "1em",
+          }
+        }
+      >
+        CON01234
+      </span>
+      <form
+        action="/logout"
+        method="POST"
+      >
+        <input
+          name="crumb"
+          type="hidden"
+          value=""
+        />
+        <button
+          className="btn btn--sm btn--100"
+        >
+          Logout
+        </button>
+      </form>
+    </div>
+  </div>,
+  <div
+    className="mn css-1jubgvi"
+  >
+    <div
+      className="b b-c b-c--hsm"
+    >
+      <div
+        className="sh m-b300 "
+      >
+        <h2
+          className="sh-title"
+        >
+          Change Password
+        </h2>
+      </div>
+      <form
+        action=""
+        className="m-v500"
+        method="POST"
+        onSubmit={[Function]}
+      >
+        <input
+          autoComplete="username"
+          name="username"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
+          value="CON01234"
+        />
+        <div
+          className="g g--r m-v200"
+        >
+          <div
+            className="g--6 m-b500"
+          >
+            <div
+              className="txt-l m-b200"
+              style={
+                Object {
+                  "marginTop": 1,
+                }
+              }
+            >
+              New passwords must:
+            </div>
+            <ul
+              className="ul"
+              style={
+                Object {
+                  "lineHeight": 1.6,
+                }
+              }
+            >
+              <li
+                className=""
+              >
+                Be at least 10 characters long
+              </li>
+              <li
+                className=""
+              >
+                Use at least 3 of these:
+                <ul
+                  className="ul"
+                >
+                  <li
+                    className=""
+                  >
+                    A lowercase letter
+                  </li>
+                  <li
+                    className=""
+                  >
+                    An uppercase letter
+                  </li>
+                  <li
+                    className=""
+                  >
+                    A number
+                  </li>
+                  <li
+                    className=""
+                  >
+                    A special character
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="css-5qhwje"
+              >
+                Not have spaces
+              </li>
+              <li
+                className="css-5qhwje"
+              >
+                Not be longer than 32 characters
+              </li>
+            </ul>
+            <div
+              className="t--subinfo m-v300 m-b200"
+            >
+              Don’t use personal info, like your name or address. Your new password will have to be different than your last 5 passwords.
+            </div>
+          </div>
+          <div
+            className="g--6"
+          >
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-2099349523"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                Current Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="current-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-2099349523"
+                name="password"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--info t--err m-v100"
+              >
+                 
+              </div>
+            </div>
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-529028998"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                New Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="new-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-529028998"
+                name="newPassword"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--info t--err m-v100"
+              >
+                 
+              </div>
+            </div>
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-2475388040"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                Confirm Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="new-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-2475388040"
+                name="confirmPassword"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--info t--err m-v100"
+              >
+                 
+              </div>
+            </div>
+            <div
+              className="ta-r"
+            >
+              <button
+                className="btn"
+                disabled={true}
                 type="submit"
               >
                 Change Password
@@ -1448,14 +1846,16 @@ Array [
         onSubmit={[Function]}
       >
         <input
-          name="crumb"
-          type="hidden"
-          value=""
-        />
-        <input
           autoComplete="username"
           name="username"
-          type="hidden"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
           value="CON01234"
         />
         <div
@@ -1630,15 +2030,311 @@ Array [
                  
               </div>
             </div>
+            <div
+              className="ta-r"
+            >
+              <button
+                className="btn"
+                disabled={true}
+                type="submit"
+              >
+                Reset Password
+              </button>
+            </div>
           </div>
         </div>
-        <button
-          className="btn"
-          type="submit"
-        >
-          Reset Password
-        </button>
       </form>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Storyshots ForgotPasswordPage network error 1`] = `
+Array [
+  <div
+    className="css-1gni7w7 p-a200"
+  >
+    <h1
+      className="css-e3scnp"
+    >
+      Access Boston
+    </h1>
+  </div>,
+  <div
+    className="mn css-1jubgvi"
+  >
+    <div
+      className="b b-c b-c--hsm"
+    >
+      <div
+        className="sh m-b300 "
+      >
+        <h2
+          className="sh-title"
+        >
+          Forgot Password
+        </h2>
+      </div>
+      <form
+        action=""
+        className="m-v500"
+        method="POST"
+        onSubmit={[Function]}
+      >
+        <input
+          autoComplete="username"
+          name="username"
+          readOnly={true}
+          style={
+            Object {
+              "position": "absolute",
+              "visibility": "hidden",
+            }
+          }
+          type="text"
+          value="CON01234"
+        />
+        <div
+          className="g g--r m-v200"
+        >
+          <div
+            className="g--6 m-b500"
+          >
+            <div
+              className="txt-l m-b200"
+              style={
+                Object {
+                  "marginTop": 1,
+                }
+              }
+            >
+              New passwords must:
+            </div>
+            <ul
+              className="ul"
+              style={
+                Object {
+                  "lineHeight": 1.6,
+                }
+              }
+            >
+              <li
+                className=""
+              >
+                Be at least 10 characters long
+              </li>
+              <li
+                className=""
+              >
+                Use at least 3 of these:
+                <ul
+                  className="ul"
+                >
+                  <li
+                    className=""
+                  >
+                    A lowercase letter
+                  </li>
+                  <li
+                    className=""
+                  >
+                    An uppercase letter
+                  </li>
+                  <li
+                    className=""
+                  >
+                    A number
+                  </li>
+                  <li
+                    className=""
+                  >
+                    A special character
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="css-5qhwje"
+              >
+                Not have spaces
+              </li>
+              <li
+                className="css-5qhwje"
+              >
+                Not be longer than 32 characters
+              </li>
+            </ul>
+            <div
+              className="t--subinfo m-v300 m-b200"
+            >
+              Don’t use personal info, like your name or address. Your new password will have to be different than your last 5 passwords.
+            </div>
+          </div>
+          <div
+            className="g--6"
+          >
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-529028998"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                New Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="new-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-529028998"
+                name="newPassword"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--info t--err m-v100"
+              >
+                 
+              </div>
+            </div>
+            <div
+              className="txt"
+              style={
+                Object {
+                  "marginBottom": "0.5rem",
+                }
+              }
+            >
+              <label
+                className="txt-l"
+                htmlFor="input-2475388040"
+                style={
+                  Object {
+                    "marginTop": 0,
+                  }
+                }
+              >
+                Confirm Password
+                <span
+                  aria-hidden="true"
+                  className="t--req"
+                >
+                   
+                  Required
+                </span>
+              </label>
+              <input
+                autoCapitalize="off"
+                autoComplete="new-password"
+                autoCorrect="off"
+                autoFocus={false}
+                className=" txt-f "
+                id="input-2475388040"
+                name="confirmPassword"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                spellCheck={false}
+                type="password"
+                value=""
+              />
+              <div
+                className="t--info t--err m-v100"
+              >
+                 
+              </div>
+            </div>
+            <div
+              className="ta-r"
+            >
+              <button
+                className="btn"
+                disabled={true}
+                type="submit"
+              >
+                Reset Password
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>,
+  <div
+    className="md"
+  >
+    <div
+      className="md-c br br-t400 css-1y2scv5"
+    >
+      <div
+        className="md-b p-a300"
+      >
+        <div
+          className="t--intro t--err"
+        >
+          There was a network problem
+        </div>
+        <div
+          className="t--info m-v300"
+        >
+          Your password was probably not changed. If this keeps happening, please get in touch:
+        </div>
+        <ul
+          className="ul t--s300 lh--400"
+        >
+          <li>
+            DoIT Service Desk
+            <br />
+            <a
+              href="tel:6176357378"
+            >
+              (617) 635-7378
+            </a>
+          </li>
+          <li>
+            BPS Technology Help Desk Support
+            <br />
+            <a
+              href="tel:6176359200"
+            >
+              (617) 635-9200
+            </a>
+          </li>
+        </ul>
+        <div
+          className="ta-r"
+        >
+          <button
+            className="btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
     </div>
   </div>,
 ]


### PR DESCRIPTION
 - Shows network errors for change password and forgot password cases
 - Factors out IdentityIQ requesting to handle errors better
 - Adds timeout to IIQ server
 - Adds logging around SAML errors

Also:
 - Clears out lingering "crumb" form values, which we don't need because
   the forms are JS-only for now
 - Ensures that form buttons are disabled on initial render (#64)

Fixes #64