### PR TITLE
Renames Cart to DeathCertificateCart

### DIFF
--- a/services-js/registry-certs/client/AppLayout.tsx
+++ b/services-js/registry-certs/client/AppLayout.tsx
@@ -9,7 +9,7 @@ const navigationHtml: string = require('../templates/navigation.html');
 const footerHtml: string = require('../templates/footer.html');
 
 import Nav from './common/Nav';
-import Cart from './store/Cart';
+import DeathCertificateCart from './store/DeathCertificateCart';
 
 import { FREEDOM_RED } from './common/style-constants';
 
@@ -20,7 +20,7 @@ type Props =
     }
   | {
       showNav: true;
-      cart: Cart;
+      cart: DeathCertificateCart;
     };
 
 const LAST_BREADCRUMB_STYLE = css({

--- a/services-js/registry-certs/client/common/CostSummary.stories.tsx
+++ b/services-js/registry-certs/client/common/CostSummary.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import Cart from '../store/Cart';
+import DeathCertificateCart from '../store/DeathCertificateCart';
 
 import CostSummary from './CostSummary';
 
@@ -12,7 +12,7 @@ import {
 } from '../../fixtures/client/death-certificates';
 
 function makeCart() {
-  const cart = new Cart();
+  const cart = new DeathCertificateCart();
 
   cart.setQuantity(TYPICAL_CERTIFICATE, 1);
   cart.setQuantity(PENDING_CERTIFICATE, 3);

--- a/services-js/registry-certs/client/common/CostSummary.tsx
+++ b/services-js/registry-certs/client/common/CostSummary.tsx
@@ -8,12 +8,12 @@ import {
   CERTIFICATE_COST_STRING,
 } from '../../lib/costs';
 
-import Cart from '../store/Cart';
+import DeathCertificateCart from '../store/DeathCertificateCart';
 
 type ServiceFeeType = 'CREDIT' | 'DEBIT';
 
 interface Props {
-  cart: Cart;
+  cart: DeathCertificateCart;
   serviceFeeType: ServiceFeeType;
   allowServiceFeeTypeChoice?: boolean;
 }

--- a/services-js/registry-certs/client/common/Nav.stories.tsx
+++ b/services-js/registry-certs/client/common/Nav.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Nav from './Nav';
 
-import Cart from '../store/Cart';
+import DeathCertificateCart from '../store/DeathCertificateCart';
 
-storiesOf('Nav', module).add('default', () => <Nav cart={new Cart()} />);
+storiesOf('Nav', module).add('default', () => (
+  <Nav cart={new DeathCertificateCart()} />
+));

--- a/services-js/registry-certs/client/common/Nav.tsx
+++ b/services-js/registry-certs/client/common/Nav.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 import { observer } from 'mobx-react';
 import { css } from 'emotion';
 
-import Cart from '../store/Cart';
+import DeathCertificateCart from '../store/DeathCertificateCart';
 import { CHARLES_BLUE, SERIF } from './style-constants';
 
 interface Props {
-  cart: Cart;
+  cart: DeathCertificateCart;
 }
 
 const BAR_STYLE = css({

--- a/services-js/registry-certs/client/dao/CheckoutDao.test.ts
+++ b/services-js/registry-certs/client/dao/CheckoutDao.test.ts
@@ -1,6 +1,6 @@
 import { FetchGraphql } from '@cityofboston/next-client-common';
 
-import Cart from '../store/Cart';
+import DeathCertificateCart from '../store/DeathCertificateCart';
 import Order from '../models/Order';
 
 import CheckoutDao from './CheckoutDao';
@@ -13,7 +13,7 @@ let fetchGraphql: FetchGraphql;
 let stripe: stripe.Stripe;
 let dao: CheckoutDao;
 
-let cart: Cart;
+let cart: DeathCertificateCart;
 let order: Order;
 
 beforeEach(() => {
@@ -24,7 +24,7 @@ beforeEach(() => {
 
   dao = new CheckoutDao(fetchGraphql, stripe);
 
-  cart = new Cart();
+  cart = new DeathCertificateCart();
   order = new Order();
 });
 

--- a/services-js/registry-certs/client/dao/CheckoutDao.ts
+++ b/services-js/registry-certs/client/dao/CheckoutDao.ts
@@ -2,7 +2,7 @@ import { action, runInAction } from 'mobx';
 
 import { FetchGraphql } from '@cityofboston/next-client-common';
 
-import Cart from '../store/Cart';
+import DeathCertificateCart from '../store/DeathCertificateCart';
 import Order from '../models/Order';
 
 import submitDeathCertificateOrder from '../queries/submit-death-certificate-order';
@@ -96,7 +96,10 @@ export default class CheckoutDao {
 
   // Does not reject. Instead stores errors in Order.processingError
   @action
-  async submit(cart: Cart, order: Order): Promise<string | null> {
+  async submit(
+    cart: DeathCertificateCart,
+    order: Order
+  ): Promise<string | null> {
     try {
       order.processing = true;
       order.processingError = null;

--- a/services-js/registry-certs/client/death/cart/CartItem.stories.tsx
+++ b/services-js/registry-certs/client/death/cart/CartItem.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 import SiteAnalytics from '../../lib/SiteAnalytics';
 
 import {
@@ -13,7 +13,7 @@ import {
 import CartItem from './CartItem';
 
 function makeProps(certificate) {
-  const cart = new Cart();
+  const cart = new DeathCertificateCart();
   const siteAnalytics = new SiteAnalytics();
 
   cart.setQuantity(certificate, 1);

--- a/services-js/registry-certs/client/death/cart/CartItem.test.tsx
+++ b/services-js/registry-certs/client/death/cart/CartItem.test.tsx
@@ -1,28 +1,30 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import Cart, { CartEntry } from '../../store/Cart';
+import DeathCertificateCart, {
+  DeathCertificateCartEntry,
+} from '../../store/DeathCertificateCart';
 import SiteAnalytics from '../../lib/SiteAnalytics';
 
 import CartItem from './CartItem';
 import { TYPICAL_CERTIFICATE } from '../../../fixtures/client/death-certificates';
 
-jest.mock('../../store/Cart');
+jest.mock('../../store/DeathCertificateCart');
 
 describe('quantity field', () => {
-  let entry: CartEntry;
+  let entry: DeathCertificateCartEntry;
   let cart;
   let siteAnalytics;
   let wrapper;
   let quantityField;
 
   beforeEach(() => {
-    entry = new CartEntry();
+    entry = new DeathCertificateCartEntry();
     entry.id = TYPICAL_CERTIFICATE.id;
     entry.cert = TYPICAL_CERTIFICATE;
     entry.quantity = 4;
 
-    cart = new Cart();
+    cart = new DeathCertificateCart();
     siteAnalytics = new SiteAnalytics();
 
     // mount because the quantity field is behind a render prop

--- a/services-js/registry-certs/client/death/cart/CartItem.tsx
+++ b/services-js/registry-certs/client/death/cart/CartItem.tsx
@@ -3,16 +3,18 @@ import { computed, action } from 'mobx';
 import { observer } from 'mobx-react';
 import { css } from 'emotion';
 
-import Cart, { CartEntry } from '../../store/Cart';
+import DeathCertificateCart, {
+  DeathCertificateCartEntry,
+} from '../../store/DeathCertificateCart';
 import SiteAnalytics from '../../lib/SiteAnalytics';
 
 import CertificateRow from '../../common/CertificateRow';
 import { OPTIMISTIC_BLUE, FREEDOM_RED } from '../../common/style-constants';
 
 export interface Props {
-  cart: Cart;
+  cart: DeathCertificateCart;
   siteAnalytics: SiteAnalytics;
-  entry: CartEntry;
+  entry: DeathCertificateCartEntry;
   lastRow: boolean;
 }
 

--- a/services-js/registry-certs/client/death/cart/CartPage.stories.tsx
+++ b/services-js/registry-certs/client/death/cart/CartPage.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { runInAction } from 'mobx';
 
 import SiteAnalytics from '../../lib/SiteAnalytics';
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 
 import CartPage from './CartPage';
 
@@ -14,7 +14,7 @@ import {
 } from '../../../fixtures/client/death-certificates';
 
 function makeCart(loading: boolean) {
-  const cart = new Cart();
+  const cart = new DeathCertificateCart();
 
   if (loading) {
     runInAction(() => {
@@ -43,11 +43,20 @@ function makeCart(loading: boolean) {
 
 storiesOf('CartPage', module)
   .add('loading', () => (
-    <CartPage cart={makeCart(true)} siteAnalytics={new SiteAnalytics()} />
+    <CartPage
+      deathCertificateCart={makeCart(true)}
+      siteAnalytics={new SiteAnalytics()}
+    />
   ))
   .add('normal page', () => (
-    <CartPage cart={makeCart(false)} siteAnalytics={new SiteAnalytics()} />
+    <CartPage
+      deathCertificateCart={makeCart(false)}
+      siteAnalytics={new SiteAnalytics()}
+    />
   ))
   .add('empty cart', () => (
-    <CartPage cart={new Cart()} siteAnalytics={new SiteAnalytics()} />
+    <CartPage
+      deathCertificateCart={new DeathCertificateCart()}
+      siteAnalytics={new SiteAnalytics()}
+    />
   ));

--- a/services-js/registry-certs/client/death/cart/CartPage.tsx
+++ b/services-js/registry-certs/client/death/cart/CartPage.tsx
@@ -16,7 +16,8 @@ import AppLayout from '../../AppLayout';
 import CartItem from './CartItem';
 import CostSummary from '../../common/CostSummary';
 
-interface Props extends Pick<PageDependencies, 'cart' | 'siteAnalytics'> {}
+interface Props
+  extends Pick<PageDependencies, 'deathCertificateCart' | 'siteAnalytics'> {}
 
 @observer
 class CartPage extends React.Component<Props> {
@@ -24,18 +25,18 @@ class CartPage extends React.Component<Props> {
   componentWillUnmount = action(
     'CartPageController componentWillUnmount',
     () => {
-      const { cart } = this.props;
-      cart.clean();
+      const { deathCertificateCart } = this.props;
+      deathCertificateCart.clean();
     }
   );
 
   render() {
-    const { cart, siteAnalytics } = this.props;
+    const { deathCertificateCart, siteAnalytics } = this.props;
 
-    const loading = !!cart.entries.find(({ cert }) => !cert);
+    const loading = !!deathCertificateCart.entries.find(({ cert }) => !cert);
 
     return (
-      <AppLayout showNav cart={cart}>
+      <AppLayout showNav cart={deathCertificateCart}>
         <div className="b-ff">
           <Head>
             <title>Boston.gov — Death Certificate Cart</title>
@@ -60,18 +61,18 @@ class CartPage extends React.Component<Props> {
 
             <div className="b-ff">
               <div>
-                {cart.entries.map((entry, i) => (
+                {deathCertificateCart.entries.map((entry, i) => (
                   <CartItem
                     key={entry.id}
                     entry={entry}
-                    cart={cart}
+                    cart={deathCertificateCart}
                     siteAnalytics={siteAnalytics}
-                    lastRow={i === cart.entries.length - 1}
+                    lastRow={i === deathCertificateCart.entries.length - 1}
                   />
                 ))}
 
                 {loading && <div className="t--intro">Loading your cart…</div>}
-                {cart.entries.length === 0 && (
+                {deathCertificateCart.entries.length === 0 && (
                   <div>
                     <div className="t--intro">There’s nothing here yet!</div>
                     <p className="t--info">
@@ -82,10 +83,10 @@ class CartPage extends React.Component<Props> {
               </div>
             </div>
 
-            {cart.entries.length > 0 && (
+            {deathCertificateCart.entries.length > 0 && (
               <div className="m-t700">
                 <CostSummary
-                  cart={cart}
+                  cart={deathCertificateCart}
                   allowServiceFeeTypeChoice
                   serviceFeeType="CREDIT"
                 />
@@ -107,7 +108,7 @@ class CartPage extends React.Component<Props> {
             )}
           </div>
 
-          {cart.entries.length > 0 && (
+          {deathCertificateCart.entries.length > 0 && (
             <div className="b--g m-t700">
               <div id="service-fee" className="b-c b-c--smv t--subinfo">
                 * You are charged an extra service fee of no more than{' '}

--- a/services-js/registry-certs/client/death/certificate/CertificatePage.stories.tsx
+++ b/services-js/registry-certs/client/death/certificate/CertificatePage.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import SiteAnalytics from '../../lib/SiteAnalytics';
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 
 import CertificatePage from './CertificatePage';
 
@@ -12,7 +12,7 @@ import {
 } from '../../../fixtures/client/death-certificates';
 
 const makeCart = (quantity: number) => {
-  const cart = new Cart();
+  const cart = new DeathCertificateCart();
 
   if (quantity) {
     cart.setQuantity(TYPICAL_CERTIFICATE, quantity);
@@ -27,7 +27,7 @@ storiesOf('CertificatePage', module)
       id={TYPICAL_CERTIFICATE.id}
       certificate={TYPICAL_CERTIFICATE}
       backUrl={'/search?q=Jayn'}
-      cart={makeCart(0)}
+      deathCertificateCart={makeCart(0)}
       siteAnalytics={new SiteAnalytics()}
     />
   ))
@@ -36,7 +36,7 @@ storiesOf('CertificatePage', module)
       id={TYPICAL_CERTIFICATE.id}
       certificate={TYPICAL_CERTIFICATE}
       backUrl={'/search?q=Jayn'}
-      cart={makeCart(5)}
+      deathCertificateCart={makeCart(5)}
       siteAnalytics={new SiteAnalytics()}
     />
   ))
@@ -45,7 +45,7 @@ storiesOf('CertificatePage', module)
       id={TYPICAL_CERTIFICATE.id}
       certificate={TYPICAL_CERTIFICATE}
       backUrl={null}
-      cart={makeCart(0)}
+      deathCertificateCart={makeCart(0)}
       siteAnalytics={new SiteAnalytics()}
     />
   ))
@@ -54,7 +54,7 @@ storiesOf('CertificatePage', module)
       id={PENDING_CERTIFICATE.id}
       certificate={PENDING_CERTIFICATE}
       backUrl={'/search?q=Jayn'}
-      cart={makeCart(0)}
+      deathCertificateCart={makeCart(0)}
       siteAnalytics={new SiteAnalytics()}
     />
   ))
@@ -63,7 +63,7 @@ storiesOf('CertificatePage', module)
       id="200001"
       certificate={null}
       backUrl={'/search?q=Jayn'}
-      cart={makeCart(0)}
+      deathCertificateCart={makeCart(0)}
       siteAnalytics={new SiteAnalytics()}
     />
   ));

--- a/services-js/registry-certs/client/death/certificate/CertificatePage.test.tsx
+++ b/services-js/registry-certs/client/death/certificate/CertificatePage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 import DeathCertificatesDao from '../../dao/DeathCertificatesDao';
 
 import CertificatePage from './CertificatePage';
@@ -61,12 +61,12 @@ describe('getInitialProps', () => {
       let component;
 
       beforeEach(() => {
-        cart = new Cart();
+        cart = new DeathCertificateCart();
         siteAnalytics = new SiteAnalytics();
 
         component = shallow(
           <CertificatePage
-            cart={cart}
+            deathCertificateCart={cart}
             siteAnalytics={siteAnalytics}
             id="0002"
             certificate={TYPICAL_CERTIFICATE}
@@ -101,7 +101,7 @@ describe('interface', () => {
     wrapper = shallow(
       <CertificatePage
         siteAnalytics={siteAnalytics}
-        cart={new Cart()}
+        deathCertificateCart={new DeathCertificateCart()}
         certificate={TYPICAL_CERTIFICATE}
         id={TYPICAL_CERTIFICATE.id}
         backUrl={'/search?q=jayne'}

--- a/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
+++ b/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
@@ -26,7 +26,7 @@ interface InitialProps {
 
 interface Props
   extends InitialProps,
-    Pick<PageDependencies, 'cart' | 'siteAnalytics'> {}
+    Pick<PageDependencies, 'deathCertificateCart' | 'siteAnalytics'> {}
 
 interface State {
   quantity: number | null;
@@ -96,10 +96,10 @@ class CertificatePage extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const { id, cart } = props;
+    const { id, deathCertificateCart } = props;
 
     this.state = {
-      quantity: cart.getQuantity(id) || 1,
+      quantity: deathCertificateCart.getQuantity(id) || 1,
     };
   }
 
@@ -113,15 +113,15 @@ class CertificatePage extends React.Component<Props, State> {
   setCartQuantity = action(
     'CertificatePageController setCartQuantity',
     async (quantity: number) => {
-      const { certificate, cart, siteAnalytics } = this.props;
+      const { certificate, deathCertificateCart, siteAnalytics } = this.props;
 
       if (certificate) {
         if (quantity === 0) {
-          cart.remove(certificate.id);
+          deathCertificateCart.remove(certificate.id);
 
           siteAnalytics.sendEvent('UX', 'click', 'add to cart');
         } else {
-          cart.setQuantity(certificate, quantity);
+          deathCertificateCart.setQuantity(certificate, quantity);
           siteAnalytics.sendEvent('UX', 'click', 'add to cart');
 
           await Router.push('/death/cart');
@@ -165,7 +165,7 @@ class CertificatePage extends React.Component<Props, State> {
   };
 
   render() {
-    const { id, certificate, backUrl, cart } = this.props;
+    const { id, certificate, backUrl, deathCertificateCart } = this.props;
 
     const { firstName, lastName } = certificate || {
       firstName: null,
@@ -177,7 +177,7 @@ class CertificatePage extends React.Component<Props, State> {
       : null;
 
     return (
-      <AppLayout showNav cart={cart}>
+      <AppLayout showNav cart={deathCertificateCart}>
         <div className="b-ff">
           <Head>
             <title>
@@ -301,10 +301,10 @@ class CertificatePage extends React.Component<Props, State> {
   }
 
   renderAddToCart() {
-    const { cart, id } = this.props;
+    const { deathCertificateCart, id } = this.props;
     const { quantity } = this.state;
 
-    const cartQuantity = cart.getQuantity(id);
+    const cartQuantity = deathCertificateCart.getQuantity(id);
 
     return (
       <form onSubmit={this.handleAddToCart} className={ADD_TO_CART_FORM_STYLE}>

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.test.tsx
@@ -5,7 +5,7 @@ import CheckoutDao from '../../dao/CheckoutDao';
 import OrderProvider from '../../store/OrderProvider';
 import Accessibility from '../../store/Accessibility';
 import SiteAnalytics from '../../lib/SiteAnalytics';
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 
 jest.mock('next/router');
 jest.mock('../../dao/CheckoutDao');
@@ -98,7 +98,7 @@ describe('rendering', () => {
   beforeEach(() => {
     pageDependenciesProps = {
       accessibility: new Accessibility(),
-      cart: new Cart(),
+      deathCertificateCart: new DeathCertificateCart(),
       checkoutDao: {} as any,
       orderProvider: new OrderProvider(),
       siteAnalytics: new SiteAnalytics(),
@@ -162,7 +162,7 @@ describe('operations', () => {
     // page doesn't really matter for this
     component = new CheckoutPage({
       accessibility: new Accessibility(),
-      cart: new Cart(),
+      deathCertificateCart: new DeathCertificateCart(),
       siteAnalytics: new SiteAnalytics(),
       stripe: null,
 

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
@@ -37,7 +37,7 @@ interface InitialProps {
 export type PageDependenciesProps = Pick<
   PageDependencies,
   | 'accessibility'
-  | 'cart'
+  | 'deathCertificateCart'
   | 'siteAnalytics'
   | 'orderProvider'
   | 'checkoutDao'
@@ -150,7 +150,7 @@ class CheckoutPageController extends React.Component<Props> {
     }
   }
 
-  reportCheckoutStep({ info, cart, siteAnalytics }: Props) {
+  reportCheckoutStep({ info, deathCertificateCart, siteAnalytics }: Props) {
     let checkoutStep: number | null = null;
     switch (info.page) {
       case 'shipping':
@@ -165,7 +165,7 @@ class CheckoutPageController extends React.Component<Props> {
     }
 
     if (checkoutStep) {
-      cart.trackCartItems();
+      deathCertificateCart.trackCartItems();
       siteAnalytics.setProductAction('checkout', { step: checkoutStep });
     }
   }
@@ -202,20 +202,20 @@ class CheckoutPageController extends React.Component<Props> {
 
   submitOrder = async () => {
     const { order } = this;
-    const { cart, checkoutDao, siteAnalytics } = this.props;
+    const { deathCertificateCart, checkoutDao, siteAnalytics } = this.props;
 
-    const orderId = await checkoutDao.submit(cart, order);
+    const orderId = await checkoutDao.submit(deathCertificateCart, order);
 
     if (orderId) {
-      cart.trackCartItems();
+      deathCertificateCart.trackCartItems();
       siteAnalytics.setProductAction('purchase', {
         id: orderId,
-        revenue: cart.size * CERTIFICATE_COST / 100,
+        revenue: deathCertificateCart.size * CERTIFICATE_COST / 100,
       });
       siteAnalytics.sendEvent('UX', 'click', 'submit order');
 
       runInAction(() => {
-        cart.clear();
+        deathCertificateCart.clear();
         this.order = new Order();
       });
 
@@ -236,13 +236,13 @@ class CheckoutPageController extends React.Component<Props> {
 
   render() {
     const { order } = this;
-    const { info, cart, stripe } = this.props;
+    const { info, deathCertificateCart, stripe } = this.props;
 
     switch (info.page) {
       case 'shipping':
         return (
           <ShippingContent
-            cart={cart}
+            cart={deathCertificateCart}
             order={order}
             submit={this.advanceToPayment}
           />
@@ -252,7 +252,7 @@ class CheckoutPageController extends React.Component<Props> {
         return (
           <PaymentContent
             stripe={stripe}
-            cart={cart}
+            cart={deathCertificateCart}
             order={order}
             submit={this.advanceToReview}
           />
@@ -260,7 +260,11 @@ class CheckoutPageController extends React.Component<Props> {
 
       case 'review':
         return (
-          <ReviewContent cart={cart} order={order} submit={this.submitOrder} />
+          <ReviewContent
+            cart={deathCertificateCart}
+            order={order}
+            submit={this.submitOrder}
+          />
         );
 
       case 'confirmation':
@@ -268,7 +272,7 @@ class CheckoutPageController extends React.Component<Props> {
           <ConfirmationContent
             orderId={info.orderId}
             contactEmail={info.contactEmail}
-            cart={cart}
+            cart={deathCertificateCart}
           />
         );
     }

--- a/services-js/registry-certs/client/death/checkout/ConfirmationContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/ConfirmationContent.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import ConfirmationContent from './ConfirmationContent';
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 
 storiesOf('ConfirmationContent', module).add('default', () => (
   <ConfirmationContent

--- a/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { observer } from 'mobx-react';
 
 import AppLayout from '../../AppLayout';
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 
 export interface Props {
   orderId: string;

--- a/services-js/registry-certs/client/death/checkout/OrderDetails.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/OrderDetails.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { runInAction } from 'mobx';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 
 import OrderDetails from './OrderDetails';
 

--- a/services-js/registry-certs/client/death/checkout/OrderDetails.tsx
+++ b/services-js/registry-certs/client/death/checkout/OrderDetails.tsx
@@ -11,7 +11,7 @@ import {
   SERVICE_FEE_URI,
 } from '../../../lib/costs';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 
 import CertificateRow from '../../common/CertificateRow';
 import {

--- a/services-js/registry-certs/client/death/checkout/PaymentContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/PaymentContent.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
 import PaymentContent from './PaymentContent';

--- a/services-js/registry-certs/client/death/checkout/PaymentContent.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/PaymentContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
 import PaymentContent from './PaymentContent';

--- a/services-js/registry-certs/client/death/checkout/PaymentContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/PaymentContent.tsx
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react';
 
 import AppLayout from '../../AppLayout';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order, { OrderInfo } from '../../models/Order';
 import { makeStateSelectOptions } from '../../common/form-elements';
 

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { DeathCertificate } from '../../types.js';
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
 import ReviewContent from './ReviewContent';

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import Order from '../../models/Order';
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 
 import ReviewContent from './ReviewContent';
 

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.tsx
@@ -13,7 +13,7 @@ import {
   SERVICE_FEE_URI,
 } from '../../../lib/costs';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
 import CostSummary from '../../common/CostSummary';

--- a/services-js/registry-certs/client/death/checkout/ShippingContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/ShippingContent.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
 import ShippingContent from './ShippingContent';

--- a/services-js/registry-certs/client/death/checkout/ShippingContent.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/ShippingContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
 import ShippingContent from './ShippingContent';

--- a/services-js/registry-certs/client/death/checkout/ShippingContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ShippingContent.tsx
@@ -7,7 +7,7 @@ import InputMask from 'react-input-mask';
 
 import AppLayout from '../../AppLayout';
 
-import Cart from '../../store/Cart';
+import Cart from '../../store/DeathCertificateCart';
 import Order, { OrderInfo } from '../../models/Order';
 import { makeStateSelectOptions } from '../../common/form-elements';
 

--- a/services-js/registry-certs/client/death/checkout/__snapshots__/CheckoutPage.test.tsx.snap
+++ b/services-js/registry-certs/client/death/checkout/__snapshots__/CheckoutPage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`rendering renders confirmation 1`] = `
 <ConfirmationContent
   cart={
-    Cart {
+    DeathCertificateCart {
       "localStorageDisposer": null,
       "siteAnalytics": null,
     }
@@ -16,7 +16,7 @@ exports[`rendering renders confirmation 1`] = `
 exports[`rendering renders payment 1`] = `
 <PaymentContent
   cart={
-    Cart {
+    DeathCertificateCart {
       "localStorageDisposer": null,
       "siteAnalytics": null,
     }
@@ -30,7 +30,7 @@ exports[`rendering renders payment 1`] = `
 exports[`rendering renders review 1`] = `
 <ReviewContent
   cart={
-    Cart {
+    DeathCertificateCart {
       "localStorageDisposer": null,
       "siteAnalytics": null,
     }
@@ -43,7 +43,7 @@ exports[`rendering renders review 1`] = `
 exports[`rendering renders shipping 1`] = `
 <ShippingContent
   cart={
-    Cart {
+    DeathCertificateCart {
       "localStorageDisposer": null,
       "siteAnalytics": null,
     }

--- a/services-js/registry-certs/client/death/search/SearchPage.stories.tsx
+++ b/services-js/registry-certs/client/death/search/SearchPage.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import SiteAnalytics from '../../lib/SiteAnalytics';
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 import SearchPage from './SearchPage';
 
 import {
@@ -18,7 +18,7 @@ storiesOf('SearchPage', module)
       page={1}
       results={null}
       siteAnalytics={new SiteAnalytics()}
-      cart={new Cart()}
+      deathCertificateCart={new DeathCertificateCart()}
     />
   ))
   .add('no results', () => (
@@ -33,7 +33,7 @@ storiesOf('SearchPage', module)
         results: [],
       }}
       siteAnalytics={new SiteAnalytics()}
-      cart={new Cart()}
+      deathCertificateCart={new DeathCertificateCart()}
     />
   ))
   .add('with results', () => (
@@ -52,6 +52,6 @@ storiesOf('SearchPage', module)
         ],
       }}
       siteAnalytics={new SiteAnalytics()}
-      cart={new Cart()}
+      deathCertificateCart={new DeathCertificateCart()}
     />
   ));

--- a/services-js/registry-certs/client/death/search/SearchPage.test.tsx
+++ b/services-js/registry-certs/client/death/search/SearchPage.test.tsx
@@ -8,7 +8,7 @@ import { DeathCertificate, DeathCertificateSearchResults } from '../../types';
 import DeathCertificatesDao from '../../dao/DeathCertificatesDao';
 import SiteAnalytics from '../../lib/SiteAnalytics';
 
-import Cart from '../../store/Cart';
+import DeathCertificateCart from '../../store/DeathCertificateCart';
 import SearchPage from './SearchPage';
 
 import {
@@ -73,7 +73,7 @@ describe('operations', () => {
       query: '',
       results: null,
       siteAnalytics: new SiteAnalytics(),
-      cart: new Cart(),
+      deathCertificateCart: new DeathCertificateCart(),
     });
   });
 
@@ -100,7 +100,7 @@ describe('content', () => {
         page={1}
         results={null}
         siteAnalytics={new SiteAnalytics()}
-        cart={new Cart()}
+        deathCertificateCart={new DeathCertificateCart()}
       />
     );
   });

--- a/services-js/registry-certs/client/death/search/SearchPage.tsx
+++ b/services-js/registry-certs/client/death/search/SearchPage.tsx
@@ -20,7 +20,7 @@ interface InitialProps {
 
 interface Props
   extends InitialProps,
-    Pick<PageDependencies, 'siteAnalytics' | 'cart'> {}
+    Pick<PageDependencies, 'siteAnalytics' | 'deathCertificateCart'> {}
 
 interface State {
   query: string;
@@ -111,11 +111,11 @@ class SearchPage extends React.Component<Props, State> {
   };
 
   render() {
-    const { results, query: originalQuery, cart } = this.props;
+    const { results, query: originalQuery, deathCertificateCart } = this.props;
     const { query } = this.state;
 
     return (
-      <AppLayout showNav cart={cart}>
+      <AppLayout showNav cart={deathCertificateCart}>
         <div>
           <div className="b-c b-c--nbp">
             <Head>

--- a/services-js/registry-certs/client/queries/submit-death-certificate-order.test.ts
+++ b/services-js/registry-certs/client/queries/submit-death-certificate-order.test.ts
@@ -1,4 +1,4 @@
-import Cart from '../store/Cart';
+import Cart from '../store/DeathCertificateCart';
 import Order from '../models/Order';
 
 import { TYPICAL_CERTIFICATE } from '../../fixtures/client/death-certificates';

--- a/services-js/registry-certs/client/queries/submit-death-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-death-certificate-order.ts
@@ -1,5 +1,5 @@
 import { gql, FetchGraphql } from '@cityofboston/next-client-common';
-import Cart from '../store/Cart';
+import Cart from '../store/DeathCertificateCart';
 import Order from '../models/Order';
 
 import {

--- a/services-js/registry-certs/client/store/DeathCertificateCart.test.ts
+++ b/services-js/registry-certs/client/store/DeathCertificateCart.test.ts
@@ -1,4 +1,4 @@
-import Cart from './Cart';
+import DeathCertificateCart from './DeathCertificateCart';
 
 jest.mock('../dao/DeathCertificatesDao');
 jest.mock('../lib/SiteAnalytics');
@@ -19,7 +19,7 @@ describe('setQuantity', () => {
   let cart;
 
   beforeEach(() => {
-    cart = new Cart();
+    cart = new DeathCertificateCart();
     cart.setQuantity(CERT_1, 1);
   });
 
@@ -41,7 +41,7 @@ describe('clean', () => {
   let cart;
 
   beforeEach(() => {
-    cart = new Cart();
+    cart = new DeathCertificateCart();
     cart.setQuantity(CERT_1, 0);
     cart.setQuantity(CERT_2, 5);
   });
@@ -59,7 +59,7 @@ describe('remove', () => {
   let cart;
 
   beforeEach(() => {
-    cart = new Cart();
+    cart = new DeathCertificateCart();
     cart.setQuantity(CERT_1, 1);
   });
 
@@ -82,7 +82,7 @@ describe('contains pending', () => {
   let cart;
 
   beforeEach(() => {
-    cart = new Cart();
+    cart = new DeathCertificateCart();
     cart.setQuantity(CERT_1, 1);
   });
 
@@ -101,7 +101,7 @@ describe('attach', () => {
   let localStorage: any;
   let deathCertificatesDao;
   let siteAnalytics;
-  let cart: Cart;
+  let cart: DeathCertificateCart;
 
   beforeEach(() => {
     localStorage = {
@@ -121,7 +121,7 @@ describe('attach', () => {
         })
     );
 
-    cart = new Cart();
+    cart = new DeathCertificateCart();
   });
 
   afterEach(() => {

--- a/services-js/registry-certs/client/store/DeathCertificateCart.ts
+++ b/services-js/registry-certs/client/store/DeathCertificateCart.ts
@@ -11,14 +11,14 @@ interface LocalStorageEntry {
   quantity: number;
 }
 
-export class CartEntry {
+export class DeathCertificateCartEntry {
   id: string = '';
   @observable.ref cert: DeathCertificate | null = null;
   @observable quantity: number = 0;
 }
 
-export default class Cart {
-  @observable entries: Array<CartEntry> = [];
+export default class DeathCertificateCart {
+  @observable entries: Array<DeathCertificateCartEntry> = [];
   @observable pendingFetches: number = 0;
 
   localStorageDisposer: Function | null = null;
@@ -41,7 +41,7 @@ export default class Cart {
           action(
             'hydrate entry from local storage start',
             ({ id, quantity }: LocalStorageEntry) => {
-              const entry = new CartEntry();
+              const entry = new DeathCertificateCartEntry();
               entry.id = id;
               entry.cert = null;
               entry.quantity = quantity;
@@ -153,7 +153,7 @@ export default class Cart {
       // disappear when you edit the values on the cart page.
       existingItem.quantity = filteredQuantity;
     } else {
-      const item = new CartEntry();
+      const item = new DeathCertificateCartEntry();
       item.id = cert.id;
       item.cert = cert;
       item.quantity = filteredQuantity;

--- a/services-js/registry-certs/pages/_app.tsx
+++ b/services-js/registry-certs/pages/_app.tsx
@@ -11,7 +11,7 @@ import {
 } from '@cityofboston/next-client-common';
 
 import { ExtendedIncomingMessage } from '@cityofboston/hapi-next';
-import Cart from '../client/store/Cart';
+import DeathCertificateCart from '../client/store/DeathCertificateCart';
 import Accessibility from '../client/store/Accessibility';
 import OrderProvider from '../client/store/OrderProvider';
 import DeathCertificatesDao from '../client/dao/DeathCertificatesDao';
@@ -73,7 +73,7 @@ export type GetInitialProps<
 export interface PageDependencies extends GetInitialPropsDependencies {
   stripe: stripe.Stripe | null;
   checkoutDao: CheckoutDao;
-  cart: Cart;
+  deathCertificateCart: DeathCertificateCart;
   accessibility: Accessibility;
   routerListener: RouterListener;
   orderProvider: OrderProvider;
@@ -173,7 +173,7 @@ export default class RegistryCertsApp extends App {
 
     const initialPageDependencies = getInitialPageDependencies();
 
-    const cart = new Cart();
+    const deathCertificateCart = new DeathCertificateCart();
     const orderProvider = new OrderProvider();
     const siteAnalytics = new SiteAnalytics();
 
@@ -181,7 +181,7 @@ export default class RegistryCertsApp extends App {
       // We attach to localStorage in the constructor, rather than
       // componentDidMount, so that the information is available on first
       // render.
-      cart.attach(
+      deathCertificateCart.attach(
         window.localStorage,
         initialPageDependencies.deathCertificatesDao,
         siteAnalytics
@@ -205,7 +205,7 @@ export default class RegistryCertsApp extends App {
       routerListener: new RouterListener(),
       accessibility: new Accessibility(),
       siteAnalytics,
-      cart,
+      deathCertificateCart,
       orderProvider,
     };
   }


### PR DESCRIPTION
Other certificate types won’t have shopping carts, so this shouldn’t be
generalized.