### PR TITLE
More death certs naming updates

### DIFF
--- a/services-js/registry-certs/client/common/CostSummary.tsx
+++ b/services-js/registry-certs/client/common/CostSummary.tsx
@@ -5,7 +5,8 @@ import { css } from 'emotion';
 import {
   calculateCreditCardCost,
   calculateDebitCardCost,
-  CERTIFICATE_COST_STRING,
+  DEATH_CERTIFICATE_COST_STRING,
+  DEATH_CERTIFICATE_COST,
 } from '../../lib/costs';
 
 import DeathCertificateCart from '../store/DeathCertificateCart';
@@ -92,8 +93,8 @@ export default class CostSummary extends React.Component<Props, State> {
     const { serviceFeeType } = this.state;
 
     return serviceFeeType === 'CREDIT'
-      ? calculateCreditCardCost(cart.size)
-      : calculateDebitCardCost(cart.size);
+      ? calculateCreditCardCost(DEATH_CERTIFICATE_COST, cart.size)
+      : calculateDebitCardCost(DEATH_CERTIFICATE_COST, cart.size);
   }
 
   render() {
@@ -107,7 +108,7 @@ export default class CostSummary extends React.Component<Props, State> {
             <tr>
               <td>
                 {cart.size} {cart.size === 1 ? 'certificate' : 'certificates'} ×{' '}
-                {CERTIFICATE_COST_STRING}
+                {DEATH_CERTIFICATE_COST_STRING}
               </td>
               <td className={COST_CELL_STYLE}>
                 ${(subtotal / 100).toFixed(2)}

--- a/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
+++ b/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
@@ -10,7 +10,7 @@ import { PageDependencies, GetInitialProps } from '../../../pages/_app';
 import { DeathCertificate } from '../../types';
 
 import {
-  CERTIFICATE_COST_STRING,
+  DEATH_CERTIFICATE_COST_STRING,
   PERCENTAGE_CC_STRING,
   FIXED_CC_STRING,
   SERVICE_FEE_URI,
@@ -234,11 +234,11 @@ class CertificatePage extends React.Component<Props, State> {
 
           <div className="b--g m-t700">
             <div className="b-c b-c--smv t--subinfo">
-              Death certificates cost {CERTIFICATE_COST_STRING} each. That price
-              includes shipping. You will be charged an extra service fee of not
-              more than {FIXED_CC_STRING} plus {PERCENTAGE_CC_STRING}. That fee
-              goes directly to a third party to pay for the cost of card
-              processing. Learn more about{' '}
+              Death certificates cost {DEATH_CERTIFICATE_COST_STRING} each. That
+              price includes shipping. You will be charged an extra service fee
+              of not more than {FIXED_CC_STRING} plus {PERCENTAGE_CC_STRING}.
+              That fee goes directly to a third party to pay for the cost of
+              card processing. Learn more about{' '}
               <a href={SERVICE_FEE_URI}>card service fees</a> at the City of
               Boston.
             </div>

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
@@ -12,7 +12,7 @@ import ShippingContent from './ShippingContent';
 import PaymentContent from './PaymentContent';
 import ReviewContent from './ReviewContent';
 import ConfirmationContent from './ConfirmationContent';
-import { CERTIFICATE_COST } from '../../../lib/costs';
+import { DEATH_CERTIFICATE_COST } from '../../../lib/costs';
 
 type PageInfo =
   | {
@@ -210,7 +210,7 @@ class CheckoutPageController extends React.Component<Props> {
       deathCertificateCart.trackCartItems();
       siteAnalytics.setProductAction('purchase', {
         id: orderId,
-        revenue: deathCertificateCart.size * CERTIFICATE_COST / 100,
+        revenue: deathCertificateCart.size * DEATH_CERTIFICATE_COST / 100,
       });
       siteAnalytics.sendEvent('UX', 'click', 'submit order');
 

--- a/services-js/registry-certs/client/death/checkout/OrderDetails.tsx
+++ b/services-js/registry-certs/client/death/checkout/OrderDetails.tsx
@@ -4,11 +4,12 @@ import VelocityTransitionGroup from 'velocity-react/velocity-transition-group';
 import { css } from 'emotion';
 
 import {
-  CERTIFICATE_COST_STRING,
+  DEATH_CERTIFICATE_COST_STRING,
   PERCENTAGE_CC_STRING,
   FIXED_CC_STRING,
   calculateCreditCardCost,
   SERVICE_FEE_URI,
+  DEATH_CERTIFICATE_COST,
 } from '../../../lib/costs';
 
 import Cart from '../../store/DeathCertificateCart';
@@ -138,8 +139,9 @@ export default class OrderDetails extends React.Component<Props, State> {
             <h2 className="stp">Order details</h2>
             <div className="t--info">
               {cart.size} {cart.size === 1 ? 'item' : 'items'} ×{' '}
-              {CERTIFICATE_COST_STRING} = ${(
-                calculateCreditCardCost(cart.size).subtotal / 100
+              {DEATH_CERTIFICATE_COST_STRING} = ${(
+                calculateCreditCardCost(DEATH_CERTIFICATE_COST, cart.size)
+                  .subtotal / 100
               ).toFixed(2)}{' '}
               + service fee*
             </div>

--- a/services-js/registry-certs/client/store/DeathCertificateCart.ts
+++ b/services-js/registry-certs/client/store/DeathCertificateCart.ts
@@ -4,7 +4,7 @@ import { DeathCertificate } from '../types';
 import DeathCertificatesDao from '../dao/DeathCertificatesDao';
 import SiteAnalytics from '../lib/SiteAnalytics';
 
-import { CERTIFICATE_COST } from '../../lib/costs';
+import { DEATH_CERTIFICATE_COST } from '../../lib/costs';
 
 interface LocalStorageEntry {
   id: string;
@@ -110,7 +110,7 @@ export default class DeathCertificateCart {
         'Death certificate',
         'Death certificate',
         quantity,
-        CERTIFICATE_COST / 100
+        DEATH_CERTIFICATE_COST / 100
       );
     });
   }
@@ -143,7 +143,7 @@ export default class DeathCertificateCart {
         'Death certificate',
         'Death certificate',
         Math.abs(quantityChange),
-        CERTIFICATE_COST / 100
+        DEATH_CERTIFICATE_COST / 100
       );
       siteAnalytics.setProductAction(quantityChange < 0 ? 'remove' : 'add');
     }
@@ -173,7 +173,7 @@ export default class DeathCertificateCart {
           'Death certificate',
           'Death certificate',
           this.getQuantity(certId),
-          CERTIFICATE_COST / 100
+          DEATH_CERTIFICATE_COST / 100
         );
         siteAnalytics.setProductAction('remove');
       }

--- a/services-js/registry-certs/lib/costs.test.ts
+++ b/services-js/registry-certs/lib/costs.test.ts
@@ -2,6 +2,7 @@ import {
   FIXED_CC_SERVICE_FEE,
   PERCENTAGE_CC_SERVICE_FEE,
   calculateCreditCardCost,
+  DEATH_CERTIFICATE_COST,
 } from './costs';
 
 // We run this over a bunch of different amounts to verify that, after rounding
@@ -9,7 +10,10 @@ import {
 // with the right certificate cost for Registry.
 it(`calculates service fee correctly for certificates`, () => {
   for (let q = 0; q < 100; ++q) {
-    const { total, serviceFee, subtotal } = calculateCreditCardCost(q);
+    const { total, serviceFee, subtotal } = calculateCreditCardCost(
+      DEATH_CERTIFICATE_COST,
+      q
+    );
 
     // Stripe rounding: https://support.stripe.com/questions/what-rules-do-you-use-for-rounding-stripe-fees
     const stripesCut = Math.round(

--- a/services-js/registry-certs/lib/costs.ts
+++ b/services-js/registry-certs/lib/costs.ts
@@ -1,6 +1,6 @@
 // All costs are in cents, which is how Stripe does things.
 
-export const CERTIFICATE_COST = 14 * 100;
+export const DEATH_CERTIFICATE_COST = 14 * 100;
 
 // CC == "credit card"
 export const FIXED_CC_SERVICE_FEE = 25;
@@ -14,9 +14,9 @@ export const PERCENTAGE_DC_SERVICE_FEE = 0.015;
 // percentage.
 const CC_PERCENT_OF_TOTAL = 1 / (1 - PERCENTAGE_CC_SERVICE_FEE) - 1;
 
-export const CERTIFICATE_COST_STRING = `$${(CERTIFICATE_COST / 100).toFixed(
-  2
-)}`;
+export const DEATH_CERTIFICATE_COST_STRING = `$${(
+  DEATH_CERTIFICATE_COST / 100
+).toFixed(2)}`;
 export const PERCENTAGE_CC_STRING = `${(
   Math.round(CC_PERCENT_OF_TOTAL * 10000) / 100
 ).toFixed(2)}%`;
@@ -24,16 +24,18 @@ export const FIXED_CC_STRING = `$${(FIXED_CC_SERVICE_FEE / 100).toFixed(2)}`;
 
 export const SERVICE_FEE_URI = 'https://www.cityofboston.gov/payments/faqs.asp';
 
-export function calculateCreditCardCost(quantity: number) {
+export function calculateCreditCardCost(eachCost: number, quantity: number) {
   return calculateCost(
+    eachCost,
     quantity,
     FIXED_CC_SERVICE_FEE,
     PERCENTAGE_CC_SERVICE_FEE
   );
 }
 
-export function calculateDebitCardCost(quantity: number) {
+export function calculateDebitCardCost(eachCost: number, quantity: number) {
   return calculateCost(
+    eachCost,
     quantity,
     FIXED_DC_SERVICE_FEE,
     PERCENTAGE_DC_SERVICE_FEE
@@ -41,11 +43,12 @@ export function calculateDebitCardCost(quantity: number) {
 }
 
 export function calculateCost(
+  eachCost: number,
   quantity: number,
   fixedCost: number,
   percentageCost: number
 ) {
-  const subtotal = quantity * CERTIFICATE_COST;
+  const subtotal = quantity * eachCost;
 
   // Math: https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
   const total = Math.round((subtotal + fixedCost) / (1 - percentageCost));

--- a/services-js/registry-certs/server/graphql/death-certificates.test.ts
+++ b/services-js/registry-certs/server/graphql/death-certificates.test.ts
@@ -1,7 +1,8 @@
 import MockDate from 'mockdate';
 
 import { resolvers, parseAgeOrDateOfBirth } from './death-certificates';
-import RegistryDb, { FixtureRegistryDb } from '../services/RegistryDb';
+import RegistryDb from '../services/RegistryDb';
+import RegistryDbFake from '../services/RegistryDbFake';
 
 import fixtureData from '../../fixtures/registry-data/smith.json';
 
@@ -19,7 +20,7 @@ describe('DeathCertificates resolvers', () => {
   let registryDb: RegistryDb;
 
   beforeEach(() => {
-    registryDb = new FixtureRegistryDb(fixtureData as any) as any;
+    registryDb = new RegistryDbFake(fixtureData as any) as any;
   });
 
   describe('search', () => {

--- a/services-js/registry-certs/server/graphql/death-certificates.ts
+++ b/services-js/registry-certs/server/graphql/death-certificates.ts
@@ -179,7 +179,7 @@ export async function loadOrder(registryDb: RegistryDb, id: string) {
       cost: quantity * certificateCost,
       // Will only be executed if dereferenced.
       certificate: async () => {
-        const cert = await registryDb.lookup(id);
+        const cert = await registryDb.lookupDeathCertificate(id);
         return cert ? searchResultToDeathCertificate(cert) : null;
       },
     };
@@ -230,7 +230,7 @@ const deathCertificatesResolvers: Resolvers<DeathCertificates, Context> = {
 
     const results: Array<
       DeathCertificateSearchResult
-    > = await registryDb.search(
+    > = await registryDb.searchDeathCertificates(
       query,
       queryPage,
       queryPageSize,
@@ -250,7 +250,7 @@ const deathCertificatesResolvers: Resolvers<DeathCertificates, Context> = {
     };
   },
   certificate: async (_root, { id }, { registryDb }) => {
-    const res = await registryDb.lookup(id);
+    const res = await registryDb.lookupDeathCertificate(id);
 
     if (res) {
       return searchResultToDeathCertificate(res);
@@ -261,7 +261,7 @@ const deathCertificatesResolvers: Resolvers<DeathCertificates, Context> = {
   certificates: (_root, { ids }, { registryDb }) =>
     Promise.all(
       ids.map(async (id): Promise<DeathCertificate | null> => {
-        const res = await registryDb.lookup(id);
+        const res = await registryDb.lookupDeathCertificate(id);
         if (res) {
           return searchResultToDeathCertificate(res);
         } else {

--- a/services-js/registry-certs/server/services/RegistryDbFake.ts
+++ b/services-js/registry-certs/server/services/RegistryDbFake.ts
@@ -1,0 +1,41 @@
+import RegistryDb, {
+  DeathCertificateSearchResult,
+  DeathCertificate,
+  FindOrderResult,
+} from './RegistryDb';
+
+export default class RegistryDbFake implements Required<RegistryDb> {
+  deathCertificates: Array<DeathCertificateSearchResult>;
+
+  constructor(deathCertificates: Array<DeathCertificateSearchResult>) {
+    this.deathCertificates = deathCertificates;
+  }
+
+  async searchDeathCertificates(
+    _query: string,
+    page: number,
+    pageSize: number
+  ): Promise<Array<DeathCertificateSearchResult>> {
+    return this.deathCertificates.slice(page * pageSize, (page + 1) * pageSize);
+  }
+
+  async lookupDeathCertificate(id: string): Promise<DeathCertificate | null> {
+    return this.deathCertificates.find(
+      res => res.CertificateID.toString() === id
+    )!;
+  }
+
+  async addOrder(): Promise<number> {
+    return 50;
+  }
+
+  async addItem(): Promise<void> {}
+  async addPayment(): Promise<void> {}
+
+  async findOrder(): Promise<FindOrderResult | null> {
+    const orderFixture = require('../../fixtures/registry-orders/order.json');
+    return orderFixture;
+  }
+
+  async cancelOrder(): Promise<void> {}
+}


### PR DESCRIPTION
 - Adds "DeathCertificates" to search and lookup in RegistryDb
 - Adds a parameter to add order / item functions to specify the type of
   certificate
 - Parameterizes cost calculations on certificate type

Also:
 - Separates out RegistryDbFake into its own file, uses it more in tests
   to add type safety around mock methods.