### PR TITLE
Prep for apply form submissions

### DIFF
--- a/services-js/commissions-app/src/client/common/TextInputContainer.tsx
+++ b/services-js/commissions-app/src/client/common/TextInputContainer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { TextInput } from '@cityofboston/react-fleet';
 
-
 /**
  * Convenience component to simplify use with Formik.
  */
@@ -16,11 +15,11 @@ function TextInputContainer({
   field: { name, value },
   form: { touched, errors, handleBlur, handleChange },
   ...props
-  }): JSX.Element {
-
+}): JSX.Element {
   return (
     <TextInput
       small
+      name={name}
       label={props.label}
       error={touched[name] && errors[name]}
       value={value}

--- a/services-js/commissions-app/src/lib/validationSchema.ts
+++ b/services-js/commissions-app/src/lib/validationSchema.ts
@@ -3,18 +3,39 @@ import 'core-js/fn/array/from';
 
 import * as Yup from 'yup';
 
-export const applicationForm = Yup.object().shape({
+export interface ApplyFormValues {
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  streetAddress: string;
+  unit: string;
+  city: string;
+  state: string;
+  zip: string;
+  phone: string;
+  email: string;
+  confirmEmail: string;
+  commissionIds: string[];
+  degreeAttained: string;
+  educationalInstitution: string;
+  otherInformation: string;
+  coverLetter: File | null;
+  resume: File | null;
+}
+
+export const applyFormSchema = Yup.object<ApplyFormValues>({
   firstName: Yup.string().required('First name is required'),
+  middleName: Yup.string(),
   lastName: Yup.string().required('Last name is required'),
   streetAddress: Yup.string().required('Address is required'),
+  unit: Yup.string(),
   city: Yup.string().required('City is required'),
   state: Yup.string().required('State is required'),
   zip: Yup.string()
     .required('Zip code is required')
     .matches(new RegExp(/^\d{5}$/), 'Zip codes should have 5 digits'),
-  phone: Yup.number()
-    .positive()
-    .integer(),
+  // TODO(finh): use phone regexp
+  phone: Yup.string(),
   email: Yup.string()
     .email()
     .required('Email is required'),
@@ -22,11 +43,22 @@ export const applicationForm = Yup.object().shape({
     .email()
     .required('Please enter your email again')
     .oneOf([Yup.ref('email', undefined)], 'Email addresses do not match'),
-  selectedCommissions: Yup.array()
+  // This transform ensures that we cast a single string to an array. Necessary
+  // for when someone only signs up for one commission so the form parser
+  // doesn’t make an array of values.
+  //
+  // We would like to use Yup’s built-in array#ensure but can’t due to:
+  // https://github.com/jquense/yup/issues/343
+  commissionIds: Yup.array(Yup.string())
+    .transform((_, orig) => (orig == null ? [] : [].concat(orig)))
     .max(5, 'Maximum of five selections')
     .required('You must make at least one selection'),
+  degreeAttained: Yup.string(),
+  otherInformation: Yup.string(),
   educationalInstitution: Yup.string().min(
     2,
     'Educational institution needs to be valid'
   ),
+  coverLetter: Yup.mixed(),
+  resume: Yup.mixed(),
 });

--- a/services-js/commissions-app/src/pages/_document.tsx
+++ b/services-js/commissions-app/src/pages/_document.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import { extractCritical } from 'emotion-server';
 
-import { CompatibilityWarning } from '@cityofboston/react-fleet';
+import {
+  CompatibilityWarning,
+  PUBLIC_CSS_URL,
+} from '@cityofboston/react-fleet';
 
 export default class MyDocument extends Document {
   props: any;
@@ -42,6 +45,7 @@ export default class MyDocument extends Document {
             href="/assets/favicon.ico"
             type="image/vnd.microsoft.icon"
           />
+          <link rel="stylesheet" href={PUBLIC_CSS_URL} />
 
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
 

--- a/services-js/commissions-app/src/server/commissions-app.ts
+++ b/services-js/commissions-app/src/server/commissions-app.ts
@@ -35,6 +35,7 @@ import graphqlSchema, { Context } from './graphql/schema';
 import CommissionsDao from './dao/CommissionsDao';
 import CommissionsDaoFake from './dao/CommissionsDaoFake';
 import { ConnectionPool } from 'mssql';
+import { applyFormSchema } from '../lib/validationSchema';
 
 const PATH_PREFIX = '/commissions';
 const dev = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
@@ -157,6 +158,25 @@ export async function makeServer(port, rollbar: Rollbar) {
     method: 'GET',
     path: '/commissions',
     handler: (_, h) => h.redirect('/commissions/apply'),
+  });
+
+  server.route({
+    method: 'POST',
+    path: '/commissions/submit',
+    handler: async (req, h) => {
+      try {
+        const validForm = await applyFormSchema.validate(
+          applyFormSchema.cast(req.payload),
+          // Since we do our own `cast` we can be strict.
+          { strict: true }
+        );
+        console.log(validForm);
+      } catch (e) {
+        console.log(e);
+      }
+
+      return h.response('ok');
+    },
   });
 
   server.route(adminOkRoute);

--- a/services-js/commissions-app/src/stories/ApplyPage.stories.tsx
+++ b/services-js/commissions-app/src/stories/ApplyPage.stories.tsx
@@ -28,5 +28,6 @@ storiesOf('ApplyPage', module).add('default', () => (
         openSeats: 0,
       },
     ]}
+    commissionID="1"
   />
 ));

--- a/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -1,36 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots ApplyPage default 1`] = `
-<div
-  className="mn"
->
-  <div>
-    <a
-      className="btn a11y--h a11y--f"
-      href="#content-start"
-      onClick={[Function]}
-      style={
-        Object {
-          "margin": 4,
-        }
+<div>
+  <a
+    className="btn a11y--h a11y--f"
+    href="#content-start"
+    onClick={[Function]}
+    style={
+      Object {
+        "margin": 4,
       }
-      tabIndex={1}
-    >
-      Jump to content
-    </a>
-    <input
-      aria-label="Open Boston.gov menu"
-      className="brg-tr"
-      id="brg-tr"
-      onKeyDown={[Function]}
-      type="checkbox"
-    />
-    <nav
-      aria-label="Boston.gov menu"
-      className="nv-m"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "
+    }
+    tabIndex={1}
+  >
+    Jump to content
+  </a>
+  <input
+    aria-label="Open Boston.gov menu"
+    className="brg-tr"
+    id="brg-tr"
+    onKeyDown={[Function]}
+    type="checkbox"
+  />
+  <nav
+    aria-label="Boston.gov menu"
+    className="nv-m"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
   <div class=\\"nv-m-h\\">
       <div class=\\"nv-m-h-ic\\">
         <a href=\\"https://www.boston.gov/\\" title=\\"Go to home page\\">
@@ -67,26 +64,26 @@ exports[`Storyshots ApplyPage default 1`] = `
 </ul></li>
 </ul>  </div>
 ",
-        }
       }
-    />
+    }
+  />
+  <div
+    className="mn--full-ie"
+  >
     <div
-      className="mn--full-ie"
+      className="mn mn--full "
     >
-      <div
-        className="mn mn--full "
-      >
-        <input
-          aria-hidden="true"
-          className="s-tr"
-          id="s-tr"
-          type="checkbox"
-        />
-        <header
-          className="h"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "
+      <input
+        aria-hidden="true"
+        className="s-tr"
+        id="s-tr"
+        type="checkbox"
+      />
+      <header
+        className="h"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "
     <label for=\\"brg-tr\\" class=\\"brg-b\\">
   <div class=\\"brg\\">
     <span class=\\"brg-c\\">
@@ -139,16 +136,19 @@ exports[`Storyshots ApplyPage default 1`] = `
   </form>
 </div>
   ",
-            }
           }
-          role="banner"
-        />
+        }
+        role="banner"
+      />
+      <div
+        className="a11y--content-start"
+        id="content-start"
+      />
+      <main
+        className="b-ff"
+      >
         <div
-          className="a11y--content-start"
-          id="content-start"
-        />
-        <main
-          className="b-ff"
+          className="mn"
         >
           <div
             className="b-c b-c--ntp"
@@ -226,6 +226,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         aria-label=""
                         className="txt-f txt-f--sm "
                         id="firstName"
+                        name="firstName"
                         onBlur={[Function]}
                         onChange={[Function]}
                         placeholder="First Name"
@@ -259,6 +260,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         aria-label=""
                         className="txt-f txt-f--sm "
                         id="middleName"
+                        name="middleName"
                         onBlur={[Function]}
                         onChange={[Function]}
                         type="text"
@@ -296,6 +298,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       aria-label=""
                       className="txt-f txt-f--sm "
                       id="lastName"
+                      name="lastName"
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="Last Name"
@@ -338,6 +341,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       aria-label=""
                       className="txt-f txt-f--sm "
                       id="streetAddress"
+                      name="streetAddress"
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="Street Address"
@@ -371,6 +375,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       aria-label=""
                       className="txt-f txt-f--sm "
                       id="unit"
+                      name="unit"
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="Unit or Apartment #"
@@ -412,6 +417,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       aria-label=""
                       className="txt-f txt-f--sm "
                       id="city"
+                      name="city"
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="City"
@@ -453,6 +459,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         aria-label=""
                         className="txt-f txt-f--sm "
                         id="state"
+                        name="state"
                         onBlur={[Function]}
                         onChange={[Function]}
                         placeholder="State"
@@ -491,6 +498,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         aria-label=""
                         className="txt-f txt-f--sm "
                         id="zip"
+                        name="zip"
                         onBlur={[Function]}
                         onChange={[Function]}
                         placeholder="Zip Code"
@@ -526,6 +534,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     aria-label=""
                     className="txt-f txt-f--sm "
                     id="phone"
+                    name="phone"
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Phone Number"
@@ -563,6 +572,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     aria-label=""
                     className="txt-f txt-f--sm "
                     id="email"
+                    name="email"
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Email"
@@ -601,6 +611,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     aria-label=""
                     className="txt-f txt-f--sm "
                     id="confirmEmail"
+                    name="confirmEmail"
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Confirm Email"
@@ -648,6 +659,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     aria-label=""
                     className="txt-f txt-f--sm "
                     id="degreeAttained"
+                    name="degreeAttained"
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Degree Attained"
@@ -680,6 +692,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     aria-label=""
                     className="txt-f txt-f--sm "
                     id="educationalInstitution"
+                    name="educationalInstitution"
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Educational Institution"
@@ -784,8 +797,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <input
                           checked={false}
                           className="cb-f"
-                          name="commissionIds-openSeats"
-                          onBlur={[Function]}
+                          name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
                           value="0"
@@ -809,10 +821,9 @@ exports[`Storyshots ApplyPage default 1`] = `
                         className="cb "
                       >
                         <input
-                          checked={false}
+                          checked={true}
                           className="cb-f"
-                          name="commissionIds-openSeats"
-                          onBlur={[Function]}
+                          name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
                           value="1"
@@ -838,8 +849,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <input
                           checked={false}
                           className="cb-f"
-                          name="commissionIds-openSeats"
-                          onBlur={[Function]}
+                          name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
                           value="2"
@@ -905,8 +915,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <input
                           checked={false}
                           className="cb-f"
-                          name="commissionIds-noSeats"
-                          onBlur={[Function]}
+                          name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
                           value="3"
@@ -1050,20 +1059,22 @@ exports[`Storyshots ApplyPage default 1`] = `
               </p>
               <button
                 className="btn btn--700"
+                disabled={true}
                 type="submit"
               >
                 Submit Application
               </button>
             </form>
           </div>
-        </main>
-      </div>
+        </div>
+      </main>
     </div>
-    <footer
-      className="ft"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "
+  </div>
+  <footer
+    className="ft"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
     <div class=\\"ft-c\\">
       <ul class=\\"ft-ll ft-ll--r\\">
         <li class=\\"ft-ll-i\\"><a href=\\"http://www.cityofboston.gov/311/\\" class=\\"ft-ll-a lnk--yellow\\"><span class=\\"ft-ll-311\\">BOS:311</span><span class=\\"tablet--hidden\\"> - </span>Report an issue</a></li>
@@ -1076,15 +1087,14 @@ exports[`Storyshots ApplyPage default 1`] = `
 <li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/public-records\\" title=\\"\\" class=\\"ft-ll-a\\">Public records requests</a></li>
 </ul>    </div>
   ",
-        }
       }
-      style={
-        Object {
-          "position": "relative",
-          "zIndex": 2,
-        }
+    }
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 2,
       }
-    />
-  </div>
+    }
+  />
 </div>
 `;


### PR DESCRIPTION
Moves things around so that form validation can be done on both client-
and server- side. Also changes to support POSTing a FormData object with
fetch so that we can get file uploads.

 - Moves form values interface into validationSchema.ts
 - Changes selection to be by commission ID, not commission object
 - Switches to HTML <form> element so we can get a ref for it for
   creating a FormData
 - Adds "name" attribute to checkboxes and other fields so that they
   show up in FormData
 - Removes touch / blur handling from checkboxes because it seems to
   break FieldArray by overwriting its array value with a boolean
 - Adds all fields to the application form schema and uses the
   ApplyFormValues interface to strongly type it

Also:
 - Tweaks apply page to put <div class="mn"> inside the <AppLayout> and
   moves the stylesheet to _document
 - Adds a <title> element to the form page
 - Changes the ApplyPage stories to exercise pre-checking a commission