### PR TITLE
passes “required” prop down for native <input> elements

### DIFF
--- a/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
@@ -66,7 +66,7 @@ const DEFAULT_PROPS: Props = {
   isSubmitting: false,
   isValid: false,
   submissionError: false,
-  clearSubmissionError: action('clearSubmissionErro'),
+  clearSubmissionError: action('clearSubmissionError'),
 };
 
 storiesOf('ApplicationForm', module)
@@ -79,6 +79,7 @@ storiesOf('ApplicationForm', module)
         firstName: 'First name is required',
         lastName: 'Last name is required',
       }}
+      // @ts-ignore
       touched={{ firstName: true, lastName: true }}
     />
   ))

--- a/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
@@ -79,7 +79,6 @@ storiesOf('ApplicationForm', module)
         firstName: 'First name is required',
         lastName: 'Last name is required',
       }}
-      // @ts-ignore
       touched={{ firstName: true, lastName: true }}
     />
   ))

--- a/services-js/commissions-app/src/client/ApplicationForm.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.tsx
@@ -63,7 +63,7 @@ export default function ApplicationForm(props: Props): JSX.Element {
     clearSubmissionError,
   } = props;
 
-  const Field = ({ name, label, placeholder }: FieldProps) => (
+  const Field = ({ name, label, placeholder, required }: FieldProps) => (
     <TextInput
       small
       name={name}
@@ -74,6 +74,7 @@ export default function ApplicationForm(props: Props): JSX.Element {
       id={`ApplicationForm-${name}`}
       onBlur={handleBlur}
       onChange={handleChange}
+      required={required}
     />
   );
 

--- a/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -55,6 +55,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
               >
                 First Name
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -64,6 +69,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="First Name"
+              required={true}
               type="text"
               value=""
             />
@@ -121,6 +127,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
             >
               Last Name
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -130,6 +141,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Last Name"
+            required={true}
             type="text"
             value=""
           />
@@ -158,6 +170,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
             >
               Street Address
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -167,6 +184,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Street Address"
+            required={true}
             type="text"
             value=""
           />
@@ -228,6 +246,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
             >
               City
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -237,6 +260,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="City"
+            required={true}
             type="text"
             value=""
           />
@@ -264,6 +288,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
               >
                 State
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -273,6 +302,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="State"
+              required={true}
               type="text"
               value=""
             />
@@ -297,6 +327,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
               >
                 Zip
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -306,6 +341,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="Zip Code"
+              required={true}
               type="text"
               value=""
             />
@@ -365,6 +401,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
           >
             Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -374,6 +415,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Email"
+          required={true}
           type="text"
           value=""
         />
@@ -398,6 +440,11 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
           >
             Confirm Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -407,6 +454,7 @@ exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Confirm Email"
+          required={true}
           type="text"
           value=""
         />
@@ -895,6 +943,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               >
                 First Name
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -904,6 +957,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="First Name"
+              required={true}
               type="text"
               value=""
             />
@@ -961,6 +1015,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               Last Name
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -970,6 +1029,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Last Name"
+            required={true}
             type="text"
             value=""
           />
@@ -998,6 +1058,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               Street Address
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -1007,6 +1072,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Street Address"
+            required={true}
             type="text"
             value=""
           />
@@ -1068,6 +1134,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               City
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -1077,6 +1148,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="City"
+            required={true}
             type="text"
             value=""
           />
@@ -1104,6 +1176,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               >
                 State
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -1113,6 +1190,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="State"
+              required={true}
               type="text"
               value=""
             />
@@ -1137,6 +1215,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               >
                 Zip
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -1146,6 +1229,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="Zip Code"
+              required={true}
               type="text"
               value=""
             />
@@ -1205,6 +1289,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           >
             Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -1214,6 +1303,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Email"
+          required={true}
           type="text"
           value=""
         />
@@ -1238,6 +1328,11 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           >
             Confirm Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -1247,6 +1342,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Confirm Email"
+          required={true}
           type="text"
           value=""
         />
@@ -1735,6 +1831,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               >
                 First Name
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -1744,6 +1845,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="First Name"
+              required={true}
               type="text"
               value=""
             />
@@ -1801,6 +1903,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               Last Name
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -1810,6 +1917,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Last Name"
+            required={true}
             type="text"
             value=""
           />
@@ -1838,6 +1946,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               Street Address
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -1847,6 +1960,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Street Address"
+            required={true}
             type="text"
             value=""
           />
@@ -1908,6 +2022,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               City
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -1917,6 +2036,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="City"
+            required={true}
             type="text"
             value=""
           />
@@ -1944,6 +2064,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               >
                 State
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -1953,6 +2078,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="State"
+              required={true}
               type="text"
               value=""
             />
@@ -1977,6 +2103,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               >
                 Zip
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -1986,6 +2117,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="Zip Code"
+              required={true}
               type="text"
               value=""
             />
@@ -2045,6 +2177,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           >
             Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -2054,6 +2191,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Email"
+          required={true}
           type="text"
           value=""
         />
@@ -2078,6 +2216,11 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           >
             Confirm Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -2087,6 +2230,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Confirm Email"
+          required={true}
           type="text"
           value=""
         />
@@ -2575,6 +2719,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               >
                 First Name
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -2584,6 +2733,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="First Name"
+              required={true}
               type="text"
               value="Gwen"
             />
@@ -2641,6 +2791,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               Last Name
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -2650,6 +2805,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Last Name"
+            required={true}
             type="text"
             value="Stacy"
           />
@@ -2678,6 +2834,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               Street Address
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -2687,6 +2848,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Street Address"
+            required={true}
             type="text"
             value="123 Fake St."
           />
@@ -2748,6 +2910,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               City
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -2757,6 +2924,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="City"
+            required={true}
             type="text"
             value="New York"
           />
@@ -2784,6 +2952,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               >
                 State
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -2793,6 +2966,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="State"
+              required={true}
               type="text"
               value="NY"
             />
@@ -2817,6 +2991,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               >
                 Zip
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -2826,6 +3005,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="Zip Code"
+              required={true}
               type="text"
               value="01110"
             />
@@ -2885,6 +3065,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           >
             Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -2894,6 +3079,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Email"
+          required={true}
           type="text"
           value="ghosty@spiders.net"
         />
@@ -2918,6 +3104,11 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           >
             Confirm Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -2927,6 +3118,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Confirm Email"
+          required={true}
           type="text"
           value="ghosty@spiders.net"
         />
@@ -3415,6 +3607,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               >
                 First Name
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -3424,6 +3621,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="First Name"
+              required={true}
               type="text"
               value=""
             />
@@ -3481,6 +3679,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               Last Name
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -3490,6 +3693,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Last Name"
+            required={true}
             type="text"
             value=""
           />
@@ -3518,6 +3722,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               Street Address
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -3527,6 +3736,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Street Address"
+            required={true}
             type="text"
             value=""
           />
@@ -3588,6 +3798,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               City
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -3597,6 +3812,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="City"
+            required={true}
             type="text"
             value=""
           />
@@ -3624,6 +3840,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               >
                 State
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -3633,6 +3854,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="State"
+              required={true}
               type="text"
               value=""
             />
@@ -3657,6 +3879,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               >
                 Zip
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -3666,6 +3893,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="Zip Code"
+              required={true}
               type="text"
               value=""
             />
@@ -3725,6 +3953,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           >
             Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -3734,6 +3967,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Email"
+          required={true}
           type="text"
           value=""
         />
@@ -3758,6 +3992,11 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           >
             Confirm Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -3767,6 +4006,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Confirm Email"
+          required={true}
           type="text"
           value=""
         />
@@ -4299,6 +4539,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               >
                 First Name
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -4308,6 +4553,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="First Name"
+              required={true}
               type="text"
               value=""
             />
@@ -4365,6 +4611,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               Last Name
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -4374,6 +4625,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Last Name"
+            required={true}
             type="text"
             value=""
           />
@@ -4402,6 +4654,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               Street Address
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -4411,6 +4668,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="Street Address"
+            required={true}
             type="text"
             value=""
           />
@@ -4472,6 +4730,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               City
             </span>
+            <span
+              className="t--req"
+            >
+              Required
+            </span>
           </label>
           <input
             aria-label=""
@@ -4481,6 +4744,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             placeholder="City"
+            required={true}
             type="text"
             value=""
           />
@@ -4508,6 +4772,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               >
                 State
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -4517,6 +4786,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="State"
+              required={true}
               type="text"
               value=""
             />
@@ -4541,6 +4811,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               >
                 Zip
               </span>
+              <span
+                className="t--req"
+              >
+                Required
+              </span>
             </label>
             <input
               aria-label=""
@@ -4550,6 +4825,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               placeholder="Zip Code"
+              required={true}
               type="text"
               value=""
             />
@@ -4609,6 +4885,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           >
             Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -4618,6 +4899,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Email"
+          required={true}
           type="text"
           value=""
         />
@@ -4642,6 +4924,11 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           >
             Confirm Email
           </span>
+          <span
+            className="t--req"
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
@@ -4651,6 +4938,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           placeholder="Confirm Email"
+          required={true}
           type="text"
           value=""
         />
@@ -5314,6 +5602,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                         >
                           First Name
                         </span>
+                        <span
+                          className="t--req"
+                        >
+                          Required
+                        </span>
                       </label>
                       <input
                         aria-label=""
@@ -5323,6 +5616,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         onBlur={[Function]}
                         onChange={[Function]}
                         placeholder="First Name"
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -5380,6 +5674,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         Last Name
                       </span>
+                      <span
+                        className="t--req"
+                      >
+                        Required
+                      </span>
                     </label>
                     <input
                       aria-label=""
@@ -5389,6 +5688,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="Last Name"
+                      required={true}
                       type="text"
                       value=""
                     />
@@ -5417,6 +5717,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         Street Address
                       </span>
+                      <span
+                        className="t--req"
+                      >
+                        Required
+                      </span>
                     </label>
                     <input
                       aria-label=""
@@ -5426,6 +5731,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="Street Address"
+                      required={true}
                       type="text"
                       value=""
                     />
@@ -5487,6 +5793,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         City
                       </span>
+                      <span
+                        className="t--req"
+                      >
+                        Required
+                      </span>
                     </label>
                     <input
                       aria-label=""
@@ -5496,6 +5807,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       onBlur={[Function]}
                       onChange={[Function]}
                       placeholder="City"
+                      required={true}
                       type="text"
                       value=""
                     />
@@ -5523,6 +5835,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                         >
                           State
                         </span>
+                        <span
+                          className="t--req"
+                        >
+                          Required
+                        </span>
                       </label>
                       <input
                         aria-label=""
@@ -5532,6 +5849,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         onBlur={[Function]}
                         onChange={[Function]}
                         placeholder="State"
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -5556,6 +5874,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                         >
                           Zip
                         </span>
+                        <span
+                          className="t--req"
+                        >
+                          Required
+                        </span>
                       </label>
                       <input
                         aria-label=""
@@ -5565,6 +5888,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                         onBlur={[Function]}
                         onChange={[Function]}
                         placeholder="Zip Code"
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -5624,6 +5948,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                     >
                       Email
                     </span>
+                    <span
+                      className="t--req"
+                    >
+                      Required
+                    </span>
                   </label>
                   <input
                     aria-label=""
@@ -5633,6 +5962,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Email"
+                    required={true}
                     type="text"
                     value=""
                   />
@@ -5657,6 +5987,11 @@ exports[`Storyshots ApplyPage default 1`] = `
                     >
                       Confirm Email
                     </span>
+                    <span
+                      className="t--req"
+                    >
+                      Required
+                    </span>
                   </label>
                   <input
                     aria-label=""
@@ -5666,6 +6001,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                     onBlur={[Function]}
                     onChange={[Function]}
                     placeholder="Confirm Email"
+                    required={true}
                     type="text"
                     value=""
                   />


### PR DESCRIPTION
The red ”Required” indicator in the text field labels will appear if the `<input>` element has the `required` attribute present; this change passes it down from the `<Field>` component onto the native element.

 I added the `@ts-ignore` in the Story because Typescript was complaining to me irt the `touched` values. ¯\_(ツ)_/¯