### PR TITLE
Commissions list design update

### DIFF
--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -694,7 +694,7 @@ exports[`Storyshots Form Elements/Inputs Checkbox 1`] = `
 >
   <input
     checked={true}
-    className="cb-f"
+    className="cb-f "
     name="checkbox"
     onBlur={[Function]}
     onChange={[Function]}

--- a/modules-js/react-fleet/src/form-elements/inputs/Checkbox.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/Checkbox.tsx
@@ -6,7 +6,7 @@ interface Props {
   onChange: any;
   onBlur?: any;
   required?: boolean;
-  error?: string;
+  error?: boolean | string | Object;
   value?: string;
   checked?: boolean;
   style?: object;
@@ -21,7 +21,7 @@ export default function Checkbox(props: Props): JSX.Element {
         value={props.value}
         required={props.required}
         type="checkbox"
-        className="cb-f"
+        className={`cb-f ${props.error ? 'cb-f--err' : ''}`}
         onChange={props.onChange}
         onBlur={props.onBlur}
         checked={props.checked}

--- a/services-js/commissions-app/package.json
+++ b/services-js/commissions-app/package.json
@@ -10,7 +10,7 @@
     "build:server": "tsc -p tsconfig.server.json",
     "build:next": "next build src",
     "dev": "npm run prebuild && tsc-watch -p tsconfig.server.json --onSuccess \"npm run start\"",
-    "storybook": "start-storybook -p 9001",
+    "storybook": "start-storybook -p 9001 -s static",
     "watch-dependencies": "lerna run --parallel --scope commissions-app --include-filtered-dependencies watch",
     "prepare": "npm run build",
     "prepare-deploy": "build-storybook -s static",

--- a/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
@@ -8,35 +8,31 @@ const COMMISSIONS = [
     name: 'Aberdeen Architectural Conservation District Commission',
     id: 0,
     openSeats: 2,
+    homepageUrl: 'http://',
   },
   {
     name:
       'Back Bay West/Bay State Road Architectural Conservation District Commission',
     id: 1,
     openSeats: 1,
+    homepageUrl: 'http://',
   },
   {
     name: 'Living Wage Advisory Committee',
     id: 2,
     openSeats: 1,
+    homepageUrl: 'http://',
   },
   {
     name: 'Licensing Board for the City of Boston',
     id: 3,
     openSeats: 0,
+    homepageUrl: 'http://',
   },
 ];
 
-const COMMISSIONS_WITH_OPEN_SEATS = COMMISSIONS.filter(
-  ({ openSeats }) => openSeats > 0
-);
-const COMMISSIONS_WITHOUT_OPEN_SEATS = COMMISSIONS.filter(
-  ({ openSeats }) => openSeats === 0
-);
-
 const DEFAULT_PROPS: Props = {
-  commissionsWithOpenSeats: COMMISSIONS_WITH_OPEN_SEATS,
-  commissionsWithoutOpenSeats: COMMISSIONS_WITHOUT_OPEN_SEATS,
+  commissions: COMMISSIONS,
   formRef: React.createRef(),
   values: {
     firstName: '',
@@ -105,12 +101,6 @@ storiesOf('ApplicationForm', module)
         coverLetter: {} as any,
         resume: {} as any,
       }}
-    />
-  ))
-  .add('auto-expand no open seats', () => (
-    <ApplicationForm
-      {...DEFAULT_PROPS}
-      values={{ ...DEFAULT_PROPS.values, commissionIds: ['3'] }}
     />
   ))
   .add('submitting', () => <ApplicationForm {...DEFAULT_PROPS} isSubmitting />)

--- a/services-js/commissions-app/src/client/ApplicationForm.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.tsx
@@ -15,6 +15,7 @@ import {
 
 import ApplicantInformationSection from './ApplicantInformationSection';
 import CommissionsListSection from './CommissionsListSection';
+import { PARAGRAPH_STYLING } from './common/style-common';
 
 type RequiredFormikProps = Pick<
   FormikProps<ApplyFormValues>,
@@ -30,8 +31,7 @@ type RequiredFormikProps = Pick<
 >;
 
 export interface Props extends RequiredFormikProps {
-  commissionsWithOpenSeats: Commission[];
-  commissionsWithoutOpenSeats: Commission[];
+  commissions: Commission[];
   formRef: React.RefObject<HTMLFormElement>;
   submissionError?: boolean;
   clearSubmissionError: () => void;
@@ -43,8 +43,6 @@ export interface FieldProps {
   placeholder?: string;
   required?: boolean;
 }
-
-const PARAGRAPH_STYLING = 't--s400 lh--400';
 
 // todo: https://github.com/CityOfBoston/digital/pull/97/files#r224776915
 
@@ -127,17 +125,9 @@ export default function ApplicationForm(props: Props): JSX.Element {
       <hr className="hr hr--sq" />
 
       <CommissionsListSection
-        commissionsWithOpenSeats={props.commissionsWithOpenSeats}
-        commissionsWithoutOpenSeats={props.commissionsWithoutOpenSeats}
+        commissions={props.commissions}
         selectedCommissionIds={values.commissionIds}
-        errors={errors}
-        paragraphElement={
-          <p className={PARAGRAPH_STYLING}>
-            You can apply for a board or commission that does not currently have
-            any open positions, and we will review your application when a seat
-            opens.
-          </p>
-        }
+        setSelectedIds={ids => setFieldValue('commissionIds', ids)}
       />
 
       <hr className="hr hr--sq" />

--- a/services-js/commissions-app/src/client/CommissionsListSection.stories.tsx
+++ b/services-js/commissions-app/src/client/CommissionsListSection.stories.tsx
@@ -1,0 +1,428 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import CommissionsListSection, { Props } from './CommissionsListSection';
+import { action } from '@storybook/addon-actions';
+
+const COMMISSIONS = [
+  {
+    name: 'Trustees of Charitable Donations for Inhabitants of Boston',
+    id: 1,
+    openSeats: 12,
+    homepageUrl:
+      'https://www.boston.gov/departments/treasury/trustees-charitable-donations-inhabitants-boston',
+  },
+  {
+    name: 'Boston School Committee Nominating Panel',
+    id: 2,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/schools/Boston-School-Committee-Nominating-Panel',
+  },
+  {
+    name: 'Boston School Committee',
+    id: 4,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/schools/Boston-School-Committee',
+  },
+  {
+    name: 'Neighborhood Housing Trust Fund',
+    id: 7,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/treasury/Neighborhood-Housing-Trust-Fund',
+  },
+  {
+    name: 'City of Boston School Trust Fund',
+    id: 10,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/schools/city-boston-school-trust-fund',
+  },
+  {
+    name: 'George Robert White Fund',
+    id: 11,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/treasury/George-Robert-White-Fund',
+  },
+  {
+    name: 'Fund for Parks & Recreation in Boston',
+    id: 13,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/parks-and-recreation/fund-parks-and-recreation-boston',
+  },
+  {
+    name: 'Resident Advisory Board',
+    id: 15,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/housing-authority/Resident-Advisory-Board',
+  },
+  {
+    name: 'Boston Cultural Council',
+    id: 16,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/arts-and-culture/Boston-Cultural-Council',
+  },
+  {
+    name: 'Neighborhood Jobs Trust',
+    id: 18,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/economic-development/Neighborhood-Jobs-Trust',
+  },
+  {
+    name: 'Zoning Commission',
+    id: 21,
+    openSeats: 4,
+    homepageUrl:
+      'https://www.boston.gov/departments/planning-development-agency/Zoning-Commission',
+  },
+  {
+    name: 'Boston Fair Housing Commission',
+    id: 25,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/fair-housing-and-equity/Boston-Fair-Housing-Commission',
+  },
+  {
+    name: 'Boston Compensation Advisory Board',
+    id: 28,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/licensing-board/Boston-Compensation-Advisory-Board',
+  },
+  {
+    name: 'Mass. Water Resources Authority',
+    id: 31,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/environment/mass-water-resources-authority',
+  },
+  {
+    name: 'Board of Review--Assessing',
+    id: 32,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/assessing/board-review-assessing',
+  },
+  {
+    name: 'Air Pollution Control Commission',
+    id: 34,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/environment/Air-Pollution-Control-Commission',
+  },
+  {
+    name: 'Archives and Records Advisory Commission',
+    id: 35,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/archives-and-records-management',
+  },
+  {
+    name: 'Boston Art Commission',
+    id: 36,
+    openSeats: 2,
+    homepageUrl:
+      'https://www.boston.gov/departments/arts-and-culture/Boston-Art-Commission',
+  },
+  {
+    name: 'Audit Committee of the City of Boston',
+    id: 37,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/auditing/audit-committee-city-boston',
+  },
+  {
+    name: 'Back Bay Architectural Commission',
+    id: 38,
+    openSeats: 7,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/back-bay-architectural-district',
+  },
+  {
+    name:
+      'Back Bay West/Bay State Road Architectural Conservation District Commission',
+    id: 39,
+    openSeats: 5,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/bay-state-roadback-bay-west-area-architectural-conservation-district',
+  },
+  {
+    name: 'Bay Village Historic District Commission',
+    id: 40,
+    openSeats: 4,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/bay-village-historic-district',
+  },
+  {
+    name: 'Beacon Hill Architectural Commission',
+    id: 41,
+    openSeats: 8,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/historic-beacon-hill-district',
+  },
+  {
+    name: 'Board of Examiners',
+    id: 42,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/inspectional-services/board-examiners',
+  },
+  {
+    name: 'Boston Employment Commission',
+    id: 43,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/small-business-development/boston-employment-commission',
+  },
+  {
+    name: 'Boston Housing Authority Monitoring Committee',
+    id: 44,
+    openSeats: 9,
+    homepageUrl:
+      'https://www.boston.gov/departments/housing-authority/Boston-Housing-Authority-Monitoring-Committee',
+  },
+  {
+    name: 'Boston Industrial Development Financing Authority',
+    id: 45,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/planning-development-agency/Boston-Industrial-Development-Financing-Authority',
+  },
+  {
+    name: 'Boston Public Health Commission',
+    id: 46,
+    openSeats: 1,
+    homepageUrl: 'https://www.boston.gov/departments/public-health-commission',
+  },
+  {
+    name: 'Boston Public Library Board of Trustees',
+    id: 47,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/library/boston-public-library-board-trustees',
+  },
+  {
+    name:
+      'Boston Redevelopment Authority (BRA)/Economic Development Industrial Corp (EDIC)',
+    id: 48,
+    openSeats: 2,
+    homepageUrl:
+      'https://www.boston.gov/departments/planning-development-agency',
+  },
+  {
+    name: 'Edward Ingersoll Browne Trust Fund',
+    id: 51,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/treasury/Edward-Ingersoll-Browne-Trust-Fund',
+  },
+  {
+    name: 'Boston Elections Commission',
+    id: 52,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/election/Boston-Elections-Commission',
+  },
+  {
+    name: 'Freedom Trail Commission',
+    id: 53,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/public-works/Freedom-Trail-Commission',
+  },
+  {
+    name: 'Parks & Recreation Commission',
+    id: 55,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/parks-and-recreation/Parks-and-Recreation-Commission',
+  },
+  {
+    name: 'Public Improvement Commission',
+    id: 56,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/public-works/Public-Improvement-Commission',
+  },
+  {
+    name: 'Licensing Board for the City of Boston',
+    id: 59,
+    openSeats: 0,
+    homepageUrl: 'https://www.boston.gov/departments/licensing-board',
+  },
+  {
+    name: 'Boston Conservation Commission',
+    id: 60,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/environment/conservation-commission',
+  },
+  {
+    name: 'Boston Water and Sewer Commission',
+    id: 64,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/water-and-sewer-commission',
+  },
+  {
+    name: 'Boston Landmarks Commission',
+    id: 65,
+    openSeats: 10,
+    homepageUrl: 'https://www.boston.gov/departments/landmarks-commission',
+  },
+  {
+    name:
+      'Mission Hill Triangle Architectural Conservation District Commission',
+    id: 66,
+    openSeats: 7,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/mission-hill-triangle',
+  },
+  {
+    name: 'South End Landmark District Commission',
+    id: 67,
+    openSeats: 7,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/south-end-landmark-district',
+  },
+  {
+    name: 'St. Botolph Architectural Conservation District Commission',
+    id: 68,
+    openSeats: 5,
+    homepageUrl: 'https://www.boston.gov/historic-district/saint-botolph',
+  },
+  {
+    name: 'Boston Civic Design Commission',
+    id: 69,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/planning-development-agency/Boston-Civic-Design-Commission',
+  },
+  {
+    name: 'Fund for Boston Neighborhoods, Inc.',
+    id: 84,
+    openSeats: 5,
+    homepageUrl:
+      'https://www.boston.gov/departments/tourism-sports-and-entertainment/fund-boston-neighborhoods-inc',
+  },
+  {
+    name: 'Public Facilities Commission',
+    id: 85,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/public-facilities/Public-Facilities-Commission',
+  },
+  {
+    name: 'Residency Compliance Commission',
+    id: 86,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/property-management/Residency-Compliance-Commission',
+  },
+  {
+    name: 'City of Boston Scholarship Fund',
+    id: 87,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/schools/city-boston-scholarship-fund',
+  },
+  {
+    name: 'Boston Groundwater Trust',
+    id: 157,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/environment/Boston-Groundwater-Trust',
+  },
+  {
+    name: 'Fort Point Channel Landmark District Commission',
+    id: 162,
+    openSeats: 6,
+    homepageUrl: 'https://www.boston.gov/historic-district/fort-point-channel',
+  },
+  {
+    name: 'Boston Disability Advisory Commission',
+    id: 165,
+    openSeats: 0,
+    homepageUrl:
+      'https://www.boston.gov/departments/disabilities-commission/disability-commission-advisory-board',
+  },
+  {
+    name: 'Aberdeen Architectural Conservation District Commission',
+    id: 170,
+    openSeats: 7,
+    homepageUrl:
+      'https://www.boston.gov/historic-district/aberdeen-architectural-conservation-district',
+  },
+  {
+    name: 'Boston Retirement Board',
+    id: 171,
+    openSeats: 0,
+    homepageUrl: 'https://www.boston.gov/departments/retirement',
+  },
+  {
+    name: 'Zoning Board of Appeals',
+    id: 180,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/inspectional-services/zoning-board-appeal',
+  },
+  {
+    name: 'Trustee of the Copley Square Charitable Trust',
+    id: 209,
+    openSeats: 0,
+    homepageUrl: null,
+  },
+  {
+    name: 'Off-Street Parking Facilities Board',
+    id: 210,
+    openSeats: 3,
+    homepageUrl:
+      'https://www.boston.gov/departments/transportation/Off-Street-Parking-Facilities-Board',
+  },
+  {
+    name: 'Living Wage Advisory Committee',
+    id: 211,
+    openSeats: 1,
+    homepageUrl:
+      'https://www.boston.gov/departments/labor-relations/living-wage-advisory-committee',
+  },
+  {
+    name: 'Animal Control Commission',
+    id: 212,
+    openSeats: 9,
+    homepageUrl:
+      'https://www.boston.gov/departments/inspectional-services/animal-control-commission',
+  },
+  {
+    name: 'Community Preservation Committee',
+    id: 214,
+    openSeats: 0,
+    homepageUrl: 'https://www.boston.gov/community-preservation',
+  },
+];
+
+const DEFAULT_PROPS: Props = {
+  commissions: COMMISSIONS,
+  selectedCommissionIds: ['2'],
+  setSelectedIds: action('setSelected'),
+};
+
+storiesOf('CommissionsListSection', module)
+  .addDecorator(story => <div className="b-c">{story()}</div>)
+  .add('default', () => <CommissionsListSection {...DEFAULT_PROPS} />)
+  .add('too many checked', () => (
+    <CommissionsListSection
+      {...DEFAULT_PROPS}
+      selectedCommissionIds={['1', '2', '4', '7', '10', '171']}
+      testExpanded
+    />
+  ))
+  .add('no initial selections', () => (
+    <CommissionsListSection {...DEFAULT_PROPS} selectedCommissionIds={[]} />
+  ));

--- a/services-js/commissions-app/src/client/common/style-common.ts
+++ b/services-js/commissions-app/src/client/common/style-common.ts
@@ -1,0 +1,1 @@
+export const PARAGRAPH_STYLING = 't--s400 lh--400';

--- a/services-js/commissions-app/src/client/graphql/fetch-commissions.ts
+++ b/services-js/commissions-app/src/client/graphql/fetch-commissions.ts
@@ -7,6 +7,7 @@ const QUERY = gql`
       id
       name
       openSeats
+      homepageUrl
     }
   }
 `;

--- a/services-js/commissions-app/src/client/graphql/queries.d.ts
+++ b/services-js/commissions-app/src/client/graphql/queries.d.ts
@@ -9,6 +9,7 @@ export interface FetchCommissions_commissions {
   id: number;
   name: string;
   openSeats: number;
+  homepageUrl: string | null;
 }
 
 export interface FetchCommissions {

--- a/services-js/commissions-app/src/pages/_document.tsx
+++ b/services-js/commissions-app/src/pages/_document.tsx
@@ -42,7 +42,7 @@ export default class MyDocument extends Document {
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link
             rel="shortcut icon"
-            href="/assets/favicon.ico"
+            href="/commissions/assets/favicon.ico"
             type="image/vnd.microsoft.icon"
           />
           <link rel="stylesheet" href={PUBLIC_CSS_URL} />

--- a/services-js/commissions-app/src/pages/commissions/apply.tsx
+++ b/services-js/commissions-app/src/pages/commissions/apply.tsx
@@ -44,6 +44,7 @@ export default class ApplyPage extends React.Component<Props, State> {
     query: { commissionID },
   }: NextContext<IncomingMessage>): Promise<Props> {
     const commissions = await fetchCommissions();
+    commissions.sort((current, next) => current.name.localeCompare(next.name));
 
     return { commissions, commissionID };
   }
@@ -106,14 +107,6 @@ export default class ApplyPage extends React.Component<Props, State> {
       resume: null,
     };
 
-    const commissionsWithoutOpenSeats = commissions
-      .filter(commission => commission.openSeats === 0)
-      .sort((current, next) => current.name.localeCompare(next.name));
-
-    const commissionsWithOpenSeats = commissions
-      .filter(commission => commission.openSeats > 0)
-      .sort((current, next) => current.name.localeCompare(next.name));
-
     return (
       <AppLayout>
         <Head>
@@ -140,8 +133,7 @@ export default class ApplyPage extends React.Component<Props, State> {
                 render={formikProps => (
                   <ApplicationForm
                     {...formikProps}
-                    commissionsWithOpenSeats={commissionsWithOpenSeats}
-                    commissionsWithoutOpenSeats={commissionsWithoutOpenSeats}
+                    commissions={commissions}
                     formRef={this.formRef}
                     submissionError={this.state.submissionError}
                     clearSubmissionError={() =>

--- a/services-js/commissions-app/src/server/commissions-app.ts
+++ b/services-js/commissions-app/src/server/commissions-app.ts
@@ -189,7 +189,7 @@ export async function makeServer(port, rollbar: Rollbar) {
   });
 
   server.route(adminOkRoute);
-  server.route(makeStaticAssetRoutes());
+  server.route(makeStaticAssetRoutes('/commissions/'));
 
   if (nextApp) {
     server.route(makeRoutesForNextApp(nextApp, '/commissions/'));

--- a/services-js/commissions-app/src/stories/ApplyPage.stories.tsx
+++ b/services-js/commissions-app/src/stories/ApplyPage.stories.tsx
@@ -11,22 +11,26 @@ storiesOf('ApplyPage', module)
           name: 'Aberdeen Architectural Conservation District Commission',
           id: 0,
           openSeats: 2,
+          homepageUrl: 'http://',
         },
         {
           name:
             'Back Bay West/Bay State Road Architectural Conservation District Commission',
           id: 1,
           openSeats: 1,
+          homepageUrl: 'http://',
         },
         {
           name: 'Living Wage Advisory Committee',
           id: 2,
           openSeats: 1,
+          homepageUrl: 'http://',
         },
         {
           name: 'Licensing Board for the City of Boston',
           id: 3,
           openSeats: 0,
+          homepageUrl: 'http://',
         },
       ]}
       commissionID="1"

--- a/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -1,893 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots ApplicationForm auto-expand no open seats 1`] = `
-<div
-  className="b-c"
->
-  <form
-    onSubmit={[Function]}
-  >
-    <h1
-      className="sh-title"
-    >
-      Boards and Commissions Application Form
-    </h1>
-    <p
-      className="t--s400 lh--400"
-    >
-      Please note that many of these Boards and Commissions require City of Boston residency as well as specific qualifications for members. Please familiarize yourself with each board or commissions’s enabling legislation. If you have any questions, email
-       
-      <a
-        href="mailto:boardsandcommissions@boston.gov"
-      >
-        boardsandcommissions@boston.gov
-      </a>
-      .
-    </p>
-    <section>
-      <div
-        className="sh m-b300 "
-      >
-        <h2
-          className="sh-title"
-        >
-          Applicant Information
-        </h2>
-      </div>
-      <div
-        className="css-pefnot"
-      >
-        <div
-          className="css-c3kz39"
-        >
-          <div>
-            <label
-              className="txt-l txt-l--sm"
-              htmlFor="ApplicationForm-firstName"
-            >
-              <span
-                style={
-                  Object {
-                    "marginRight": "0.5em",
-                    "whiteSpace": "nowrap",
-                  }
-                }
-              >
-                First Name
-              </span>
-              <span
-                className="t--req"
-              >
-                Required
-              </span>
-            </label>
-            <input
-              aria-label=""
-              className="txt-f txt-f--sm "
-              id="ApplicationForm-firstName"
-              name="firstName"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="First Name"
-              required={true}
-              type="text"
-              value=""
-            />
-            <div
-              className="t--subinfo t--err m-b100"
-            >
-               
-            </div>
-          </div>
-          <div>
-            <label
-              className="txt-l txt-l--sm"
-              htmlFor="ApplicationForm-middleName"
-            >
-              <span
-                style={
-                  Object {
-                    "marginRight": "0.5em",
-                    "whiteSpace": "nowrap",
-                  }
-                }
-              >
-                Initial
-              </span>
-            </label>
-            <input
-              aria-label=""
-              className="txt-f txt-f--sm "
-              id="ApplicationForm-middleName"
-              name="middleName"
-              onBlur={[Function]}
-              onChange={[Function]}
-              type="text"
-              value=""
-            />
-            <div
-              className="t--subinfo t--err m-b100"
-            >
-               
-            </div>
-          </div>
-        </div>
-        <div>
-          <label
-            className="txt-l txt-l--sm"
-            htmlFor="ApplicationForm-lastName"
-          >
-            <span
-              style={
-                Object {
-                  "marginRight": "0.5em",
-                  "whiteSpace": "nowrap",
-                }
-              }
-            >
-              Last Name
-            </span>
-            <span
-              className="t--req"
-            >
-              Required
-            </span>
-          </label>
-          <input
-            aria-label=""
-            className="txt-f txt-f--sm "
-            id="ApplicationForm-lastName"
-            name="lastName"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="Last Name"
-            required={true}
-            type="text"
-            value=""
-          />
-          <div
-            className="t--subinfo t--err m-b100"
-          >
-             
-          </div>
-        </div>
-      </div>
-      <div
-        className="css-c3kz39"
-      >
-        <div>
-          <label
-            className="txt-l txt-l--sm"
-            htmlFor="ApplicationForm-streetAddress"
-          >
-            <span
-              style={
-                Object {
-                  "marginRight": "0.5em",
-                  "whiteSpace": "nowrap",
-                }
-              }
-            >
-              Street Address
-            </span>
-            <span
-              className="t--req"
-            >
-              Required
-            </span>
-          </label>
-          <input
-            aria-label=""
-            className="txt-f txt-f--sm "
-            id="ApplicationForm-streetAddress"
-            name="streetAddress"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="Street Address"
-            required={true}
-            type="text"
-            value=""
-          />
-          <div
-            className="t--subinfo t--err m-b100"
-          >
-             
-          </div>
-        </div>
-        <div>
-          <label
-            className="txt-l txt-l--sm"
-            htmlFor="ApplicationForm-unit"
-          >
-            <span
-              style={
-                Object {
-                  "marginRight": "0.5em",
-                  "whiteSpace": "nowrap",
-                }
-              }
-            >
-              Unit
-            </span>
-          </label>
-          <input
-            aria-label=""
-            className="txt-f txt-f--sm "
-            id="ApplicationForm-unit"
-            name="unit"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="Unit or Apartment #"
-            type="text"
-            value=""
-          />
-          <div
-            className="t--subinfo t--err m-b100"
-          >
-             
-          </div>
-        </div>
-      </div>
-      <div
-        className="css-pefnot"
-      >
-        <div>
-          <label
-            className="txt-l txt-l--sm"
-            htmlFor="ApplicationForm-city"
-          >
-            <span
-              style={
-                Object {
-                  "marginRight": "0.5em",
-                  "whiteSpace": "nowrap",
-                }
-              }
-            >
-              City
-            </span>
-            <span
-              className="t--req"
-            >
-              Required
-            </span>
-          </label>
-          <input
-            aria-label=""
-            className="txt-f txt-f--sm "
-            id="ApplicationForm-city"
-            name="city"
-            onBlur={[Function]}
-            onChange={[Function]}
-            placeholder="City"
-            required={true}
-            type="text"
-            value=""
-          />
-          <div
-            className="t--subinfo t--err m-b100"
-          >
-             
-          </div>
-        </div>
-        <div
-          className="css-vke4cr"
-        >
-          <div>
-            <label
-              className="txt-l txt-l--sm"
-              htmlFor="ApplicationForm-state"
-            >
-              <span
-                style={
-                  Object {
-                    "marginRight": "0.5em",
-                    "whiteSpace": "nowrap",
-                  }
-                }
-              >
-                State
-              </span>
-              <span
-                className="t--req"
-              >
-                Required
-              </span>
-            </label>
-            <input
-              aria-label=""
-              className="txt-f txt-f--sm "
-              id="ApplicationForm-state"
-              name="state"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="State"
-              required={true}
-              type="text"
-              value=""
-            />
-            <div
-              className="t--subinfo t--err m-b100"
-            >
-               
-            </div>
-          </div>
-          <div>
-            <label
-              className="txt-l txt-l--sm"
-              htmlFor="ApplicationForm-zip"
-            >
-              <span
-                style={
-                  Object {
-                    "marginRight": "0.5em",
-                    "whiteSpace": "nowrap",
-                  }
-                }
-              >
-                Zip
-              </span>
-              <span
-                className="t--req"
-              >
-                Required
-              </span>
-            </label>
-            <input
-              aria-label=""
-              className="txt-f txt-f--sm "
-              id="ApplicationForm-zip"
-              name="zip"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="Zip Code"
-              required={true}
-              type="text"
-              value=""
-            />
-            <div
-              className="t--subinfo t--err m-b100"
-            >
-               
-            </div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <label
-          className="txt-l txt-l--sm"
-          htmlFor="ApplicationForm-phone"
-        >
-          <span
-            style={
-              Object {
-                "marginRight": "0.5em",
-                "whiteSpace": "nowrap",
-              }
-            }
-          >
-            Phone
-          </span>
-        </label>
-        <input
-          aria-label=""
-          className="txt-f txt-f--sm "
-          id="ApplicationForm-phone"
-          name="phone"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Phone Number"
-          type="text"
-          value=""
-        />
-        <div
-          className="t--subinfo t--err m-b100"
-        >
-           
-        </div>
-      </div>
-      <div>
-        <label
-          className="txt-l txt-l--sm"
-          htmlFor="ApplicationForm-email"
-        >
-          <span
-            style={
-              Object {
-                "marginRight": "0.5em",
-                "whiteSpace": "nowrap",
-              }
-            }
-          >
-            Email
-          </span>
-          <span
-            className="t--req"
-          >
-            Required
-          </span>
-        </label>
-        <input
-          aria-label=""
-          className="txt-f txt-f--sm "
-          id="ApplicationForm-email"
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Email"
-          required={true}
-          type="text"
-          value=""
-        />
-        <div
-          className="t--subinfo t--err m-b100"
-        >
-           
-        </div>
-      </div>
-      <div>
-        <label
-          className="txt-l txt-l--sm"
-          htmlFor="ApplicationForm-confirmEmail"
-        >
-          <span
-            style={
-              Object {
-                "marginRight": "0.5em",
-                "whiteSpace": "nowrap",
-              }
-            }
-          >
-            Confirm Email
-          </span>
-          <span
-            className="t--req"
-          >
-            Required
-          </span>
-        </label>
-        <input
-          aria-label=""
-          className="txt-f txt-f--sm "
-          id="ApplicationForm-confirmEmail"
-          name="confirmEmail"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Confirm Email"
-          required={true}
-          type="text"
-          value=""
-        />
-        <div
-          className="t--subinfo t--err m-b100"
-        >
-           
-        </div>
-      </div>
-    </section>
-    <hr
-      className="hr hr--sq"
-    />
-    <section>
-      <div
-        className="sh m-b300 "
-      >
-        <h2
-          className="sh-title"
-        >
-          Education and Experience
-        </h2>
-      </div>
-      <div>
-        <label
-          className="txt-l txt-l--sm"
-          htmlFor="ApplicationForm-degreeAttained"
-        >
-          <span
-            style={
-              Object {
-                "marginRight": "0.5em",
-                "whiteSpace": "nowrap",
-              }
-            }
-          >
-            Degree Attained
-          </span>
-        </label>
-        <input
-          aria-label=""
-          className="txt-f txt-f--sm "
-          id="ApplicationForm-degreeAttained"
-          name="degreeAttained"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Degree Attained"
-          type="text"
-          value=""
-        />
-        <div
-          className="t--subinfo t--err m-b100"
-        >
-           
-        </div>
-      </div>
-      <div>
-        <label
-          className="txt-l txt-l--sm"
-          htmlFor="ApplicationForm-educationalInstitution"
-        >
-          <span
-            style={
-              Object {
-                "marginRight": "0.5em",
-                "whiteSpace": "nowrap",
-              }
-            }
-          >
-            Educational Institution
-          </span>
-        </label>
-        <input
-          aria-label=""
-          className="txt-f txt-f--sm "
-          id="ApplicationForm-educationalInstitution"
-          name="educationalInstitution"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Educational Institution"
-          type="text"
-          value=""
-        />
-        <div
-          className="t--subinfo t--err m-b100"
-        >
-           
-        </div>
-      </div>
-      <div
-        className="txt"
-      >
-        <label
-          className="txt-l txt-l--sm"
-          htmlFor="FeedbackForm-otherInformation"
-        >
-          Relevant Work Experience
-        </label>
-        <textarea
-          aria-label=""
-          className="txt-f txt-f--sm  "
-          id="FeedbackForm-otherInformation"
-          name="otherInformation"
-          onBlur={[Function]}
-          onChange={[Function]}
-          placeholder="Other information..."
-          rows={3}
-          value=""
-        />
-      </div>
-    </section>
-    <hr
-      className="hr hr--sq"
-    />
-    <div
-      className="sh m-b300 "
-    >
-      <h2
-        className="sh-title"
-      >
-        Boards and Commissions
-      </h2>
-    </div>
-    <p
-      className="t--s400 lh--400"
-    >
-      You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
-    </p>
-    <section
-      className="m-b100"
-    >
-      <div
-        className="sh sh--sm"
-      >
-        <h3
-          className="sh-title css-14x07yu"
-        >
-          <button
-            aria-expanded={true}
-            className="css-1mteg3g"
-            onClick={[Function]}
-            type="button"
-          >
-            Open Positions
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              overflow="visible"
-              viewBox="0 0 20 20"
-            >
-              <path
-                d="M 2,5 10,16 18,5"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2.5"
-              />
-            </svg>
-          </button>
-        </h3>
-      </div>
-      <div
-        hidden={false}
-      >
-        <ul
-          className="css-1mya83q"
-        >
-          <li
-            className="m-b500"
-            style={
-              Object {
-                "listStyleType": "none",
-              }
-            }
-          >
-            <label
-              className="cb "
-            >
-              <input
-                checked={false}
-                className="cb-f"
-                name="commissionIds"
-                onChange={[Function]}
-                type="checkbox"
-                value="0"
-              />
-              <span
-                className="cb-l"
-              >
-                Aberdeen Architectural Conservation District Commission
-              </span>
-            </label>
-          </li>
-          <li
-            className="m-b500"
-            style={
-              Object {
-                "listStyleType": "none",
-              }
-            }
-          >
-            <label
-              className="cb "
-            >
-              <input
-                checked={false}
-                className="cb-f"
-                name="commissionIds"
-                onChange={[Function]}
-                type="checkbox"
-                value="1"
-              />
-              <span
-                className="cb-l"
-              >
-                Back Bay West/Bay State Road Architectural Conservation District Commission
-              </span>
-            </label>
-          </li>
-          <li
-            className="m-b500"
-            style={
-              Object {
-                "listStyleType": "none",
-              }
-            }
-          >
-            <label
-              className="cb "
-            >
-              <input
-                checked={false}
-                className="cb-f"
-                name="commissionIds"
-                onChange={[Function]}
-                type="checkbox"
-                value="2"
-              />
-              <span
-                className="cb-l"
-              >
-                Living Wage Advisory Committee
-              </span>
-            </label>
-          </li>
-        </ul>
-      </div>
-    </section>
-    <section>
-      <div
-        className="sh sh--sm"
-      >
-        <h3
-          className="sh-title css-14x07yu"
-        >
-          <button
-            aria-expanded={true}
-            className="css-1mteg3g"
-            onClick={[Function]}
-            type="button"
-          >
-            No Open Positions
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              overflow="visible"
-              viewBox="0 0 20 20"
-            >
-              <path
-                d="M 2,5 10,16 18,5"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2.5"
-              />
-            </svg>
-          </button>
-        </h3>
-      </div>
-      <div
-        hidden={false}
-      >
-        <ul
-          className="css-1mya83q"
-        >
-          <li
-            className="m-b500"
-            style={
-              Object {
-                "listStyleType": "none",
-              }
-            }
-          >
-            <label
-              className="cb "
-            >
-              <input
-                checked={true}
-                className="cb-f"
-                name="commissionIds"
-                onChange={[Function]}
-                type="checkbox"
-                value="3"
-              />
-              <span
-                className="cb-l"
-              >
-                Licensing Board for the City of Boston
-              </span>
-            </label>
-          </li>
-        </ul>
-      </div>
-    </section>
-    <p
-      className="t--subinfo t--err"
-      style={
-        Object {
-          "color": "#fb4d42",
-          "marginTop": "-0.5em",
-        }
-      }
-    >
-        
-    </p>
-    <hr
-      className="hr hr--sq"
-    />
-    <section>
-      <div
-        className="sh m-b300 "
-      >
-        <h2
-          className="sh-title"
-        >
-          Reference Information
-        </h2>
-      </div>
-      <p
-        className="m-b400"
-      >
-        Files must be PDFs and under 5MB each in size.
-      </p>
-      <div
-        className="txt m-b300 css-1mxs0p5"
-      >
-        <input
-          accept="application/pdf"
-          className="css-1dv1kvn"
-          id="FileInput-coverLetter"
-          name="coverLetter"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="file"
-        />
-        <label
-          className="btn btn--sm btn--100 false"
-          htmlFor="FileInput-coverLetter"
-          style={
-            Object {
-              "fontWeight": "bold",
-              "whiteSpace": "nowrap",
-            }
-          }
-        >
-          Choose 
-          Cover Letter
-           file
-        </label>
-        <div
-          className="css-y0g14a"
-        >
-          <span>
-            No file selected
-          </span>
-        </div>
-      </div>
-      <div
-        className="txt m-b300 css-1mxs0p5"
-      >
-        <input
-          accept="application/pdf"
-          className="css-1dv1kvn"
-          id="FileInput-resume"
-          name="resume"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="file"
-        />
-        <label
-          className="btn btn--sm btn--100 false"
-          htmlFor="FileInput-resume"
-          style={
-            Object {
-              "fontWeight": "bold",
-              "whiteSpace": "nowrap",
-            }
-          }
-        >
-          Choose 
-          Resumé
-           file
-        </label>
-        <div
-          className="css-y0g14a"
-        >
-          <span>
-            No file selected
-          </span>
-        </div>
-      </div>
-    </section>
-    <hr
-      className="hr hr--sq"
-      style={
-        Object {
-          "marginTop": "3rem",
-        }
-      }
-    />
-    <button
-      className="btn btn--700"
-      disabled={true}
-      type="submit"
-    >
-      Submit Application
-    </button>
-  </form>
-</div>
-`;
-
 exports[`Storyshots ApplicationForm blank 1`] = `
 <div
   className="b-c"
@@ -1469,10 +581,10 @@ exports[`Storyshots ApplicationForm blank 1`] = `
     <p
       className="t--s400 lh--400"
     >
-      You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
+      Choose up to 5 boards and commissions from the list below.
     </p>
     <section
-      className="m-b100"
+      className="m-v500"
     >
       <div
         className="sh sh--sm"
@@ -1486,7 +598,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             onClick={[Function]}
             type="button"
           >
-            Open Positions
+            Available Positions
             <svg
               aria-hidden="true"
               focusable="false"
@@ -1508,7 +620,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         hidden={false}
       >
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -1523,7 +635,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -1532,7 +644,20 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               <span
                 className="cb-l"
               >
-                Aberdeen Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Aberdeen Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -1549,7 +674,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -1558,7 +683,20 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               <span
                 className="cb-l"
               >
-                Back Bay West/Bay State Road Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Back Bay West/Bay State Road Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -1575,7 +713,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -1584,14 +722,29 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               <span
                 className="cb-l"
               >
-                Living Wage Advisory Committee
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Living Wage Advisory Committee
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <section>
+    <section
+      className="m-v300"
+    >
       <div
         className="sh sh--sm"
       >
@@ -1625,8 +778,13 @@ exports[`Storyshots ApplicationForm blank 1`] = `
       <div
         hidden={true}
       >
+        <p
+          className="t--s400 lh--400"
+        >
+          You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+        </p>
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -1641,7 +799,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -1650,24 +808,26 @@ exports[`Storyshots ApplicationForm blank 1`] = `
               <span
                 className="cb-l"
               >
-                Licensing Board for the City of Boston
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Licensing Board for the City of Boston
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <p
-      className="t--subinfo t--err"
-      style={
-        Object {
-          "color": "#fb4d42",
-          "marginTop": "-0.5em",
-        }
-      }
-    >
-        
-    </p>
     <hr
       className="hr hr--sq"
     />
@@ -2357,10 +1517,10 @@ exports[`Storyshots ApplicationForm errors 1`] = `
     <p
       className="t--s400 lh--400"
     >
-      You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
+      Choose up to 5 boards and commissions from the list below.
     </p>
     <section
-      className="m-b100"
+      className="m-v500"
     >
       <div
         className="sh sh--sm"
@@ -2374,7 +1534,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             onClick={[Function]}
             type="button"
           >
-            Open Positions
+            Available Positions
             <svg
               aria-hidden="true"
               focusable="false"
@@ -2396,7 +1556,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         hidden={false}
       >
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -2411,7 +1571,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -2420,7 +1580,20 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               <span
                 className="cb-l"
               >
-                Aberdeen Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Aberdeen Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -2437,7 +1610,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -2446,7 +1619,20 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               <span
                 className="cb-l"
               >
-                Back Bay West/Bay State Road Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Back Bay West/Bay State Road Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -2463,7 +1649,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -2472,14 +1658,29 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               <span
                 className="cb-l"
               >
-                Living Wage Advisory Committee
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Living Wage Advisory Committee
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <section>
+    <section
+      className="m-v300"
+    >
       <div
         className="sh sh--sm"
       >
@@ -2513,8 +1714,13 @@ exports[`Storyshots ApplicationForm errors 1`] = `
       <div
         hidden={true}
       >
+        <p
+          className="t--s400 lh--400"
+        >
+          You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+        </p>
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -2529,7 +1735,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -2538,24 +1744,26 @@ exports[`Storyshots ApplicationForm errors 1`] = `
               <span
                 className="cb-l"
               >
-                Licensing Board for the City of Boston
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Licensing Board for the City of Boston
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <p
-      className="t--subinfo t--err"
-      style={
-        Object {
-          "color": "#fb4d42",
-          "marginTop": "-0.5em",
-        }
-      }
-    >
-        
-    </p>
     <hr
       className="hr hr--sq"
     />
@@ -3245,10 +2453,45 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
     <p
       className="t--s400 lh--400"
     >
-      You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
+      You’re chosen to apply to these boards and commissions:
+    </p>
+    <ul
+      className="ul"
+    >
+      <li
+        className="t--info"
+        style={
+          Object {
+            "paddingTop": 0,
+          }
+        }
+      >
+        Living Wage Advisory Committee
+      </li>
+      <li
+        className="t--info"
+        style={
+          Object {
+            "paddingTop": "0.5em",
+          }
+        }
+      >
+        Licensing Board for the City of Boston
+      </li>
+    </ul>
+    <p
+      className="t--s400 lh--400"
+    >
+      You can change your selection by expanding the list below.
+       
+      <span
+        className=""
+      >
+        You may apply for up to 5 boards or commissions at once.
+      </span>
     </p>
     <section
-      className="m-b100"
+      className="m-v500"
     >
       <div
         className="sh sh--sm"
@@ -3257,12 +2500,12 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           className="sh-title css-14x07yu"
         >
           <button
-            aria-expanded={true}
+            aria-expanded={false}
             className="css-1mteg3g"
             onClick={[Function]}
             type="button"
           >
-            Open Positions
+            Available Positions
             <svg
               aria-hidden="true"
               focusable="false"
@@ -3281,10 +2524,10 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </h3>
       </div>
       <div
-        hidden={false}
+        hidden={true}
       >
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -3299,7 +2542,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -3308,7 +2551,20 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               <span
                 className="cb-l"
               >
-                Aberdeen Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Aberdeen Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -3325,7 +2581,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -3334,7 +2590,20 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               <span
                 className="cb-l"
               >
-                Back Bay West/Bay State Road Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Back Bay West/Bay State Road Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -3351,7 +2620,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               <input
                 checked={true}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -3360,14 +2629,29 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               <span
                 className="cb-l"
               >
-                Living Wage Advisory Committee
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Living Wage Advisory Committee
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <section>
+    <section
+      className="m-v300"
+    >
       <div
         className="sh sh--sm"
       >
@@ -3375,7 +2659,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           className="sh-title css-14x07yu"
         >
           <button
-            aria-expanded={true}
+            aria-expanded={false}
             className="css-1mteg3g"
             onClick={[Function]}
             type="button"
@@ -3399,10 +2683,15 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </h3>
       </div>
       <div
-        hidden={false}
+        hidden={true}
       >
+        <p
+          className="t--s400 lh--400"
+        >
+          You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+        </p>
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -3417,7 +2706,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             >
               <input
                 checked={true}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -3426,24 +2715,26 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
               <span
                 className="cb-l"
               >
-                Licensing Board for the City of Boston
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Licensing Board for the City of Boston
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <p
-      className="t--subinfo t--err"
-      style={
-        Object {
-          "color": "#fb4d42",
-          "marginTop": "-0.5em",
-        }
-      }
-    >
-        
-    </p>
     <hr
       className="hr hr--sq"
     />
@@ -4133,10 +3424,10 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
     <p
       className="t--s400 lh--400"
     >
-      You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
+      Choose up to 5 boards and commissions from the list below.
     </p>
     <section
-      className="m-b100"
+      className="m-v500"
     >
       <div
         className="sh sh--sm"
@@ -4150,7 +3441,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             onClick={[Function]}
             type="button"
           >
-            Open Positions
+            Available Positions
             <svg
               aria-hidden="true"
               focusable="false"
@@ -4172,7 +3463,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         hidden={false}
       >
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -4187,7 +3478,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -4196,7 +3487,20 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               <span
                 className="cb-l"
               >
-                Aberdeen Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Aberdeen Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -4213,7 +3517,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -4222,7 +3526,20 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               <span
                 className="cb-l"
               >
-                Back Bay West/Bay State Road Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Back Bay West/Bay State Road Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -4239,7 +3556,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -4248,14 +3565,29 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               <span
                 className="cb-l"
               >
-                Living Wage Advisory Committee
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Living Wage Advisory Committee
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <section>
+    <section
+      className="m-v300"
+    >
       <div
         className="sh sh--sm"
       >
@@ -4289,8 +3621,13 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
       <div
         hidden={true}
       >
+        <p
+          className="t--s400 lh--400"
+        >
+          You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+        </p>
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -4305,7 +3642,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -4314,24 +3651,26 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
               <span
                 className="cb-l"
               >
-                Licensing Board for the City of Boston
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Licensing Board for the City of Boston
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <p
-      className="t--subinfo t--err"
-      style={
-        Object {
-          "color": "#fb4d42",
-          "marginTop": "-0.5em",
-        }
-      }
-    >
-        
-    </p>
     <hr
       className="hr hr--sq"
     />
@@ -5065,10 +4404,10 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
     <p
       className="t--s400 lh--400"
     >
-      You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
+      Choose up to 5 boards and commissions from the list below.
     </p>
     <section
-      className="m-b100"
+      className="m-v500"
     >
       <div
         className="sh sh--sm"
@@ -5082,7 +4421,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             onClick={[Function]}
             type="button"
           >
-            Open Positions
+            Available Positions
             <svg
               aria-hidden="true"
               focusable="false"
@@ -5104,7 +4443,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         hidden={false}
       >
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -5119,7 +4458,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -5128,7 +4467,20 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               <span
                 className="cb-l"
               >
-                Aberdeen Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Aberdeen Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -5145,7 +4497,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -5154,7 +4506,20 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               <span
                 className="cb-l"
               >
-                Back Bay West/Bay State Road Architectural Conservation District Commission
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Back Bay West/Bay State Road Architectural Conservation District Commission
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
@@ -5171,7 +4536,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -5180,14 +4545,29 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               <span
                 className="cb-l"
               >
-                Living Wage Advisory Committee
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Living Wage Advisory Committee
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <section>
+    <section
+      className="m-v300"
+    >
       <div
         className="sh sh--sm"
       >
@@ -5221,8 +4601,13 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
       <div
         hidden={true}
       >
+        <p
+          className="t--s400 lh--400"
+        >
+          You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+        </p>
         <ul
-          className="css-1mya83q"
+          className="css-1d7r5sf"
         >
           <li
             className="m-b500"
@@ -5237,7 +4622,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             >
               <input
                 checked={false}
-                className="cb-f"
+                className="cb-f "
                 name="commissionIds"
                 onChange={[Function]}
                 type="checkbox"
@@ -5246,24 +4631,26 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
               <span
                 className="cb-l"
               >
-                Licensing Board for the City of Boston
+                <div
+                  className="css-ud4bns"
+                >
+                  <span>
+                    Licensing Board for the City of Boston
+                  </span>
+                  <a
+                    href="http://"
+                    target="_blank"
+                    title="Homepage"
+                  >
+                    Homepage
+                  </a>
+                </div>
               </span>
             </label>
           </li>
         </ul>
       </div>
     </section>
-    <p
-      className="t--subinfo t--err"
-      style={
-        Object {
-          "color": "#fb4d42",
-          "marginTop": "-0.5em",
-        }
-      }
-    >
-        
-    </p>
     <hr
       className="hr hr--sq"
     />
@@ -6128,10 +5515,35 @@ exports[`Storyshots ApplyPage default 1`] = `
               <p
                 className="t--s400 lh--400"
               >
-                You can apply for a board or commission that does not currently have any open positions, and we will review your application when a seat opens.
+                You’re chosen to apply to these boards and commissions:
+              </p>
+              <ul
+                className="ul"
+              >
+                <li
+                  className="t--info"
+                  style={
+                    Object {
+                      "paddingTop": 0,
+                    }
+                  }
+                >
+                  Back Bay West/Bay State Road Architectural Conservation District Commission
+                </li>
+              </ul>
+              <p
+                className="t--s400 lh--400"
+              >
+                You can change your selection by expanding the list below.
+                 
+                <span
+                  className=""
+                >
+                  You may apply for up to 5 boards or commissions at once.
+                </span>
               </p>
               <section
-                className="m-b100"
+                className="m-v500"
               >
                 <div
                   className="sh sh--sm"
@@ -6140,12 +5552,12 @@ exports[`Storyshots ApplyPage default 1`] = `
                     className="sh-title css-14x07yu"
                   >
                     <button
-                      aria-expanded={true}
+                      aria-expanded={false}
                       className="css-1mteg3g"
                       onClick={[Function]}
                       type="button"
                     >
-                      Open Positions
+                      Available Positions
                       <svg
                         aria-hidden="true"
                         focusable="false"
@@ -6164,10 +5576,10 @@ exports[`Storyshots ApplyPage default 1`] = `
                   </h3>
                 </div>
                 <div
-                  hidden={false}
+                  hidden={true}
                 >
                   <ul
-                    className="css-1mya83q"
+                    className="css-1d7r5sf"
                   >
                     <li
                       className="m-b500"
@@ -6182,7 +5594,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="cb-f"
+                          className="cb-f "
                           name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
@@ -6191,7 +5603,20 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <span
                           className="cb-l"
                         >
-                          Aberdeen Architectural Conservation District Commission
+                          <div
+                            className="css-ud4bns"
+                          >
+                            <span>
+                              Aberdeen Architectural Conservation District Commission
+                            </span>
+                            <a
+                              href="http://"
+                              target="_blank"
+                              title="Homepage"
+                            >
+                              Homepage
+                            </a>
+                          </div>
                         </span>
                       </label>
                     </li>
@@ -6208,7 +5633,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         <input
                           checked={true}
-                          className="cb-f"
+                          className="cb-f "
                           name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
@@ -6217,7 +5642,20 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <span
                           className="cb-l"
                         >
-                          Back Bay West/Bay State Road Architectural Conservation District Commission
+                          <div
+                            className="css-ud4bns"
+                          >
+                            <span>
+                              Back Bay West/Bay State Road Architectural Conservation District Commission
+                            </span>
+                            <a
+                              href="http://"
+                              target="_blank"
+                              title="Homepage"
+                            >
+                              Homepage
+                            </a>
+                          </div>
                         </span>
                       </label>
                     </li>
@@ -6234,7 +5672,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="cb-f"
+                          className="cb-f "
                           name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
@@ -6243,14 +5681,29 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <span
                           className="cb-l"
                         >
-                          Living Wage Advisory Committee
+                          <div
+                            className="css-ud4bns"
+                          >
+                            <span>
+                              Living Wage Advisory Committee
+                            </span>
+                            <a
+                              href="http://"
+                              target="_blank"
+                              title="Homepage"
+                            >
+                              Homepage
+                            </a>
+                          </div>
                         </span>
                       </label>
                     </li>
                   </ul>
                 </div>
               </section>
-              <section>
+              <section
+                className="m-v300"
+              >
                 <div
                   className="sh sh--sm"
                 >
@@ -6284,8 +5737,13 @@ exports[`Storyshots ApplyPage default 1`] = `
                 <div
                   hidden={true}
                 >
+                  <p
+                    className="t--s400 lh--400"
+                  >
+                    You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+                  </p>
                   <ul
-                    className="css-1mya83q"
+                    className="css-1d7r5sf"
                   >
                     <li
                       className="m-b500"
@@ -6300,7 +5758,7 @@ exports[`Storyshots ApplyPage default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="cb-f"
+                          className="cb-f "
                           name="commissionIds"
                           onChange={[Function]}
                           type="checkbox"
@@ -6309,24 +5767,26 @@ exports[`Storyshots ApplyPage default 1`] = `
                         <span
                           className="cb-l"
                         >
-                          Licensing Board for the City of Boston
+                          <div
+                            className="css-ud4bns"
+                          >
+                            <span>
+                              Licensing Board for the City of Boston
+                            </span>
+                            <a
+                              href="http://"
+                              target="_blank"
+                              title="Homepage"
+                            >
+                              Homepage
+                            </a>
+                          </div>
                         </span>
                       </label>
                     </li>
                   </ul>
                 </div>
               </section>
-              <p
-                className="t--subinfo t--err"
-                style={
-                  Object {
-                    "color": "#fb4d42",
-                    "marginTop": "-0.5em",
-                  }
-                }
-              >
-                  
-              </p>
               <hr
                 className="hr hr--sq"
               />
@@ -6680,5 +6140,7200 @@ exports[`Storyshots ApplyPage submitted successfully 1`] = `
       }
     }
   />
+</div>
+`;
+
+exports[`Storyshots CommissionsListSection default 1`] = `
+<div
+  className="b-c"
+>
+  <div
+    className="sh m-b300 "
+  >
+    <h2
+      className="sh-title"
+    >
+      Boards and Commissions
+    </h2>
+  </div>
+  <p
+    className="t--s400 lh--400"
+  >
+    You’re chosen to apply to these boards and commissions:
+  </p>
+  <ul
+    className="ul"
+  >
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": 0,
+        }
+      }
+    >
+      Boston School Committee Nominating Panel
+    </li>
+  </ul>
+  <p
+    className="t--s400 lh--400"
+  >
+    You can change your selection by expanding the list below.
+     
+    <span
+      className=""
+    >
+      You may apply for up to 5 boards or commissions at once.
+    </span>
+  </p>
+  <section
+    className="m-v500"
+  >
+    <div
+      className="sh sh--sm"
+    >
+      <h3
+        className="sh-title css-14x07yu"
+      >
+        <button
+          aria-expanded={false}
+          className="css-1mteg3g"
+          onClick={[Function]}
+          type="button"
+        >
+          Available Positions
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            overflow="visible"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M 2,5 10,16 18,5"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2.5"
+            />
+          </svg>
+        </button>
+      </h3>
+    </div>
+    <div
+      hidden={true}
+    >
+      <ul
+        className="css-1d7r5sf"
+      >
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="1"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Trustees of Charitable Donations for Inhabitants of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/trustees-charitable-donations-inhabitants-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="2"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston School Committee Nominating Panel
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/Boston-School-Committee-Nominating-Panel"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="7"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Neighborhood Housing Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/Neighborhood-Housing-Trust-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="13"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fund for Parks & Recreation in Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/parks-and-recreation/fund-parks-and-recreation-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="18"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Neighborhood Jobs Trust
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/economic-development/Neighborhood-Jobs-Trust"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="21"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Zoning Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Zoning-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="34"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Air Pollution Control Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/Air-Pollution-Control-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="35"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Archives and Records Advisory Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/archives-and-records-management"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="36"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Art Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/arts-and-culture/Boston-Art-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="37"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Audit Committee of the City of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/auditing/audit-committee-city-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="38"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Back Bay Architectural Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/back-bay-architectural-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="39"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Back Bay West/Bay State Road Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/bay-state-roadback-bay-west-area-architectural-conservation-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="40"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Bay Village Historic District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/bay-village-historic-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="41"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Beacon Hill Architectural Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/historic-beacon-hill-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="42"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Board of Examiners
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/board-examiners"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="44"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Housing Authority Monitoring Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/housing-authority/Boston-Housing-Authority-Monitoring-Committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="45"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Industrial Development Financing Authority
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Boston-Industrial-Development-Financing-Authority"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="46"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Public Health Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-health-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="48"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Redevelopment Authority (BRA)/Economic Development Industrial Corp (EDIC)
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="52"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Elections Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/election/Boston-Elections-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="60"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Conservation Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/conservation-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="64"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Water and Sewer Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/water-and-sewer-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="65"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Landmarks Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/landmarks-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="66"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Mission Hill Triangle Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/mission-hill-triangle"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="67"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  South End Landmark District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/south-end-landmark-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="68"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  St. Botolph Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/saint-botolph"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="84"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fund for Boston Neighborhoods, Inc.
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/tourism-sports-and-entertainment/fund-boston-neighborhoods-inc"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="87"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  City of Boston Scholarship Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/city-boston-scholarship-fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="157"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Groundwater Trust
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/Boston-Groundwater-Trust"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="162"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fort Point Channel Landmark District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/fort-point-channel"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="170"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Aberdeen Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/aberdeen-architectural-conservation-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="180"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Zoning Board of Appeals
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/zoning-board-appeal"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="210"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Off-Street Parking Facilities Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/transportation/Off-Street-Parking-Facilities-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="211"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Living Wage Advisory Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/labor-relations/living-wage-advisory-committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="212"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Animal Control Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/animal-control-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </section>
+  <section
+    className="m-v300"
+  >
+    <div
+      className="sh sh--sm"
+    >
+      <h3
+        className="sh-title css-14x07yu"
+      >
+        <button
+          aria-expanded={false}
+          className="css-1mteg3g"
+          onClick={[Function]}
+          type="button"
+        >
+          No Open Positions
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            overflow="visible"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M 2,5 10,16 18,5"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2.5"
+            />
+          </svg>
+        </button>
+      </h3>
+    </div>
+    <div
+      hidden={true}
+    >
+      <p
+        className="t--s400 lh--400"
+      >
+        You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+      </p>
+      <ul
+        className="css-1d7r5sf"
+      >
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="4"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston School Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/Boston-School-Committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="10"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  City of Boston School Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/city-boston-school-trust-fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="11"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  George Robert White Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/George-Robert-White-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="15"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Resident Advisory Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/housing-authority/Resident-Advisory-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="16"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Cultural Council
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/arts-and-culture/Boston-Cultural-Council"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="25"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Fair Housing Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/fair-housing-and-equity/Boston-Fair-Housing-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="28"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Compensation Advisory Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/licensing-board/Boston-Compensation-Advisory-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="31"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Mass. Water Resources Authority
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/mass-water-resources-authority"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="32"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Board of Review--Assessing
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/assessing/board-review-assessing"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="43"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Employment Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/small-business-development/boston-employment-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="47"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Public Library Board of Trustees
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/library/boston-public-library-board-trustees"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="51"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Edward Ingersoll Browne Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/Edward-Ingersoll-Browne-Trust-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="53"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Freedom Trail Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-works/Freedom-Trail-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="55"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Parks & Recreation Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/parks-and-recreation/Parks-and-Recreation-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="56"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Public Improvement Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-works/Public-Improvement-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="59"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Licensing Board for the City of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/licensing-board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="69"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Civic Design Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Boston-Civic-Design-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="85"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Public Facilities Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-facilities/Public-Facilities-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="86"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Residency Compliance Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/property-management/Residency-Compliance-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="165"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Disability Advisory Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/disabilities-commission/disability-commission-advisory-board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="171"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Retirement Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/retirement"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="209"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Trustee of the Copley Square Charitable Trust
+                </span>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="214"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Community Preservation Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/community-preservation"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`Storyshots CommissionsListSection no initial selections 1`] = `
+<div
+  className="b-c"
+>
+  <div
+    className="sh m-b300 "
+  >
+    <h2
+      className="sh-title"
+    >
+      Boards and Commissions
+    </h2>
+  </div>
+  <p
+    className="t--s400 lh--400"
+  >
+    Choose up to 5 boards and commissions from the list below.
+  </p>
+  <section
+    className="m-v500"
+  >
+    <div
+      className="sh sh--sm"
+    >
+      <h3
+        className="sh-title css-14x07yu"
+      >
+        <button
+          aria-expanded={true}
+          className="css-1mteg3g"
+          onClick={[Function]}
+          type="button"
+        >
+          Available Positions
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            overflow="visible"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M 2,5 10,16 18,5"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2.5"
+            />
+          </svg>
+        </button>
+      </h3>
+    </div>
+    <div
+      hidden={false}
+    >
+      <ul
+        className="css-1d7r5sf"
+      >
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="1"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Trustees of Charitable Donations for Inhabitants of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/trustees-charitable-donations-inhabitants-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="2"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston School Committee Nominating Panel
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/Boston-School-Committee-Nominating-Panel"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="7"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Neighborhood Housing Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/Neighborhood-Housing-Trust-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="13"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fund for Parks & Recreation in Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/parks-and-recreation/fund-parks-and-recreation-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="18"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Neighborhood Jobs Trust
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/economic-development/Neighborhood-Jobs-Trust"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="21"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Zoning Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Zoning-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="34"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Air Pollution Control Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/Air-Pollution-Control-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="35"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Archives and Records Advisory Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/archives-and-records-management"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="36"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Art Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/arts-and-culture/Boston-Art-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="37"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Audit Committee of the City of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/auditing/audit-committee-city-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="38"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Back Bay Architectural Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/back-bay-architectural-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="39"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Back Bay West/Bay State Road Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/bay-state-roadback-bay-west-area-architectural-conservation-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="40"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Bay Village Historic District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/bay-village-historic-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="41"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Beacon Hill Architectural Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/historic-beacon-hill-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="42"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Board of Examiners
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/board-examiners"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="44"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Housing Authority Monitoring Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/housing-authority/Boston-Housing-Authority-Monitoring-Committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="45"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Industrial Development Financing Authority
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Boston-Industrial-Development-Financing-Authority"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="46"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Public Health Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-health-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="48"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Redevelopment Authority (BRA)/Economic Development Industrial Corp (EDIC)
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="52"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Elections Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/election/Boston-Elections-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="60"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Conservation Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/conservation-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="64"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Water and Sewer Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/water-and-sewer-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="65"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Landmarks Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/landmarks-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="66"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Mission Hill Triangle Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/mission-hill-triangle"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="67"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  South End Landmark District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/south-end-landmark-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="68"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  St. Botolph Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/saint-botolph"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="84"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fund for Boston Neighborhoods, Inc.
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/tourism-sports-and-entertainment/fund-boston-neighborhoods-inc"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="87"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  City of Boston Scholarship Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/city-boston-scholarship-fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="157"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Groundwater Trust
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/Boston-Groundwater-Trust"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="162"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fort Point Channel Landmark District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/fort-point-channel"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="170"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Aberdeen Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/aberdeen-architectural-conservation-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="180"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Zoning Board of Appeals
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/zoning-board-appeal"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="210"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Off-Street Parking Facilities Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/transportation/Off-Street-Parking-Facilities-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="211"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Living Wage Advisory Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/labor-relations/living-wage-advisory-committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="212"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Animal Control Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/animal-control-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </section>
+  <section
+    className="m-v300"
+  >
+    <div
+      className="sh sh--sm"
+    >
+      <h3
+        className="sh-title css-14x07yu"
+      >
+        <button
+          aria-expanded={false}
+          className="css-1mteg3g"
+          onClick={[Function]}
+          type="button"
+        >
+          No Open Positions
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            overflow="visible"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M 2,5 10,16 18,5"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2.5"
+            />
+          </svg>
+        </button>
+      </h3>
+    </div>
+    <div
+      hidden={true}
+    >
+      <p
+        className="t--s400 lh--400"
+      >
+        You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+      </p>
+      <ul
+        className="css-1d7r5sf"
+      >
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="4"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston School Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/Boston-School-Committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="10"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  City of Boston School Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/city-boston-school-trust-fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="11"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  George Robert White Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/George-Robert-White-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="15"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Resident Advisory Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/housing-authority/Resident-Advisory-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="16"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Cultural Council
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/arts-and-culture/Boston-Cultural-Council"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="25"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Fair Housing Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/fair-housing-and-equity/Boston-Fair-Housing-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="28"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Compensation Advisory Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/licensing-board/Boston-Compensation-Advisory-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="31"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Mass. Water Resources Authority
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/mass-water-resources-authority"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="32"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Board of Review--Assessing
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/assessing/board-review-assessing"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="43"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Employment Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/small-business-development/boston-employment-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="47"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Public Library Board of Trustees
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/library/boston-public-library-board-trustees"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="51"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Edward Ingersoll Browne Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/Edward-Ingersoll-Browne-Trust-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="53"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Freedom Trail Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-works/Freedom-Trail-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="55"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Parks & Recreation Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/parks-and-recreation/Parks-and-Recreation-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="56"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Public Improvement Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-works/Public-Improvement-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="59"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Licensing Board for the City of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/licensing-board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="69"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Civic Design Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Boston-Civic-Design-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="85"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Public Facilities Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-facilities/Public-Facilities-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="86"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Residency Compliance Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/property-management/Residency-Compliance-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="165"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Disability Advisory Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/disabilities-commission/disability-commission-advisory-board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="171"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Retirement Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/retirement"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="209"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Trustee of the Copley Square Charitable Trust
+                </span>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="214"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Community Preservation Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/community-preservation"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`Storyshots CommissionsListSection too many checked 1`] = `
+<div
+  className="b-c"
+>
+  <div
+    className="sh m-b300 "
+  >
+    <h2
+      className="sh-title"
+    >
+      Boards and Commissions
+    </h2>
+  </div>
+  <p
+    className="t--s400 lh--400"
+  >
+    You’re chosen to apply to these boards and commissions:
+  </p>
+  <ul
+    className="ul"
+  >
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": 0,
+        }
+      }
+    >
+      Trustees of Charitable Donations for Inhabitants of Boston
+    </li>
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": "0.5em",
+        }
+      }
+    >
+      Boston School Committee Nominating Panel
+    </li>
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": "0.5em",
+        }
+      }
+    >
+      Boston School Committee
+    </li>
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": "0.5em",
+        }
+      }
+    >
+      Neighborhood Housing Trust Fund
+    </li>
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": "0.5em",
+        }
+      }
+    >
+      City of Boston School Trust Fund
+    </li>
+    <li
+      className="t--info"
+      style={
+        Object {
+          "paddingTop": "0.5em",
+        }
+      }
+    >
+      Boston Retirement Board
+    </li>
+  </ul>
+  <p
+    className="t--s400 lh--400"
+  >
+    You can change your selection by expanding the list below.
+     
+    <span
+      className="t--err"
+    >
+      You may apply for up to 5 boards or commissions at once.
+    </span>
+  </p>
+  <section
+    className="m-v500"
+  >
+    <div
+      className="sh sh--sm"
+    >
+      <h3
+        className="sh-title css-14x07yu"
+      >
+        <button
+          aria-expanded={true}
+          className="css-1mteg3g"
+          onClick={[Function]}
+          type="button"
+        >
+          Available Positions
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            overflow="visible"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M 2,5 10,16 18,5"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2.5"
+            />
+          </svg>
+        </button>
+      </h3>
+    </div>
+    <div
+      hidden={false}
+    >
+      <ul
+        className="css-1d7r5sf"
+      >
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f cb-f--err"
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="1"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Trustees of Charitable Donations for Inhabitants of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/trustees-charitable-donations-inhabitants-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f cb-f--err"
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="2"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston School Committee Nominating Panel
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/Boston-School-Committee-Nominating-Panel"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f cb-f--err"
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="7"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Neighborhood Housing Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/Neighborhood-Housing-Trust-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="13"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fund for Parks & Recreation in Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/parks-and-recreation/fund-parks-and-recreation-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="18"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Neighborhood Jobs Trust
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/economic-development/Neighborhood-Jobs-Trust"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="21"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Zoning Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Zoning-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="34"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Air Pollution Control Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/Air-Pollution-Control-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="35"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Archives and Records Advisory Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/archives-and-records-management"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="36"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Art Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/arts-and-culture/Boston-Art-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="37"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Audit Committee of the City of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/auditing/audit-committee-city-boston"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="38"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Back Bay Architectural Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/back-bay-architectural-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="39"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Back Bay West/Bay State Road Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/bay-state-roadback-bay-west-area-architectural-conservation-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="40"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Bay Village Historic District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/bay-village-historic-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="41"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Beacon Hill Architectural Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/historic-beacon-hill-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="42"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Board of Examiners
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/board-examiners"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="44"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Housing Authority Monitoring Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/housing-authority/Boston-Housing-Authority-Monitoring-Committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="45"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Industrial Development Financing Authority
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Boston-Industrial-Development-Financing-Authority"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="46"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Public Health Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-health-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="48"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Redevelopment Authority (BRA)/Economic Development Industrial Corp (EDIC)
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="52"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Elections Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/election/Boston-Elections-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="60"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Conservation Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/conservation-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="64"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Water and Sewer Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/water-and-sewer-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="65"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Landmarks Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/landmarks-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="66"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Mission Hill Triangle Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/mission-hill-triangle"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="67"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  South End Landmark District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/south-end-landmark-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="68"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  St. Botolph Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/saint-botolph"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="84"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fund for Boston Neighborhoods, Inc.
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/tourism-sports-and-entertainment/fund-boston-neighborhoods-inc"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="87"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  City of Boston Scholarship Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/city-boston-scholarship-fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="157"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Groundwater Trust
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/Boston-Groundwater-Trust"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="162"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Fort Point Channel Landmark District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/fort-point-channel"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="170"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Aberdeen Architectural Conservation District Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/historic-district/aberdeen-architectural-conservation-district"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="180"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Zoning Board of Appeals
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/zoning-board-appeal"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="210"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Off-Street Parking Facilities Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/transportation/Off-Street-Parking-Facilities-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="211"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Living Wage Advisory Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/labor-relations/living-wage-advisory-committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="212"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Animal Control Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/inspectional-services/animal-control-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </section>
+  <section
+    className="m-v300"
+  >
+    <div
+      className="sh sh--sm"
+    >
+      <h3
+        className="sh-title css-14x07yu"
+      >
+        <button
+          aria-expanded={false}
+          className="css-1mteg3g"
+          onClick={[Function]}
+          type="button"
+        >
+          No Open Positions
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            overflow="visible"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M 2,5 10,16 18,5"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2.5"
+            />
+          </svg>
+        </button>
+      </h3>
+    </div>
+    <div
+      hidden={true}
+    >
+      <p
+        className="t--s400 lh--400"
+      >
+        You can apply for a board or commission that does not currently have any open positions. We will review your application when a seat opens.
+      </p>
+      <ul
+        className="css-1d7r5sf"
+      >
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f cb-f--err"
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="4"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston School Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/Boston-School-Committee"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f cb-f--err"
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="10"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  City of Boston School Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/schools/city-boston-school-trust-fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="11"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  George Robert White Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/George-Robert-White-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="15"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Resident Advisory Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/housing-authority/Resident-Advisory-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="16"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Cultural Council
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/arts-and-culture/Boston-Cultural-Council"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="25"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Fair Housing Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/fair-housing-and-equity/Boston-Fair-Housing-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="28"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Compensation Advisory Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/licensing-board/Boston-Compensation-Advisory-Board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="31"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Mass. Water Resources Authority
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/environment/mass-water-resources-authority"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="32"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Board of Review--Assessing
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/assessing/board-review-assessing"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="43"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Employment Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/small-business-development/boston-employment-commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="47"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Public Library Board of Trustees
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/library/boston-public-library-board-trustees"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="51"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Edward Ingersoll Browne Trust Fund
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/treasury/Edward-Ingersoll-Browne-Trust-Fund"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="53"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Freedom Trail Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-works/Freedom-Trail-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="55"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Parks & Recreation Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/parks-and-recreation/Parks-and-Recreation-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="56"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Public Improvement Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-works/Public-Improvement-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="59"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Licensing Board for the City of Boston
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/licensing-board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="69"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Civic Design Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/planning-development-agency/Boston-Civic-Design-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="85"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Public Facilities Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/public-facilities/Public-Facilities-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="86"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Residency Compliance Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/property-management/Residency-Compliance-Commission"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="165"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Disability Advisory Commission
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/disabilities-commission/disability-commission-advisory-board"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={true}
+              className="cb-f cb-f--err"
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="171"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Boston Retirement Board
+                </span>
+                <a
+                  href="https://www.boston.gov/departments/retirement"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="209"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Trustee of the Copley Square Charitable Trust
+                </span>
+              </div>
+            </span>
+          </label>
+        </li>
+        <li
+          className="m-b500"
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <label
+            className="cb "
+          >
+            <input
+              checked={false}
+              className="cb-f "
+              name="commissionIds"
+              onChange={[Function]}
+              type="checkbox"
+              value="214"
+            />
+            <span
+              className="cb-l"
+            >
+              <div
+                className="css-ud4bns"
+              >
+                <span>
+                  Community Preservation Committee
+                </span>
+                <a
+                  href="https://www.boston.gov/community-preservation"
+                  target="_blank"
+                  title="Homepage"
+                >
+                  Homepage
+                </a>
+              </div>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </section>
 </div>
 `;

--- a/services-js/commissions-app/static/assets/external-link.svg
+++ b/services-js/commissions-app/static/assets/external-link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><path stroke="#288be4" stroke-width="2" stroke-linecap="round" fill="#FFF" d="M2 2h20v20H2z"/><path d="M9 7h8v8" fill="#288be4"/><path d="M15.256 9L8 16.256" stroke="#288be4" stroke-width="2" stroke-linecap="round"/></g></svg>


### PR DESCRIPTION
Collapses the list by default if you’ve already selected a commission.
Adds links to the commission’s home page.

Also:
 - Supports the new error state for checkboxes
 - Fixes commissions-app’s static assets to be served at /commissions/