### PR TITLE
Adds Google Analytics to commissions-app

### DIFF
--- a/modules-js/next-client-common/package.json
+++ b/modules-js/next-client-common/package.json
@@ -30,6 +30,7 @@
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-jest-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
+    "@types/google.analytics": "^0.0.39",
     "@types/hapi": "^17.0.19",
     "@types/isomorphic-fetch": "^0.0.34",
     "@types/jest": "23.x.x",

--- a/modules-js/next-client-common/src/GaSiteAnalytics.ts
+++ b/modules-js/next-client-common/src/GaSiteAnalytics.ts
@@ -1,0 +1,27 @@
+import { SiteAnalytics, EventOptions } from './SiteAnalytics';
+
+/**
+ * SiteAnalytics implementation that uses the legacy "ga.js" implementation and
+ * ga() function.
+ */
+export default class GaSiteAnalytics extends SiteAnalytics {
+  initialPageview() {
+    // This is split out separately because the e-commerce code needs to set
+    // impression data before the pageview is sent.
+    ga('send', 'pageview');
+  }
+
+  changePath(path: string) {
+    ga('set', 'page', path);
+  }
+
+  sendEvent(action: string, options: EventOptions = {}) {
+    ga('send', {
+      hitType: 'event',
+      eventCategory: options.category,
+      eventAction: action,
+      eventLabel: options.label,
+      eventValue: options.value,
+    });
+  }
+}

--- a/modules-js/next-client-common/src/GtagSiteAnalytics.tsx
+++ b/modules-js/next-client-common/src/GtagSiteAnalytics.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { SiteAnalytics, EventOptions } from './SiteAnalytics';
+
+/**
+ * SiteAnalytics implementation for the new Google Tag Manager JavaScript.
+ */
+export default class GtagSiteAnalytics extends SiteAnalytics {
+  private googleTrackingId: string;
+
+  constructor(googleTrackingId: string | null = SiteAnalytics.getTrackingId()) {
+    super();
+
+    this.googleTrackingId = googleTrackingId || '';
+  }
+
+  static makeTrackingCode(
+    googleTrackingId: string | null = SiteAnalytics.getTrackingId()
+  ): React.ReactNode {
+    if (!googleTrackingId) {
+      return null;
+    }
+
+    return (
+      <>
+        <script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${googleTrackingId}`}
+        />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${googleTrackingId}');
+            `,
+          }}
+        />
+      </>
+    );
+  }
+
+  initialPageview() {
+    // nothing to do, since the 'config' in the initial snippet handles this.
+  }
+
+  changePath(path: string) {
+    gtag('config', this.googleTrackingId, { page_path: path });
+  }
+
+  sendEvent(action: string, options: EventOptions = {}) {
+    gtag('event', action, {
+      event_category: options.category,
+      event_label: options.label,
+      value: options.value,
+    });
+  }
+}

--- a/modules-js/next-client-common/src/RouterListener.ts
+++ b/modules-js/next-client-common/src/RouterListener.ts
@@ -1,5 +1,6 @@
 import NProgress from 'nprogress';
 import Router from 'next/router';
+import { SiteAnalytics } from './SiteAnalytics';
 
 // import Accessibility from '../store/Accessibility';
 
@@ -13,14 +14,14 @@ export function makeNProgressStyle(height: number = 65) {
 export default class RouterListener {
   // accessibility: Accessibility | null = null;
   router: Router | null = null;
-  ga: any = null;
+  siteAnalytics: SiteAnalytics | null = null;
   routeStartMs: number = 0;
   progressStartTimeout: number | null = null;
 
-  attach(router: Router, ga: any) {
+  attach(router: Router, siteAnalytics: SiteAnalytics | null) {
     this.router = router;
     // this.accessibility = accessibility;
-    this.ga = ga;
+    this.siteAnalytics = siteAnalytics;
 
     router.onRouteChangeStart = this.routeChangeStart;
     router.onRouteChangeComplete = this.routeChangeComplete;
@@ -32,8 +33,8 @@ export default class RouterListener {
     // been called, so any impression data that needs to be sent in pageview has
     // been set.
     window.setTimeout(function() {
-      if (ga) {
-        ga('send', 'pageview');
+      if (siteAnalytics) {
+        siteAnalytics.initialPageview();
       }
     }, 0);
   }
@@ -60,10 +61,10 @@ export default class RouterListener {
 
     NProgress.done();
 
-    const { ga } = this;
+    const { siteAnalytics } = this;
 
-    if (ga) {
-      ga('set', 'page', url);
+    if (siteAnalytics) {
+      siteAnalytics.changePath(url);
     }
 
     // if (accessibility) {

--- a/modules-js/next-client-common/src/SiteAnalytics.ts
+++ b/modules-js/next-client-common/src/SiteAnalytics.ts
@@ -1,0 +1,36 @@
+import getConfig from 'next/config';
+import { GOOGLE_TRACKING_ID_KEY } from './next-client-common';
+
+export interface EventOptions {
+  category?: string;
+  label?: string;
+  value?: number;
+}
+
+/**
+ * Abstraction around Google Analytics implementations.
+ */
+export abstract class SiteAnalytics {
+  static getTrackingId(): string | null {
+    const { publicRuntimeConfig } = getConfig() || { publicRuntimeConfig: {} };
+
+    return publicRuntimeConfig[GOOGLE_TRACKING_ID_KEY] || null;
+  }
+
+  /**
+   * Called after the page is first rendered. Important for the GA
+   * implementation, as there are impression methods that must be called before
+   * "pageview" is sent.
+   */
+  abstract initialPageview();
+
+  /**
+   * Called when the Next router switches to a different page.
+   */
+  abstract changePath(path: string);
+
+  /**
+   * Used to send custom events to Google Analytics.
+   */
+  abstract sendEvent(action: string, options?: EventOptions);
+}

--- a/modules-js/next-client-common/src/gtag.d.ts
+++ b/modules-js/next-client-common/src/gtag.d.ts
@@ -1,0 +1,26 @@
+interface GoogleAnalyticsEventOptions {
+  send_to?: string;
+  value?: number;
+  event_category?: string;
+  event_label?: string;
+  description?: string;
+  fatal?: boolean;
+  [metricName: string]: string | number | boolean | undefined;
+}
+
+interface GoogleAnalyticsConfigOptions {
+  page_path?: string;
+  custom_map?: { [metricIndex: string]: string };
+}
+
+declare function gtag(action: 'js', date: Date);
+declare function gtag(
+  action: 'config',
+  property: string,
+  options?: GoogleAnalyticsConfigOptions
+);
+declare function gtag(
+  action: 'event',
+  eventName: string,
+  eventOptions?: GoogleAnalyticsEventOptions
+);

--- a/modules-js/next-client-common/src/next-client-common.ts
+++ b/modules-js/next-client-common/src/next-client-common.ts
@@ -5,10 +5,13 @@ import { ServerInjectResponse } from 'hapi';
 
 export { default as RouterListener } from './RouterListener';
 export * from './RouterListener';
+export { default as GtagSiteAnalytics } from './GtagSiteAnalytics';
+export { default as GaSiteAnalytics } from './GaSiteAnalytics';
 
 export const API_KEY_CONFIG_KEY = 'graphqlApiKey';
 export const HAPI_INJECT_CONFIG_KEY = 'graphqlHapiInject';
 export const GRAPHQL_PATH_KEY = 'graphqlPath';
+export const GOOGLE_TRACKING_ID_KEY = 'googleTrackingId';
 
 // We parameterize the Request type because it’s common to pass extra things
 // into the server-side getInitialProps methods by attaching them as properties

--- a/services-js/commissions-app/src/pages/_app.tsx
+++ b/services-js/commissions-app/src/pages/_app.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import App, { Container } from 'next/app';
+import Router from 'next/router';
 import { hydrate } from 'emotion';
+import { SiteAnalytics } from '@cityofboston/next-client-common/build/SiteAnalytics';
+import {
+  RouterListener,
+  GtagSiteAnalytics,
+} from '@cityofboston/next-client-common';
 
 interface Props {
   pageProps: any;
@@ -10,6 +16,9 @@ interface Props {
 export default class CommissionsApp extends App {
   // TypeScript doesn't know that App already has a props member.
   protected props: Props;
+
+  protected routerListener: RouterListener;
+  protected siteAnalytics: SiteAnalytics;
 
   static async getInitialProps({ Component, ctx }) {
     const pageProps = Component.getInitialProps
@@ -32,6 +41,17 @@ export default class CommissionsApp extends App {
     if (typeof window !== 'undefined') {
       hydrate((window as any).__NEXT_DATA__.ids);
     }
+
+    this.routerListener = new RouterListener();
+    this.siteAnalytics = new GtagSiteAnalytics();
+  }
+
+  componentDidMount() {
+    this.routerListener.attach(Router, this.siteAnalytics);
+  }
+
+  componentWillUnmount() {
+    this.routerListener.detach();
   }
 
   render() {

--- a/services-js/commissions-app/src/pages/_document.tsx
+++ b/services-js/commissions-app/src/pages/_document.tsx
@@ -6,6 +6,7 @@ import {
   CompatibilityWarning,
   PUBLIC_CSS_URL,
 } from '@cityofboston/react-fleet';
+import { GtagSiteAnalytics } from '@cityofboston/next-client-common';
 
 export default class MyDocument extends Document {
   props: any;
@@ -48,6 +49,8 @@ export default class MyDocument extends Document {
           <link rel="stylesheet" href={PUBLIC_CSS_URL} />
 
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
+
+          {GtagSiteAnalytics.makeTrackingCode()}
 
           {rollbarAccessToken && (
             <script

--- a/services-js/commissions-app/src/pages/commissions/apply.tsx
+++ b/services-js/commissions-app/src/pages/commissions/apply.tsx
@@ -9,7 +9,10 @@ import { AppLayout } from '@cityofboston/react-fleet';
 
 import ApplicationForm from '../../client/ApplicationForm';
 import ApplicationSubmitted from '../../client/ApplicationSubmitted';
-import { NextContext } from '@cityofboston/next-client-common';
+import {
+  NextContext,
+  GtagSiteAnalytics,
+} from '@cityofboston/next-client-common';
 import { IncomingMessage } from 'http';
 import { Formik } from 'formik';
 import { ApplyFormValues, applyFormSchema } from '../../lib/validationSchema';
@@ -50,6 +53,8 @@ export default class ApplyPage extends React.Component<Props, State> {
   }
 
   handleSubmit = async () => {
+    const siteAnalytics = new GtagSiteAnalytics();
+
     const form = this.formRef.current;
     if (!form) {
       return;
@@ -64,6 +69,11 @@ export default class ApplyPage extends React.Component<Props, State> {
     const data = new FormData(form);
 
     try {
+      siteAnalytics.sendEvent('submit', {
+        category: 'Application',
+        value: data.getAll('commissionIds').length,
+      });
+
       const resp = await fetch('/commissions/submit', {
         method: 'POST',
         body: data,
@@ -74,6 +84,10 @@ export default class ApplyPage extends React.Component<Props, State> {
       }
 
       this.setState({ applicationSubmitted: true });
+
+      siteAnalytics.sendEvent('success', {
+        category: 'Application',
+      });
     } catch (e) {
       this.setState({
         submissionError: true,

--- a/services-js/commissions-app/src/server/commissions-app.ts
+++ b/services-js/commissions-app/src/server/commissions-app.ts
@@ -17,6 +17,7 @@ import {
   API_KEY_CONFIG_KEY,
   GRAPHQL_PATH_KEY,
   HAPI_INJECT_CONFIG_KEY,
+  GOOGLE_TRACKING_ID_KEY,
 } from '@cityofboston/next-client-common';
 
 import {
@@ -127,6 +128,7 @@ export async function makeServer(port, rollbar: Rollbar) {
       ...config.publicRuntimeConfig,
       [GRAPHQL_PATH_KEY]: '/commissions/graphql',
       [API_KEY_CONFIG_KEY]: process.env.WEB_API_KEY,
+      [GOOGLE_TRACKING_ID_KEY]: process.env.GOOGLE_TRACKING_ID,
     };
 
     config.serverRuntimeConfig = {

--- a/services-js/registry-certs/client/lib/RouterListener.ts
+++ b/services-js/registry-certs/client/lib/RouterListener.ts
@@ -4,6 +4,7 @@ import Router from 'next/router';
 
 import Accessibility from '../store/Accessibility';
 
+// TODO(finh): Switch to next-client-common’s RouterListener and SiteAnalytics.
 export default class RouterListener {
   accessibility: Accessibility | null = null;
   router: Router | null = null;

--- a/services-js/registry-certs/client/lib/SiteAnalytics.ts
+++ b/services-js/registry-certs/client/lib/SiteAnalytics.ts
@@ -3,6 +3,7 @@ type ProductAction = 'detail' | 'add' | 'remove' | 'checkout' | 'purchase';
 type ProductCategory = 'Death certificate';
 
 // class to wrap Google Analylitcs for sending events
+// TODO(finh): Switch to next-client-common’s RouterListener and SiteAnalytics.
 export default class SiteAnalytics {
   ga: Function | null = null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,6 +1894,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/google.analytics@^0.0.39":
+  version "0.0.39"
+  resolved "http://registry.npmjs.org/@types/google.analytics/-/google.analytics-0.0.39.tgz#19a952003dbf3c7373d655a5c3203b4726b8b802"
+
 "@types/got@^7.1.7":
   version "7.1.8"
   resolved "https://registry.yarnpkg.com/@types/got/-/got-7.1.8.tgz#c5f421b25770689bf8948b1241f710d71a00d7dd"


### PR DESCRIPTION
Makes a SiteAnalytics class and Gtag and GA subclasses in
next-client-common. Links it into the existing RouterListener to send
page updates as the user clicks around.

Does not yet update registry-certs to use these new classes.