### PR TITLE
Clears build dirs when resetting templates

### DIFF
--- a/templates/js-browser-module/package.json
+++ b/templates/js-browser-module/package.json
@@ -5,7 +5,7 @@
   "license": "CC0-1.0",
   "private": true,
   "scripts": {
-    "test:reset": "rimraf ../template-test.lock",
+    "test:reset": "rimraf ./build ../template-test.lock",
     "test": "jest"
   },
   "jest": {

--- a/templates/js-server-module/package.json
+++ b/templates/js-server-module/package.json
@@ -5,7 +5,7 @@
   "license": "CC0-1.0",
   "private": true,
   "scripts": {
-    "test:reset": "rimraf ../template-test.lock",
+    "test:reset": "rimraf ./build ../template-test.lock",
     "test": "jest"
   },
   "jest": {


### PR DESCRIPTION
Sometimes the build directories don’t get deleted if tests fail or are
interrupted. This clears them out so we don’t spend additional time
compiling e.g. "@cityofboston/tmp-13450nUcY5b7XVJO0"