### PR TITLE
Changes from FormData#getAll to querySelectorAll

### DIFF
--- a/services-js/commissions-app/src/pages/commissions/apply.tsx
+++ b/services-js/commissions-app/src/pages/commissions/apply.tsx
@@ -71,7 +71,10 @@ export default class ApplyPage extends React.Component<Props, State> {
     try {
       siteAnalytics.sendEvent('submit', {
         category: 'Application',
-        value: data.getAll('commissionIds').length,
+        // We wish we could use FormData#getAll here but it’s not widely
+        // supported and can’t be polyfilled.
+        value: form.querySelectorAll('input:checked[name=commissionIds]')
+          .length,
       });
 
       const resp = await fetch('/commissions/submit', {


### PR DESCRIPTION
Unfortunately FormData#getAll isn’t implemented across browsers.

https://rollbar.com/CityofBoston/commissions-app/items/8/