### PR TITLE
Adds a form-common module for HTML form bits

### DIFF
--- a/modules-js/form-common/.babelrc
+++ b/modules-js/form-common/.babelrc
@@ -1,0 +1,18 @@
+{
+  "presets": [
+    "@cityofboston/config-babel/browser",
+    "@cityofboston/config-babel/typescript"
+  ],
+  "env": {
+    "esm": {
+      "presets": [
+        [
+          "@cityofboston/config-babel/browser",
+          {
+            "esm": true
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/modules-js/form-common/package.json
+++ b/modules-js/form-common/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@cityofboston/form-common",
+  "version": "0.0.0",
+  "description": "Utilities and helpers for HTML forms and validation",
+  "private": true,
+  "license": "CC0-1.0",
+  "main": "build/form-common.es5.js",
+  "module": "build/form-common.js",
+  "types": "build/form-common.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "watch": "concurrently \"npm run build:babel -- --watch\" \"rollup -c -w\"",
+    "prebuild": "rimraf build",
+    "build": "concurrently \"npm run build:typescript\" \"npm run build:babel && rollup -c\"",
+    "build:typescript": "tsc --emitDeclarationOnly",
+    "build:babel": "cross-env BABEL_ENV=esm babel src --out-dir build --extensions \".ts,.tsx\"",
+    "prepare": "npm run build",
+    "pretest": "tsc --noEmit",
+    "test": "jest"
+  },
+  "jest": {
+    "preset": "@cityofboston/config-jest-babel"
+  },
+  "peerDependencies": {
+    "@babel/runtime": "7.0.0",
+    "emotion": "9.2.10",
+    "react": "16.5.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "7.0.0",
+    "@babel/core": "7.0.0",
+    "@babel/runtime": "7.0.0",
+    "@cityofboston/config-babel": "^0.0.0",
+    "@cityofboston/config-jest-babel": "^0.0.0",
+    "@cityofboston/config-typescript": "^0.0.0",
+    "@types/jest": "23.x.x",
+    "babel-core": "^7.0.0-0",
+    "concurrently": "^3.5.1",
+    "cross-env": "^5.1.5",
+    "emotion": "9.2.10",
+    "jest": "23.6.0",
+    "react": "16.5.2",
+    "rimraf": "^2.6.2",
+    "rollup": "^0.60.1",
+    "typescript": "^3.1.0"
+  }
+}

--- a/modules-js/form-common/rollup.config.js
+++ b/modules-js/form-common/rollup.config.js
@@ -1,0 +1,16 @@
+// Rollup won’t package libraries in. It’s up to the bundlers (e.g. Webpack) to
+// resolve these libraries when building the apps. Since we’re in a monorepo,
+// the libraries will be available without the apps having to add the
+// dependencies themselves. Nevertheless, these should be added as both
+// peerDependencies and devDependencies in package.json, since we’re pedantic.
+const EXTERNALS = ['react', 'emotion'];
+
+export default {
+  input: 'build/form-common.js',
+  output: {
+    file: 'build/form-common.es5.js',
+    format: 'cjs',
+  },
+  // Regexp form so we can wildcard
+  external: id => /^@babel\/runtime\//.test(id) || EXTERNALS.includes(id),
+};

--- a/modules-js/form-common/src/form-common.test.ts
+++ b/modules-js/form-common/src/form-common.test.ts
@@ -1,0 +1,15 @@
+import { PHONE_REGEXP } from './form-common';
+
+describe('PHONE_REGEXP', () => {
+  it('handles no punctuation', () => {
+    expect('6175551234').toMatch(PHONE_REGEXP);
+  });
+
+  it('handles international number with punctuation', () => {
+    expect('+1 (617) 555-1234').toMatch(PHONE_REGEXP);
+  });
+
+  it('requires an area code', () => {
+    expect('555-1234').not.toMatch(PHONE_REGEXP);
+  });
+});

--- a/modules-js/form-common/src/form-common.ts
+++ b/modules-js/form-common/src/form-common.ts
@@ -1,0 +1,28 @@
+/**
+ * Creates a FormData from an object of values (e.g. from Formik). Ignores any
+ * null or undefined values. Converts any arrays into multiple values for the
+ * same key.
+ *
+ * Prefer this over using FormData’s <form> constructor, at least when optional
+ * file inputs are being used, due to a Safari 11 bug that won’t POST FormDatas
+ * that reference empty file inputs.
+ */
+export function makeFormData(values: Object): FormData {
+  const data = new FormData();
+
+  Object.keys(values).forEach(k => {
+    const v = values[k];
+    if (v === null || v === undefined) {
+      return;
+    } else if (Array.isArray(v)) {
+      v.forEach(el => data.append(k, el));
+    } else {
+      data.set(k, v);
+    }
+  });
+
+  return data;
+}
+
+// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s02.html
+export const PHONE_REGEXP = /^(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;

--- a/modules-js/form-common/tsconfig.json
+++ b/modules-js/form-common/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/@cityofboston/config-typescript/tsconfig.default.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/services-js/access-boston/package.json
+++ b/services-js/access-boston/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0",
     "@cityofboston/deploy-tools": "^0.0.0",
+    "@cityofboston/form-common": "^0.0.0",
     "@cityofboston/hapi-common": "^0.0.0",
     "@cityofboston/hapi-next": "^0.0.0",
     "@cityofboston/next-client-common": "^0.0.0",

--- a/services-js/access-boston/src/lib/validation.ts
+++ b/services-js/access-boston/src/lib/validation.ts
@@ -1,4 +1,9 @@
+// Yup requires Array.from(), but does not include the polyfill for IE
+import 'core-js/fn/array/from';
+
 import * as yup from 'yup';
+
+import { PHONE_REGEXP } from '@cityofboston/form-common';
 
 export function analyzePassword(password: string) {
   password = password || '';
@@ -105,9 +110,6 @@ const CITY_DOMAIN_REGEXPS = CITY_DOMAINS.map(
 export function testNotCityEmailAddress(val: string | undefined): boolean {
   return !val || !CITY_DOMAIN_REGEXPS.find(r => !!val.match(r));
 }
-
-// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s02.html
-const PHONE_REGEXP = /^(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
 
 export const registerDeviceSchema = yup.object().shape({
   phoneOrEmail: yup.string().oneOf(['phone', 'email']),

--- a/services-js/commissions-app/package.json
+++ b/services-js/commissions-app/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0",
     "@cityofboston/deploy-tools": "^0.0.0",
+    "@cityofboston/form-common": "^0.0.0",
     "@cityofboston/hapi-common": "^0.0.0",
     "@cityofboston/hapi-next": "^0.0.0",
     "@cityofboston/mssql-common": "^0.0.0",

--- a/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.stories.tsx
@@ -33,7 +33,6 @@ const COMMISSIONS = [
 
 const DEFAULT_PROPS: Props = {
   commissions: COMMISSIONS,
-  formRef: React.createRef(),
   values: {
     firstName: '',
     middleName: '',

--- a/services-js/commissions-app/src/client/ApplicationForm.tsx
+++ b/services-js/commissions-app/src/client/ApplicationForm.tsx
@@ -32,7 +32,6 @@ type RequiredFormikProps = Pick<
 
 export interface Props extends RequiredFormikProps {
   commissions: Commission[];
-  formRef: React.RefObject<HTMLFormElement>;
   submissionError?: boolean;
   clearSubmissionError: () => void;
 }
@@ -85,7 +84,7 @@ export default function ApplicationForm(props: Props): JSX.Element {
   );
 
   return (
-    <form onSubmit={handleSubmit} ref={props.formRef}>
+    <form onSubmit={handleSubmit}>
       <h1 className="sh-title">Boards and Commissions Application Form</h1>
 
       <p className={PARAGRAPH_STYLING}>

--- a/services-js/commissions-app/src/lib/validationSchema.ts
+++ b/services-js/commissions-app/src/lib/validationSchema.ts
@@ -2,6 +2,7 @@
 import 'core-js/fn/array/from';
 
 import * as Yup from 'yup';
+import { PHONE_REGEXP } from '@cityofboston/form-common';
 
 export interface ApplyFormValues {
   firstName: string;
@@ -22,9 +23,6 @@ export interface ApplyFormValues {
   coverLetter: File | Buffer | null;
   resume: File | Buffer | null;
 }
-
-// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s02.html
-const PHONE_REGEXP = /^(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
 
 // TODO(finh): These "max" values come from the database. We should enforce them
 // via <input> maxLength attributes rather than showing red error messages when


### PR DESCRIPTION
 - Adds a makeFormData helper so we don't need to use the FormData(form)
   constructor, which has bugs w/ Safari and empty file inputs.
 - Moves in the PHONE_REGEXP since it's a good common place for it.