### PR TITLE
Changes "prepare" to only build modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "prepublish": "lerna run --stream prepublish",
-    "prepare": "lerna run --stream prepare",
+    "prepublish": "lerna run --stream --scope @cityofboston/* prepublish",
+    "prepare": "lerna run --stream --scope @cityofboston/* prepare",
     "precommit": "lint-staged",
     "prepush": "jest --clearCache && npm run test:reset && lerna run --no-sort --stream --since origin/develop test",
     "watch": "lerna run --parallel --scope @cityofboston/* watch",


### PR DESCRIPTION
No longer builds all of the services when doing a `yarn install`, since
if you’re working on a particular app you’ll be building it anyway, and
apps don’t need to be built to have their tests run.