### PR TITLE
Runs prebuild before service tests

### DIFF
--- a/services-js/access-boston/package.json
+++ b/services-js/access-boston/package.json
@@ -14,7 +14,7 @@
     "watch-dependencies": "lerna run --parallel --scope access-boston --include-filtered-dependencies watch",
     "prepare": "npm run build",
     "start": "node build/server/start",
-    "pretest": "tsc --noEmit",
+    "pretest": "npm run prebuild && tsc --noEmit",
     "test": "npm run testcafe:local && scripts/test.js",
     "testcafe:dev": "testcafe-live remote src/**/*.testcafe.*",
     "testcafe:local": "npm run build && cross-env TEST_SERVER_URL=http://localhost:3032 PORT=3032 NODE_ENV=testcafe testcafe -a 'node build/server/start' --app-init-delay 3000 -S -s screenshots -c 3 chrome:headless src/**/*.testcafe.*",

--- a/services-js/commissions-app/package.json
+++ b/services-js/commissions-app/package.json
@@ -15,7 +15,7 @@
     "prepare": "npm run build",
     "prepare-deploy": "build-storybook -s static",
     "start": "node build/server/start",
-    "pretest": "tsc --noEmit",
+    "pretest": "npm run prebuild && tsc --noEmit",
     "test": "scripts/test.js",
     "generate-graphql-schema": "mkdir -p graphql && ts2gql src/server/graphql/schema.ts > graphql/schema.graphql",
     "generate-graphql-types": "apollo-codegen generate src/client/**/*.ts --project-name commissions-app --target typescript --output src/client/graphql/queries.d.ts && prettier --write src/client/graphql/queries.d.ts",

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prebuild": "rimraf build && npm run generate-graphql-schema && npm run generate-graphql-types",
     "dev": "npm run prebuild && tsc-watch -p tsconfig.server.json --onSuccess \"npm run start\"",
-    "pretest": "tsc --noEmit",
+    "pretest": "npm run prebuild && tsc --noEmit",
     "test": "scripts/test.js",
     "watch-dependencies": "lerna run --parallel --scope registry-certs --include-filtered-dependencies watch",
     "build": "concurrently \"npm run build:server\" \"npm run build:next\"",


### PR DESCRIPTION
prebuild creates some pregenerated files that are needed by tests.

Fixes the broken develop branch build, since without the pre-building
off apps in "prepare" it didn't have these generated files.