### PR TITLE
Backend support for birth certificates

### DIFF
--- a/services-js/registry-certs/client/queries/graphql-types.d.ts
+++ b/services-js/registry-certs/client/queries/graphql-types.d.ts
@@ -155,7 +155,7 @@ export interface SubmitDeathCertificateOrderVariables {
   billingCity: string;
   billingState: string;
   billingZip: string;
-  items: CertificateOrderItemInput[];
+  items: DeathCertificateOrderItemInput[];
   idempotencyKey: string;
 }
 
@@ -167,7 +167,7 @@ export interface SubmitDeathCertificateOrderVariables {
 //==============================================================
 
 // undefined
-export interface CertificateOrderItemInput {
+export interface DeathCertificateOrderItemInput {
   id: string;
   name: string;
   quantity: number;

--- a/services-js/registry-certs/client/queries/submit-death-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-death-certificate-order.ts
@@ -27,7 +27,7 @@ const QUERY = gql`
     $billingCity: String!
     $billingState: String!
     $billingZip: String!
-    $items: [CertificateOrderItemInput!]!
+    $items: [DeathCertificateOrderItemInput!]!
     $idempotencyKey: String!
   ) {
     submitDeathCertificateOrder(

--- a/services-js/registry-certs/lib/costs.ts
+++ b/services-js/registry-certs/lib/costs.ts
@@ -1,6 +1,7 @@
 // All costs are in cents, which is how Stripe does things.
 
 export const DEATH_CERTIFICATE_COST = 14 * 100;
+export const BIRTH_CERTIFICATE_COST = 14 * 100;
 
 // CC == "credit card"
 export const FIXED_CC_SERVICE_FEE = 25;

--- a/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
+++ b/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
@@ -66,12 +66,15 @@ GraphQLSchema {
   "_queryType": "Query",
   "_subscriptionType": null,
   "_typeMap": Object {
+    "BirthCertificateOrderItemInput": "BirthCertificateOrderItemInput",
+    "BirthCertificateSearch": "BirthCertificateSearch",
+    "BirthCertificates": "BirthCertificates",
     "Boolean": "Boolean",
     "CertificateOrderItem": "CertificateOrderItem",
-    "CertificateOrderItemInput": "CertificateOrderItemInput",
     "Date": "Date",
     "DeathCertificate": "DeathCertificate",
     "DeathCertificateOrder": "DeathCertificateOrder",
+    "DeathCertificateOrderItemInput": "DeathCertificateOrderItemInput",
     "DeathCertificateSearch": "DeathCertificateSearch",
     "DeathCertificates": "DeathCertificates",
     "Float": "Float",
@@ -93,28 +96,28 @@ GraphQLSchema {
     "directives": Array [],
     "kind": "SchemaDefinition",
     "loc": Object {
-      "end": 2123,
-      "start": 2077,
+      "end": 3093,
+      "start": 3047,
     },
     "operationTypes": Array [
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 2106,
-          "start": 2088,
+          "end": 3076,
+          "start": 3058,
         },
         "operation": "mutation",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 2106,
-            "start": 2098,
+            "end": 3076,
+            "start": 3068,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2106,
-              "start": 2098,
+              "end": 3076,
+              "start": 3068,
             },
             "value": "Mutation",
           },
@@ -123,21 +126,21 @@ GraphQLSchema {
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 2121,
-          "start": 2109,
+          "end": 3091,
+          "start": 3079,
         },
         "operation": "query",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 2121,
-            "start": 2116,
+            "end": 3091,
+            "start": 3086,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2121,
-              "start": 2116,
+              "end": 3091,
+              "start": 3086,
             },
             "value": "Query",
           },

--- a/services-js/registry-certs/server/graphql/__snapshots__/mutation.test.ts.snap
+++ b/services-js/registry-certs/server/graphql/__snapshots__/mutation.test.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Mutation resolvers submitBirthCertificateOrder throws if a validator fails 1`] = `[Error: contactName: The full name field is required.]`;
+
+exports[`Mutation resolvers submitBirthCertificateOrder throws if search fails to find 1`] = `[TypeError: Cannot read property 'length' of undefined]`;
+
 exports[`Mutation resolvers submitDeathCertificateOrder throws if a validator fails 1`] = `[Error: contactName: The full name field is required.]`;
 
 exports[`Mutation resolvers submitDeathCertificateOrder throws if there are no items 1`] = `[Error: Quantity of order is 0]`;

--- a/services-js/registry-certs/server/graphql/birth-certificates.ts
+++ b/services-js/registry-certs/server/graphql/birth-certificates.ts
@@ -1,0 +1,48 @@
+import {
+  Resolvers,
+  ResolvableWith,
+  Int,
+} from '@cityofboston/graphql-typescript';
+
+import { Context } from './index';
+
+export interface BirthCertificateSearch {
+  /**
+   * The only information we want to reveal for a search is how many
+   * non-restricted records it matched. That way we don’t leak more info than
+   * the user supplied in their search.
+   */
+  count: Int;
+}
+
+export interface BirthCertificates extends ResolvableWith<{}> {
+  search(args: {
+    firstName: string;
+    lastName: string;
+    dob: Date;
+    parent1FirstName: string;
+    parent2FirstName?: string;
+  }): BirthCertificateSearch;
+}
+
+const birthCertificatesResolvers: Resolvers<BirthCertificates, Context> = {
+  search: async (
+    _root,
+    { firstName, lastName, dob, parent1FirstName, parent2FirstName },
+    { registryDb }
+  ) => {
+    return {
+      count: (await registryDb.searchBirthCertificates(
+        firstName,
+        lastName,
+        dob,
+        parent1FirstName,
+        parent2FirstName || null
+      )).length,
+    };
+  },
+};
+
+export const resolvers = {
+  BirthCertificates: birthCertificatesResolvers,
+};

--- a/services-js/registry-certs/server/graphql/index.ts
+++ b/services-js/registry-certs/server/graphql/index.ts
@@ -7,6 +7,7 @@ import Rollbar from 'rollbar';
 import { Query, resolvers as queryResolvers } from './query';
 import { Mutation, resolvers as mutationResolvers } from './mutation';
 import { resolvers as deathResolvers } from './death-certificates';
+import { resolvers as birthResolvers } from './birth-certificates';
 
 import RegistryDb from '../services/RegistryDb';
 import Emails from '../services/Emails';
@@ -37,6 +38,7 @@ export default makeExecutableSchema({
     ...queryResolvers,
     ...mutationResolvers,
     ...deathResolvers,
+    ...birthResolvers,
   } as any,
   allowUndefinedInResolve: false,
 });

--- a/services-js/registry-certs/server/graphql/mutation.test.ts
+++ b/services-js/registry-certs/server/graphql/mutation.test.ts
@@ -1,4 +1,7 @@
 import { resolvers } from './mutation';
+import RegistryDb from '../services/RegistryDb';
+
+jest.mock('../services/RegistryDb');
 
 const DEFAULT_ORDER = {
   contactName: 'Nancy Whitehead',
@@ -23,15 +26,24 @@ const DEFAULT_ORDER = {
   billingState: 'NY',
   billingZip: '10021',
 
-  items: [
-    {
-      id: '12345',
-      name: '',
-      quantity: 10,
-    },
-  ],
-
   idempotencyKey: '1234abcd',
+};
+
+const DEFAULT_DEATH_ITEMS = [
+  {
+    id: '12345',
+    name: '',
+    quantity: 10,
+  },
+];
+
+const DEFAULT_BIRTH_ITEM = {
+  firstName: 'Danielle',
+  lastName: 'Cage',
+  dob: new Date('01 March 2006 00:00:00 GMT'),
+  parent1FirstName: 'Jessica',
+  parent2FirstName: 'Luke',
+  quantity: 10,
 };
 
 describe('Mutation resolvers', () => {
@@ -42,6 +54,8 @@ describe('Mutation resolvers', () => {
           {},
           {
             ...DEFAULT_ORDER,
+
+            items: DEFAULT_DEATH_ITEMS,
             contactName: '',
           },
           {} as any
@@ -92,11 +106,120 @@ describe('Mutation resolvers', () => {
       );
       chargesCreate.mockReturnValue(Promise.resolve({ id: 'ch_12345' }));
 
-      await resolvers.Mutation.submitDeathCertificateOrder({}, DEFAULT_ORDER, {
-        stripe,
-        registryDb,
-        emails,
-      } as any);
+      await resolvers.Mutation.submitDeathCertificateOrder(
+        {},
+        { ...DEFAULT_ORDER, items: DEFAULT_DEATH_ITEMS },
+        {
+          stripe,
+          registryDb,
+          emails,
+        } as any
+      );
+
+      expect(chargesCreate).toHaveBeenCalledWith({
+        amount: 14326,
+        currency: 'usd',
+        source: 'tok_test',
+        description: 'Death certificates (Registry)',
+        statement_descriptor: 'CITYBOSTON*REG + FEE',
+        metadata: expect.objectContaining({
+          'webapp.name': 'registry-certs',
+          'webapp.nodeEnv': 'test',
+          'order.orderId': expect.any(String),
+          'order.orderKey': '25',
+          'order.orderType': 'DC',
+          'order.quantity': '10',
+          'order.unitPrice': '1400',
+        }),
+      });
+    });
+  });
+
+  describe('submitBirthCertificateOrder', () => {
+    let registryDb: jest.Mocked<RegistryDb>;
+
+    beforeEach(() => {
+      registryDb = new RegistryDb(null as any) as any;
+    });
+
+    it('throws if a validator fails', async () => {
+      registryDb.searchBirthCertificates.mockReturnValue([]);
+
+      await expect(
+        resolvers.Mutation.submitBirthCertificateOrder(
+          {},
+          {
+            ...DEFAULT_ORDER,
+            item: DEFAULT_BIRTH_ITEM,
+            contactName: '',
+          },
+          { registryDb } as any
+        )
+      ).rejects.toMatchSnapshot();
+    });
+
+    it('throws if search fails to find', async () => {
+      await expect(
+        resolvers.Mutation.submitBirthCertificateOrder(
+          {},
+          {
+            ...DEFAULT_ORDER,
+            item: DEFAULT_BIRTH_ITEM,
+          },
+          { registryDb: new RegistryDb(null as any) } as any
+        )
+      ).rejects.toMatchSnapshot();
+    });
+
+    it('sends a charge to Stripe', async () => {
+      const tokensRetrieve = jest.fn();
+      const chargesCreate = jest.fn();
+
+      const stripe: any = {
+        charges: {
+          create: chargesCreate,
+        },
+        tokens: {
+          retrieve: tokensRetrieve,
+        },
+      };
+
+      const registryDb = {
+        addOrder: jest.fn(),
+        addItem: jest.fn(),
+        addPayment: jest.fn(),
+      };
+
+      const emails = {
+        sendReceiptEmail: jest.fn(),
+      };
+
+      registryDb.addOrder.mockReturnValue(Promise.resolve(25));
+
+      tokensRetrieve.mockReturnValue(
+        Promise.resolve({ card: { funding: 'credit' } })
+      );
+      chargesCreate.mockReturnValue(Promise.resolve({ id: 'ch_12345' }));
+
+      await resolvers.Mutation.submitDeathCertificateOrder(
+        {},
+        {
+          ...DEFAULT_ORDER,
+          items: [
+            {
+              id: '12345',
+              name: '',
+              quantity: 10,
+            },
+          ],
+        },
+
+        {
+          stripe,
+          registryDb,
+          emails,
+        } as any
+      );
 
       expect(chargesCreate).toHaveBeenCalledWith({
         amount: 14326,

--- a/services-js/registry-certs/server/graphql/query.ts
+++ b/services-js/registry-certs/server/graphql/query.ts
@@ -1,13 +1,16 @@
 import { Resolvers, ResolvableWith } from '@cityofboston/graphql-typescript';
 import { DeathCertificates } from './death-certificates';
+import { BirthCertificates } from './birth-certificates';
 import { Context } from '.';
 
 export interface Query extends ResolvableWith<{}> {
   deathCertificates: DeathCertificates;
+  birthCertificates: BirthCertificates;
 }
 
 const queryResolvers: Resolvers<Query, Context> = {
   deathCertificates: () => ({}),
+  birthCertificates: () => ({}),
 };
 
 export const resolvers = {

--- a/services-js/registry-certs/server/services/RegistryDb.ts
+++ b/services-js/registry-certs/server/services/RegistryDb.ts
@@ -14,6 +14,7 @@ const readFile = promisify(fs.readFile);
 
 export enum OrderType {
   DeathCertificate = 'DC',
+  BirthCertificate = 'BC',
 }
 
 export interface DeathCertificate {
@@ -31,6 +32,18 @@ export interface DeathCertificate {
 
 export interface DeathCertificateSearchResult extends DeathCertificate {
   ResultCount: number;
+}
+
+export interface BirthCertificate {
+  CertificatesID: number;
+  'Registered Number': string;
+  InOut: boolean;
+  'Date of Birth': string;
+  'Certificate Name': string;
+  'Last Name': string;
+  'First Name': string;
+  RegisteredYear: string;
+  Impounded: boolean;
 }
 
 export interface AddOrderOptions {
@@ -201,6 +214,37 @@ export default class RegistryDb {
     });
 
     return keys.map(k => idToOutputMap[k]);
+  }
+
+  /**
+   * This method purposely only returns the ID so that we can’t accidentally
+   * leak any additional name information from out of the database.
+   *
+   * This forces the UI to only display names provided by the user.
+   */
+  async searchBirthCertificates(
+    firstName: string,
+    lastName: string,
+    dob: Date,
+    parent1FirstName: string,
+    parent2FirstName: string | null
+  ): Promise<Array<number>> {
+    const resp: IResult<BirthCertificate> = (await this.pool
+      .request()
+      .input('firstName', firstName)
+      .input('lastName', lastName)
+      .input('DOB', dob)
+      .input('parent1FirstName', parent1FirstName)
+      .input('parent2FirstName', parent2FirstName)
+      .execute('Registry.Birth.sp_FindCertificatesWeb')) as any;
+
+    const { recordset } = resp;
+
+    if (!recordset) {
+      throw new Error('Recordset for search came back empty');
+    }
+
+    return recordset.map(({ CertificatesID }) => CertificatesID);
   }
 
   async addOrder(

--- a/services-js/registry-certs/server/services/RegistryDbFake.ts
+++ b/services-js/registry-certs/server/services/RegistryDbFake.ts
@@ -38,4 +38,15 @@ export default class RegistryDbFake implements Required<RegistryDb> {
   }
 
   async cancelOrder(): Promise<void> {}
+
+  async searchBirthCertificates(firstName: string): Promise<Array<number>> {
+    const count = firstName.match(/\d+/) ? parseInt(firstName, 10) : 1;
+
+    const out: number[] = [];
+    for (let i = 0; i < count; ++i) {
+      out.push(i + 244000);
+    }
+
+    return out;
+  }
 }


### PR DESCRIPTION
 - Adds birth certificate search stored procedure to RegistryDb
 - Adds birth certificate search resolvers to GraphQL
 - Refactors order submission to share code between birth and death
   certificates: validating addresses, calculating costs, making Stripe
   charges.
 - Adds an "order.orderType" value to the Stripe charge so that the
   payment webhook can interpret it.