### PR TITLE
Server startup changes for ECS support

### DIFF
--- a/services-js/internal-slack-bot/src/server/index.ts
+++ b/services-js/internal-slack-bot/src/server/index.ts
@@ -20,7 +20,7 @@ const rollbar = new Rollbar({
 
 const start = require('./server').default;
 
-start(process.env.PORT || 8000, rollbar).catch(err => {
+start(parseInt(process.env.PORT || '8000', 10), rollbar).catch(err => {
   console.error('Error starting server', err);
   process.exit(1);
 });

--- a/services-js/internal-slack-bot/src/server/server.ts
+++ b/services-js/internal-slack-bot/src/server/server.ts
@@ -27,7 +27,6 @@ import {
 export async function makeServer(port: number, rollbar: Rollbar) {
   const serverOptions = {
     port,
-    host: 'localhost',
     ...(process.env.USE_SSL
       ? {
           tls: {


### PR DESCRIPTION
 - Removes explicit "localhost" to make sure we bind to whatever
   interfaces are available in the container.
 - Parses the PORT environment variable to a number.