### PR TITLE
Removes template test parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,18 @@ jobs:
   - stage: test
     if: type IN (push)
     install: yarn install --frozen-lockfile
-    script: yarn run test
+    script:
+    - yarn run test
+    - yarn run test:templates
   - if: type IN (pull_request)
     install:
     - gem install travis-artifacts
     - yarn install --frozen-lockfile --ignore-scripts
     - lerna run --stream --since $TRAVIS_PULL_REQUEST_SHA^1 --include-filtered-dependencies
       prepare
-    script: yarn run test:since $TRAVIS_PULL_REQUEST_SHA^1
+    script:
+    - yarn run test:since $TRAVIS_PULL_REQUEST_SHA^1
+    - yarn run test:templates:since $TRAVIS_PULL_REQUEST_SHA^1
     after_failure:
     - travis-artifacts upload --path services-js/access-boston/screenshots --target-path
       travis/screenshots/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "prepublish": "lerna run --stream --scope @cityofboston/* prepublish",
     "prepare": "lerna run --stream --scope @cityofboston/* prepare",
     "precommit": "lint-staged",
-    "prepush": "jest --clearCache && npm run test:reset && lerna run --no-sort --stream --since origin/develop test",
+    "prepush": "jest --clearCache && lerna run --no-sort --stream --since origin/develop --ignore js-*-module test",
     "watch": "lerna run --parallel --scope @cityofboston/* watch",
-    "test": "npm run test:reset && lerna run --no-sort test --",
-    "test:reset": "lerna run --parallel test:reset",
-    "test:since": "lerna run test --no-sort --since"
+    "test": "lerna run --no-sort --ignore js-*-module test --",
+    "test:since": "lerna run test --no-sort --ignore js-*-module --since",
+    "test:templates": "lerna run --no-sort --concurrency 1 --stream --scope js-*-module test --",
+    "test:templates:since": "lerna run test --no-sort --concurrency 1 --stream --scope js-*-module --since"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --quiet"

--- a/templates/js-browser-module/package.json
+++ b/templates/js-browser-module/package.json
@@ -5,7 +5,6 @@
   "license": "CC0-1.0",
   "private": true,
   "scripts": {
-    "test:reset": "rimraf ./build ../template-test.lock",
     "test": "jest"
   },
   "jest": {
@@ -25,7 +24,6 @@
     "@types/node": "^8.0.0",
     "jest": "23.6.0",
     "khaos": "^0.9.3",
-    "lockfile": "^1.0.4",
     "rimraf": "^2.6.2",
     "shelljs": "^0.8.1",
     "tmp": "^0.0.33",

--- a/templates/js-server-module/package.json
+++ b/templates/js-server-module/package.json
@@ -5,7 +5,6 @@
   "license": "CC0-1.0",
   "private": true,
   "scripts": {
-    "test:reset": "rimraf ./build ../template-test.lock",
     "test": "jest"
   },
   "jest": {
@@ -25,7 +24,6 @@
     "@types/node": "^8.0.0",
     "jest": "23.6.0",
     "khaos": "^0.9.3",
-    "lockfile": "^1.0.4",
     "rimraf": "^2.6.2",
     "shelljs": "^0.8.1",
     "tmp": "^0.0.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12706,12 +12706,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lockfile@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
-  dependencies:
-    signal-exit "^3.0.2"
-
 lodash-node@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash-node/-/lodash-node-2.4.1.tgz#ea82f7b100c733d1a42af76801e506105e2a80ec"


### PR DESCRIPTION
The template tests do Yarn installs, which can interfere with other
tests if they're running at the same time.

This runs the template tests separately on CI, and not at all during
pushes. Changes to use --concurrency lerna flag to make only one run at
a time, so we can remove the lockfile hacks that previously prevented
the templates from stomping each other.