### PR TITLE
Makes production deploys use the Slack bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
 stages:
 - name: test
   if: branch !~ /^staging\//
-- name: deploy
-  if: branch =~ /^production\//  AND type IN (push, api)
 jobs:
   include:
   - stage: test
@@ -28,6 +26,13 @@ jobs:
     script:
     - yarn run test
     - yarn run test:templates
+    deploy:
+      provider: script
+      skip_cleanup: true
+      script:
+      - lerna exec --stream --scope @cityofboston/deploy-tools report-updated-services
+      on:
+      - develop
   - if: type IN (pull_request)
     install:
     - gem install travis-artifacts
@@ -40,30 +45,6 @@ jobs:
     after_failure:
     - travis-artifacts upload --path services-js/access-boston/screenshots --target-path
       travis/screenshots/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID
-  - stage: deploy
-    install:
-      - yarn install --frozen-lockfile --ignore-scripts
-      - npx lerna run --stream --scope @cityofboston/deploy-tools --include-filtered-dependencies
-        prepare
-    script: skip
-    deploy:
-      provider: script
-      skip_cleanup: true
-      script: deploy/travis-deploy.sh
-      on:
-        all_branches: true
-  # - stage: stage
-  #   install:
-  #     - yarn install --frozen-lockfile --ignore-scripts
-  #     - npx lerna run --stream --scope @cityofboston/deploy-tools --include-filtered-dependencies
-  #       prepare
-  #   script: skip
-  #   deploy:
-  #     provider: script
-  #     skip_cleanup: true
-  #     script: lerna exec --stream --scope @cityofboston/deploy-tools report-updated-services
-  #     on:
-  #       all_branches: true
 notifications:
   slack:
     on_success: always

--- a/scripts/service-entrypoint.sh
+++ b/scripts/service-entrypoint.sh
@@ -22,17 +22,6 @@ fi
 # Useful for debugging the AWS syncs
 ls
 
-# If we installed any SSH keys, install them to where they’ll be found.
-if [ -e id_rsa ]; then
-  mkdir -p /root/.ssh
-  chmod 700 /root/.ssh
-
-  cp id_rsa* /root/.ssh
-
-  chmod 644 /root/.ssh/id_rsa.pub
-  chmod 600 /root/.ssh/id_rsa
-fi
-
 echo "entrypoint.sh: command"
 
 exec "$@"

--- a/services-js/internal-slack-bot/.env.sample
+++ b/services-js/internal-slack-bot/.env.sample
@@ -10,6 +10,8 @@ SLACK_SIGNING_SECRET=
 # Find this by visiting the Slack channel in your browser and checking the URL
 WORKSPACE_CHANNEL_ID_DIGITAL_BUILDS=
 
+GITHUB_USERNAME=
+GITHUB_ACCESS_TOKEN=
 GITHUB_WEBHOOK_SECRET=
 
 API_KEYS=

--- a/services-js/internal-slack-bot/src/server/server.ts
+++ b/services-js/internal-slack-bot/src/server/server.ts
@@ -95,7 +95,11 @@ export async function makeServer(port: number, rollbar: Rollbar) {
 
   const deploymentInteraction = new DeploymentInteraction(
     slackClient,
-    process.env.WORKSPACE_CHANNEL_ID_DIGITAL_BUILDS!
+    process.env.WORKSPACE_CHANNEL_ID_DIGITAL_BUILDS!,
+    {
+      username: process.env.GITHUB_USERNAME,
+      password: process.env.GITHUB_ACCESS_TOKEN,
+    }
   );
 
   await server.register(loggingPlugin);


### PR DESCRIPTION
Adds code to call the GitHub API to move the branch to the new commit
before triggering CodeBuild.

Updates .travis.yml to have the notifications to the bot be the deploy
part of the test stage to avoid needing to re-install node dependencies
(and since develop is now the only branch Travis cares about).