### PR TITLE
Removes depth limit for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: node_js
 env:
 - TZ=America/New_York
 git:
-  depth: 500
+  depth: false
 cache: yarn
 branches:
   only:


### PR DESCRIPTION
Allows us to do a full "since" check for Lerna packages.