### PR TITLE
Makes the header selectors tolerant of no CSS

### DIFF
--- a/services-js/access-boston/src/integration/forgot-password.testcafe.ts
+++ b/services-js/access-boston/src/integration/forgot-password.testcafe.ts
@@ -12,7 +12,7 @@ test('Login does not apply to regular site', async t => {
   await loginPage.logIn(t, 'CON02141');
 
   const page = new PageModel();
-  await t.expect(page.sectionHeader.innerText).contains('FORGOT PASSWORD');
+  await t.expect(page.sectionHeader.withText('FORGOT PASSWORD').exists).ok();
 
   // Even though we logged in through the "forgot" flow, we won't be logged in
   // in the main app so going to the homepage should put us on the other login

--- a/services-js/access-boston/src/integration/registration-flow.testcafe.ts
+++ b/services-js/access-boston/src/integration/registration-flow.testcafe.ts
@@ -18,8 +18,10 @@ test('Registration with new password and MFA', async t => {
 
   const registerPage = new PageModel();
   await t
-    .expect(registerPage.sectionHeader.innerText)
-    .contains('WELCOME TO ACCESS BOSTON!');
+    .expect(
+      registerPage.sectionHeader.withText('WELCOME TO ACCESS BOSTON!').exists
+    )
+    .ok();
 
   await t.click(Selector('.btn').withText('GET STARTED'));
 
@@ -51,8 +53,10 @@ test('Registration with just new password', async t => {
 
   const registerPage = new PageModel();
   await t
-    .expect(registerPage.sectionHeader.innerText)
-    .contains('WELCOME TO ACCESS BOSTON!');
+    .expect(
+      registerPage.sectionHeader.withText('WELCOME TO ACCESS BOSTON!').exists
+    )
+    .ok();
 
   await t.click(Selector('.btn').withText('GET STARTED'));
 


### PR DESCRIPTION
By switching to 'withText', TestCafe will wait until there are elements
that match that text, rather than exploding immediately if the CSS isn’t
loaded (meaning the text is not yet all-caps).