### PR TITLE
Changes staging deploys to update task definitions

### DIFF
--- a/modules-js/deploy-tools/package.json
+++ b/modules-js/deploy-tools/package.json
@@ -9,6 +9,7 @@
     "prebuild": "rimraf build",
     "build": "tsc",
     "prepare": "npm run build",
+    "pretest": "tsc --noEmit",
     "test": "jest --passWithNoTests"
   },
   "bin": {

--- a/modules-js/deploy-tools/src/travis-service-deploy.ts
+++ b/modules-js/deploy-tools/src/travis-service-deploy.ts
@@ -14,7 +14,7 @@ import {
   pushImage,
   dockerAwsLogin,
   updateStagingService,
-  updateProdService,
+  updateEcsService,
   waitForDeployment,
   deregisterTaskDefinition,
   updateServiceTaskDefinition,
@@ -135,7 +135,11 @@ const cacheTag = 'latest';
   } else {
     console.error(`🎟 Updating production service ${serviceName}…`);
 
-    const result = await updateProdService(serviceName, versionedTag);
+    const result = await updateEcsService(
+      environment,
+      serviceName,
+      versionedTag
+    );
     console.error();
 
     service = result.service;


### PR DESCRIPTION
Allows us to roll back staging deploys when they fail. Previously we
just updated the container tag and forced a deploy, but when things
didn’t start up the service would flap indefinitely, eventually eating
up the host’s space.

This makes staging deploys work like production. The only change will be
more task definition versions, which shouldn’t be a big deal.