### PR TITLE
Make indexer sensitive to meta failures

### DIFF
--- a/services-js/311-indexer/README.md
+++ b/services-js/311-indexer/README.md
@@ -25,6 +25,10 @@ Copy `.env.default` to `.env` and modify any necessary values.
  1. Run `npm run-script elasticsearch-start`
  1. Run `npx ts-node server/scripts/elasticsearch-init.ts`
 
+### Debugging
+
+ * With Charles: `env NODE_TLS_REJECT_UNAUTHORIZED=0 http_proxy=http://localhost:8888/ npm run dev`
+
 ### Bulk Import
 
 Local: `npx ts-node server/scripts/import-cases.ts 20170501 20171016`

--- a/services-js/311-indexer/package.json
+++ b/services-js/311-indexer/package.json
@@ -23,7 +23,7 @@
     "@babel/runtime": "7.0.0",
     "@cityofboston/srv-decrypt-env": "^0.0.0",
     "aws-sdk": "^2.100.0",
-    "cometd": "^3.1.2",
+    "cometd": "^3.1.5",
     "cometd-nodejs-client": "^1.0.1",
     "dotenv": "^5.0.0",
     "elasticsearch": "^14.0.0",

--- a/services-js/311-indexer/server/index.ts
+++ b/services-js/311-indexer/server/index.ts
@@ -7,10 +7,15 @@ console.log('----- SERVER STARTUP -----');
 
 require('dotenv').config();
 const opbeat = require('opbeat/start');
+const HttpsProxyAgent = require('https-proxy-agent');
 
 // This monkeypatches the environment to add window and an XMLHttpRequest
 // implementation.
-require('cometd-nodejs-client').adapt();
+require('./vendor/cometd-nodejs-client').adapt(
+  process.env.http_proxy
+    ? () => new HttpsProxyAgent(process.env.http_proxy)
+    : undefined
+);
 
 // The above 'adapt' creates a window object because the cometd JS library
 // assumes a browser environment. But, the RxJS library prefers "window" as its

--- a/services-js/311-indexer/server/services/Elasticsearch.ts
+++ b/services-js/311-indexer/server/services/Elasticsearch.ts
@@ -1,4 +1,5 @@
 import AWS from 'aws-sdk';
+import HttpsProxyAgent from 'https-proxy-agent';
 import elasticsearch, {
   SearchResponse,
   BulkIndexDocumentsParams,
@@ -130,6 +131,9 @@ export default class Elasticsearch {
     this.client = new elasticsearch.Client({
       host: url,
       connectionClass: url.endsWith('.amazonaws.com') ? HttpAwsEs : undefined,
+      createNodeAgent: process.env.http_proxy
+        ? () => new HttpsProxyAgent(process.env.http_proxy)
+        : undefined,
     });
 
     this.index = index;

--- a/services-js/311-indexer/server/services/Open311.ts
+++ b/services-js/311-indexer/server/services/Open311.ts
@@ -3,6 +3,7 @@ import URLSearchParams from 'url-search-params';
 import url from 'url';
 import HttpsProxyAgent from 'https-proxy-agent';
 import moment from 'moment';
+
 export interface Case {
   service_request_id: string;
   status: string;

--- a/services-js/311-indexer/server/vendor/cometd-nodejs-client.js
+++ b/services-js/311-indexer/server/vendor/cometd-nodejs-client.js
@@ -1,0 +1,186 @@
+// vendored 11/28/19 by Fin Hopkins from https://github.com/cometd/cometd-nodejs-client
+// under the terms of the Apache license.
+//
+// Modified to add the "makeAgent" function that allows for an HTTP proxy.
+
+module.exports = {
+  adapt: function(makeAgent) {
+    var url = require('url');
+    var httpc = require('http');
+    var https = require('https');
+
+    global.window = {};
+
+    window.setTimeout = setTimeout;
+    window.clearTimeout = clearTimeout;
+
+    window.console = console;
+    window.console.debug = window.console.log;
+
+    // Fields shared by all XMLHttpRequest instances.
+    var _agentc = new httpc.Agent({
+      keepAlive: true,
+    });
+    var _agents = new https.Agent({
+      keepAlive: true,
+    });
+    var _globalCookies = {};
+
+    function _secure(uri) {
+      return /^https/i.test(uri.protocol);
+    }
+
+    // Bare minimum XMLHttpRequest implementation that works with CometD.
+    window.XMLHttpRequest = function() {
+      var _localCookies = {};
+      var _config;
+      var _request;
+
+      function _storeCookie(cookieStore, value) {
+        var host = _config.hostname;
+        var jar = cookieStore[host];
+        if (jar === undefined) {
+          cookieStore[host] = jar = {};
+        }
+        var cookies = value.split(';');
+        for (var i = 0; i < cookies.length; ++i) {
+          var cookie = cookies[i].trim();
+          var equal = cookie.indexOf('=');
+          if (equal > 0) {
+            jar[cookie.substring(0, equal)] = cookie;
+          }
+        }
+      }
+
+      function _concatCookies(cookieStore) {
+        var cookies = '';
+        var jar = cookieStore[_config.hostname];
+        if (jar) {
+          for (var name in jar) {
+            if (jar.hasOwnProperty(name)) {
+              if (cookies) {
+                cookies += '; ';
+              }
+              cookies += jar[name];
+            }
+          }
+        }
+        return cookies;
+      }
+
+      this.status = 0;
+      this.statusText = '';
+      this.readyState = window.XMLHttpRequest.UNSENT;
+      this.responseText = '';
+
+      this.open = function(method, uri) {
+        _config = url.parse(uri);
+        _config.method = method;
+        _config.agent = makeAgent
+          ? makeAgent(_secure(_config))
+          : _secure(_config)
+            ? _agents
+            : _agentc;
+        _config.headers = {};
+        this.readyState = window.XMLHttpRequest.OPENED;
+      };
+
+      this.setRequestHeader = function(name, value) {
+        if (/^cookie$/i.test(name)) {
+          _storeCookie(_localCookies, value);
+        } else {
+          _config.headers[name] = value;
+        }
+      };
+
+      this.send = function(data) {
+        var globalCookies = this.context && this.context.cookieStore;
+        if (!globalCookies) {
+          globalCookies = _globalCookies;
+        }
+        var cookies1 = _concatCookies(globalCookies);
+        var cookies2 = _concatCookies(_localCookies);
+        var delim = cookies1 && cookies2 ? '; ' : '';
+        var cookies = cookies1 + delim + cookies2;
+        if (cookies) {
+          _config.headers['Cookie'] = cookies;
+        }
+
+        var self = this;
+        var http = _secure(_config) ? https : httpc;
+        _request = http.request(_config, function(response) {
+          var success = false;
+          self.status = response.statusCode;
+          self.statusText = response.statusMessage;
+          self.readyState = window.XMLHttpRequest.HEADERS_RECEIVED;
+          var headers = response.headers;
+          for (var name in headers) {
+            if (headers.hasOwnProperty(name)) {
+              if (/^set-cookie$/i.test(name)) {
+                var header = headers[name];
+                for (var i = 0; i < header.length; ++i) {
+                  var whole = header[i];
+                  var parts = whole.split(';');
+                  var cookie = parts[0];
+                  _storeCookie(globalCookies, cookie);
+                }
+              }
+            }
+          }
+          response.on('data', function(chunk) {
+            self.readyState = window.XMLHttpRequest.LOADING;
+            self.responseText += chunk;
+          });
+          response.on('end', function() {
+            success = true;
+            self.readyState = window.XMLHttpRequest.DONE;
+            if (self.onload) {
+              self.onload();
+            }
+          });
+          response.on('close', function() {
+            if (!success) {
+              self.readyState = window.XMLHttpRequest.DONE;
+              if (self.onerror) {
+                self.onerror();
+              }
+            }
+          });
+        });
+        ['abort', 'aborted', 'error'].forEach(function(event) {
+          _request.on(event, function(x) {
+            self.readyState = window.XMLHttpRequest.DONE;
+            if (x) {
+              var error = x.message;
+              if (error) {
+                self.statusText = error;
+              }
+            }
+            if (self.onerror) {
+              self.onerror(x);
+            }
+          });
+        });
+        if (data) {
+          _request.write(data);
+        }
+        _request.end();
+      };
+
+      this.abort = function() {
+        if (_request) {
+          _request.abort();
+        }
+      };
+
+      this._config = function() {
+        return _config;
+      };
+    };
+    window.XMLHttpRequest.UNSENT = 0;
+    window.XMLHttpRequest.OPENED = 1;
+    window.XMLHttpRequest.HEADERS_RECEIVED = 2;
+    window.XMLHttpRequest.LOADING = 3;
+    window.XMLHttpRequest.DONE = 4;
+  },
+};

--- a/services-js/311-indexer/server/vendor/cometd-nodejs-client.js
+++ b/services-js/311-indexer/server/vendor/cometd-nodejs-client.js
@@ -1,4 +1,4 @@
-// vendored 11/28/19 by Fin Hopkins from https://github.com/cometd/cometd-nodejs-client
+// vendored 11/28/18 by Fin Hopkins from https://github.com/cometd/cometd-nodejs-client
 // under the terms of the Apache license.
 //
 // Modified to add the "makeAgent" function that allows for an HTTP proxy.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,9 +5922,10 @@ cometd-nodejs-client@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cometd-nodejs-client/-/cometd-nodejs-client-1.0.2.tgz#eb04cfa953a508257487f4800a725a5cd735fe27"
 
-cometd@^3.1.2:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cometd/-/cometd-3.1.4.tgz#a379d7c1067cbf7aa6b513f22c2bc5e83467fda0"
+cometd@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cometd/-/cometd-3.1.5.tgz#104d5a39932375704df37d83dbd6eb2b2f34defa"
+  integrity sha512-PCx8hWFOO0tw+lDm/yKQ+RiqLNCw9QWnmO+Ji3VPVKk1zMUIHbnIo4MaiDYobKR1Z/kvgOkxi7q4x8rngjoCoQ==
 
 commander@2.11.x:
   version "2.11.0"


### PR DESCRIPTION
This throws an error when a meta message is a failure, such as when
Salesforce errors during a long-poll reconnect. Previously these were
ignored and we just stopped receiving messages.

Updates the error handling to complete the RxJS stream rather than
immediately quit, which allows existing processing to cleanly complete.

Also updates to latest bugfix version of Comet 3.1 line and adds http
proxy support in more places for better debugging with Charles.