### PR TITLE
Mechanical transform from RxJS 5 to 6

### DIFF
--- a/services-js/311-indexer/package.json
+++ b/services-js/311-indexer/package.json
@@ -35,7 +35,7 @@
     "node-cleanup": "^2.1.2",
     "node-fetch": "^2.0.0",
     "opbeat": "^4.14.2",
-    "rxjs": "^5.5.12",
+    "rxjs": "^6.3.3",
     "url-search-params": "^0.10.0"
   },
   "devDependencies": {

--- a/services-js/311-indexer/server/stages/index-cases.ts
+++ b/services-js/311-indexer/server/stages/index-cases.ts
@@ -1,4 +1,5 @@
-import Rx from 'rxjs';
+import * as Rx from 'rxjs';
+import { bufferTime, tap, filter } from 'rxjs/operators';
 import Elasticsearch from '../services/Elasticsearch';
 import { HydratedCaseRecord } from './types';
 import {
@@ -17,33 +18,31 @@ interface Deps {
 export default ({ elasticsearch, opbeat }: Deps) => (
   cases$: Rx.Observable<HydratedCaseRecord>
 ) =>
-  cases$
-    .bufferTime(1000)
+  cases$.pipe(
+    bufferTime(1000),
     // Filter out the empty arrays from when the 1s buffer expires without any
     // values coming in.
-    .filter(arr => !!arr.length)
-    .let(
-      queue(
-        recordArr =>
-          // We run `createCases` on defer so that retryWithFallback can cause
-          // it to be tried again by re-subscribing.
-          Rx.Observable.defer(() => elasticsearch.createCases(recordArr))
-            .let(
-              retryWithBackoff(5, 2000, {
-                error: err => logNonfatalError('index-cases', err),
-              })
-            )
-            .do(response => {
-              logMessage('index-cases', 'Indexing complete', { response });
-            }),
-        {
-          length: length => logQueueLength('index-cases', length),
-          error: (err, batch: HydratedCaseRecord[]) => {
-            opbeat.captureError(err);
-            logMessage('index-cases', 'Permanent failure indexing cases', {
-              ids: batch.map(v => v.id),
-            });
-          },
-        }
-      )
-    );
+    filter(arr => !!arr.length),
+    queue(
+      recordArr =>
+        // We run `createCases` on defer so that retryWithFallback can cause
+        // it to be tried again by re-subscribing.
+        Rx.defer(() => elasticsearch.createCases(recordArr)).pipe(
+          retryWithBackoff(5, 2000, {
+            error: err => logNonfatalError('index-cases', err),
+          }),
+          tap(response => {
+            logMessage('index-cases', 'Indexing complete', { response });
+          })
+        ),
+      {
+        length: length => logQueueLength('index-cases', length),
+        error: (err, batch: HydratedCaseRecord[]) => {
+          opbeat.captureError(err);
+          logMessage('index-cases', 'Permanent failure indexing cases', {
+            ids: batch.map(v => v.id),
+          });
+        },
+      }
+    )
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -18441,16 +18441,16 @@ rxjs@^5.4.2:
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^5.5.12:
-  version "5.5.12"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
-  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
-  dependencies:
-    symbol-observable "1.0.1"
-
 rxjs@^6.1.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Removes a bunch of Observable methods in favor of the "pipe" function
and operator functions.

Also refactors where we set the parallelism for the classifier.