### PR TITLE
Lowers 311 indexer loading date range

### DIFF
--- a/services-js/311-indexer/server/scripts/import-cases.ts
+++ b/services-js/311-indexer/server/scripts/import-cases.ts
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 
-import Rx, { BehaviorSubject } from 'rxjs';
+import * as Rx from 'rxjs';
 
 import {
   map,
@@ -75,7 +75,7 @@ let caseCount = 0;
   // subscribe at the end to feed that end date back into the start of the
   // stream, so this will loop until it hits one of its takeWhile conditions to
   // complete.
-  const endDateObserver = new BehaviorSubject(endDateMoment.toDate());
+  const endDateObserver = new Rx.BehaviorSubject(endDateMoment.toDate());
   endDateObserver
     .pipe(
       // completes the stream when we've reached the start date

--- a/services-js/311-indexer/server/services/Open311.ts
+++ b/services-js/311-indexer/server/services/Open311.ts
@@ -178,11 +178,12 @@ export default class Open311 {
     const params = new URLSearchParams();
 
     if (startDate && endDate) {
-      // We need a range of <= 90 days. Since the results are sorted from the
-      // endDate, we just move up the startDate. This will generally be ok for
-      // bulk import, since it shouldn't be the case where there's a 90 day gap
-      // in cases.
-      const ninetyDaysBefore = moment(endDate).subtract(90, 'days');
+      // We need a range of <= 90 days. We use 88 to give us lots of slop around
+      // leap days and daylight savings changes. Since the results are sorted
+      // from the endDate, we just move up the startDate. This will generally be
+      // ok for bulk import, since it shouldn't be the case where there's a 88
+      // day gap in cases.
+      const ninetyDaysBefore = moment(endDate).subtract(88, 'days');
       if (moment(startDate).isBefore(ninetyDaysBefore)) {
         startDate = ninetyDaysBefore.toDate();
       }

--- a/services-js/311-indexer/server/stages/update-classifier.ts
+++ b/services-js/311-indexer/server/stages/update-classifier.ts
@@ -1,4 +1,4 @@
-import Rx, { OperatorFunction } from 'rxjs';
+import * as Rx from 'rxjs';
 import { filter, tap, map } from 'rxjs/operators';
 import { DetailedServiceRequest } from '../services/Open311';
 import Prediction from '../services/Prediction';
@@ -22,7 +22,7 @@ interface Deps {
 export default function updateClassifier(
   concurrency: number,
   { prediction, opbeat }: Deps
-): OperatorFunction<HydratedCaseRecord, unknown> {
+): Rx.OperatorFunction<HydratedCaseRecord, unknown> {
   return cases$ =>
     cases$.pipe(
       filter(({ case: c }) => !!c),


### PR DESCRIPTION
Around DST our 90 day calculation was different from Salesforce’s and it
errored out. 88 days gives us a bit of slop so that we’re guaranteed
under 90 for the range.

Also fixes some rxjs imports, which need the "* as" construction.