### PR TITLE
Adds mn-fixed-child for Safari

### DIFF
--- a/services-js/311/components/request/RequestLayout.tsx
+++ b/services-js/311/components/request/RequestLayout.tsx
@@ -197,7 +197,7 @@ export default class RequestLayout extends React.Component<Props, State> {
           style={{ backgroundColor: 'transparent' }}
           role="main"
         >
-          <div className={BACKGROUND_MAP_CONTAINER_STYLE}>
+          <div className={`mn-fixed-child ${BACKGROUND_MAP_CONTAINER_STYLE}`}>
             {/* Condition must be on the inner element. If it's on the outer
             DIV, React 16's reconcilliation of the server and client (which are
             different because we're conditional on mediaLarge) will apply the

--- a/services-js/311/components/request/__snapshots__/RequestLayout.test.tsx.snap
+++ b/services-js/311/components/request/__snapshots__/RequestLayout.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`existing service page rendering phone 1`] = `
     }
   >
     <div
-      className="css-dnm6i8"
+      className="mn-fixed-child css-dnm6i8"
     />
     <div
       className="css-15m5iw4"
@@ -542,7 +542,7 @@ exports[`existing service page rendering phone location step 1`] = `
     }
   >
     <div
-      className="css-dnm6i8"
+      className="mn-fixed-child css-dnm6i8"
     />
     <div
       className="css-18ppl9p"
@@ -756,7 +756,7 @@ exports[`missing service page rendering 1`] = `
     }
   >
     <div
-      className="css-dnm6i8"
+      className="mn-fixed-child css-dnm6i8"
     />
     <div
       className="css-15m5iw4"


### PR DESCRIPTION
Keeps the map from overlapping with the hamburger menu when it opens in
Safari, since Safari doesn’t recalculate animated position changes for
fixed children correctly.

Fixes CityOfBoston/311#928