### PR TITLE
Avoids setting current unit for intersections

### DIFF
--- a/services-js/311/components/request/request/LocationPopUp.tsx
+++ b/services-js/311/components/request/request/LocationPopUp.tsx
@@ -582,11 +582,7 @@ class AddressRow extends React.Component<AddressRowProps> {
     const { index, addressSearch } = this.props;
 
     addressSearch.highlightedPlaceIndex = index;
-
-    if (index !== addressSearch.currentPlaceIndex) {
-      addressSearch.currentPlaceIndex = index;
-      addressSearch.currentUnitIndex = 0;
-    }
+    addressSearch.currentPlaceIndex = index;
   }
 
   @action.bound

--- a/services-js/311/data/store/AddressSearch.ts
+++ b/services-js/311/data/store/AddressSearch.ts
@@ -20,10 +20,10 @@ export default class AddressSearch {
   @observable lastQuery: string = '';
   @observable.ref lastSearchError: Error | null = null;
 
-  @observable.shallow _places: Array<SearchAddressPlace> | null = null;
-  @observable _currentPlaceIndex: number = -1;
+  @observable.shallow private _places: Array<SearchAddressPlace> | null = null;
+  @observable private _currentPlaceIndex: number = -1;
   @observable highlightedPlaceIndex: number = -1;
-  @observable _currentUnitIndex: number = 0;
+  @observable private _currentUnitIndex: number = 0;
   @observable
   currentReverseGeocodeLocation: { lat: number; lng: number } | null = null;
   @observable currentReverseGeocodeLocationIsValid: boolean = true;
@@ -87,7 +87,16 @@ export default class AddressSearch {
   }
 
   set currentPlaceIndex(currentPlaceIndex: number) {
+    if (currentPlaceIndex === this._currentPlaceIndex) {
+      return;
+    }
+
     this._currentPlaceIndex = currentPlaceIndex;
+    // We specifically just set the private variable because the
+    // currentUnitIndex setter forces the intent to "ADDRESS," which is not what
+    // we want if we're picking an address or something else with
+    // alwaysUseLatLng.
+    this._currentUnitIndex = 0;
 
     // Your intent should likely already be 'ADDRESS' in this case, because
     // picking from multiple places means that you did a forward search and the


### PR DESCRIPTION
Changes the address selection code to not explicitly clear the unit
index, moving that functionality into the setter in AddressSearch.

For intersections, we always need to send the lat/lng, so we don’t want
the intent to ever be "ADDRESS."

Fixes CityOfBoston/311#933