### PR TITLE
Adds simple cache support to fetchGraphql

### DIFF
--- a/services-js/311/data/queries/load-service.ts
+++ b/services-js/311/data/queries/load-service.ts
@@ -82,6 +82,10 @@ export default async function loadService(
   code: string
 ) {
   const queryVariables: LoadServiceVariables = { code };
-  const response: LoadService = await fetchGraphql(QUERY, queryVariables);
+  const response: LoadService = await fetchGraphql(
+    QUERY,
+    queryVariables,
+    `LoadService-${code}`
+  );
   return response.service;
 }

--- a/services-js/311/data/queries/load-top-service-summaries.ts
+++ b/services-js/311/data/queries/load-top-service-summaries.ts
@@ -26,7 +26,8 @@ export default async function loadTopServiceSummaries(
   const variables: LoadTopServiceSummariesVariables = { first: count };
   const response: LoadTopServiceSummaries = await fetchGraphql(
     QUERY,
-    variables
+    variables,
+    `LoadTopServiceSummaries-${count}`
   );
   return response.topServices;
 }


### PR DESCRIPTION
Caching is done by passing in a cache object when creating the
fetchGraphql function instance, and providing a cache key any time you
want to potentially read from / write to the cache.

Makes it straightforward to cache requests made during server-side
rendering so that they’re not re-fetched in the browser.

Fixes #188