### PR TITLE
311 sorry page and telephone numbers on errors

### DIFF
--- a/services-js/311/components/common/TelephoneNumbers.tsx
+++ b/services-js/311/components/common/TelephoneNumbers.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { assetUrl, MEDIA_LARGE } from '../style-constants';
+
+const SPRITE_URL = assetUrl('img/svg/faq-icons.svg');
+
+const CONTAINER_STYLE = css({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const TELEPHONE_STYLE = css({
+  display: 'none',
+  width: 36,
+  height: 36,
+  marginRight: '1rem',
+  [MEDIA_LARGE]: {
+    display: 'block',
+  },
+});
+
+// This has to work against white and yellow backgrounds, so we inherit the text
+// color to avoid dealing with optimistic blue on yellow. The underline makes it
+// clear that it’s a link.
+const TELEPHONE_LINK_STYLE = css({
+  color: 'inherit',
+  textDecoration: 'underline',
+  whiteSpace: 'nowrap',
+});
+
+/**
+ * Component that adds a little telephone icon and information about how to call
+ * BOS:311 when the website is having issues.
+ */
+export default function TelephoneNumbers(): JSX.Element {
+  return (
+    <div className={CONTAINER_STYLE}>
+      <svg aria-hidden className={TELEPHONE_STYLE}>
+        <use xlinkHref={`${SPRITE_URL}#Phone_off`} height="36" />
+      </svg>
+
+      <div className="t--info">
+        You can always report non-emergency issues to us by calling BOS:311 at
+        311 or{' '}
+        <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+          617-635-4500
+        </a>.
+      </div>
+    </div>
+  );
+}

--- a/services-js/311/components/error/ErrorLayout.stories.tsx
+++ b/services-js/311/components/error/ErrorLayout.stories.tsx
@@ -6,5 +6,5 @@ import ErrorLayout from './ErrorLayout';
 
 storiesOf('ErrorLayout', module)
   .addDecorator(page)
-  .add('404', () => <ErrorLayout statusCode={404} store={null as any} />)
-  .add('500', () => <ErrorLayout statusCode={500} store={null as any} />);
+  .add('404', () => <ErrorLayout statusCode={404} />)
+  .add('500', () => <ErrorLayout statusCode={500} />);

--- a/services-js/311/components/error/ErrorLayout.tsx
+++ b/services-js/311/components/error/ErrorLayout.tsx
@@ -5,6 +5,8 @@ import HTTPStatus from 'http-status';
 import Head from 'next/head';
 import { css } from 'emotion';
 
+import { NextContext } from '@cityofboston/next-client-common';
+
 import { HEADER_HEIGHT, assetUrl } from '../style-constants';
 
 import FeedbackBanner from '../common/FeedbackBanner';
@@ -12,7 +14,7 @@ import Footer from '../common/Footer';
 import Nav from '../common/Nav';
 import SectionHeader from '../common/SectionHeader';
 import FormDialog from '../common/FormDialog';
-import { NextContext } from '@cityofboston/next-client-common';
+import TelephoneNumbers from '../common/TelephoneNumbers';
 
 const CONTAINER_STYLE = css({
   minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
@@ -35,7 +37,6 @@ const IMAGE_STYLE = css({
 
 type Props = {
   statusCode: number;
-  store: any;
 };
 
 export default class ErrorLayout extends React.Component<Props> {
@@ -84,14 +85,16 @@ export default class ErrorLayout extends React.Component<Props> {
               {statusCode} EEEK
             </SectionHeader>
 
-            <div className="t--info m-v400">
+            <div className="t--intro m-v500">
               {statusCode === 404
                 ? 'That link seems to have scurried away.'
                 : 'Looks like that link is playing dead. Please try again later.'}
             </div>
 
+            <TelephoneNumbers />
+
             <img
-              className={IMAGE_STYLE.toString()}
+              className={`${IMAGE_STYLE.toString()} m-v400`}
               src={assetUrl('img/404-cropped.png')}
               width="700"
               height="280"

--- a/services-js/311/components/error/SorryLayout.stories.tsx
+++ b/services-js/311/components/error/SorryLayout.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import page from '../../.storybook/page';
+import SorryLayout from './SorryLayout';
+
+storiesOf('SorryLayout', module)
+  .addDecorator(page)
+  .add('default', () => <SorryLayout />);

--- a/services-js/311/components/error/SorryLayout.tsx
+++ b/services-js/311/components/error/SorryLayout.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Head from 'next/head';
+import { css } from 'emotion';
+
+import { HEADER_HEIGHT, NAV_HEIGHT } from '../style-constants';
+
+import Footer from '../common/Footer';
+import SectionHeader from '../common/SectionHeader';
+import FormDialog from '../common/FormDialog';
+import TelephoneNumbers from '../common/TelephoneNumbers';
+
+const CONTAINER_STYLE = css({
+  minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
+  // moves us up since we’re not showing the 2ndary nav
+  marginTop: -NAV_HEIGHT,
+  backgroundColor: '#f3a536',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const SECTION_HEADER_OVERRIDE_STYLE = css({
+  borderColor: 'white',
+  ' .sh-title': {
+    color: 'white',
+  },
+});
+
+export default class SorryLayout extends React.Component {
+  render() {
+    return (
+      <div>
+        <Head>
+          <title>BOS:311 — This site is down</title>
+        </Head>
+
+        <div className={`mn--full ${CONTAINER_STYLE.toString()}`}>
+          <FormDialog
+            narrow
+            style={{
+              borderColor: 'transparent',
+              backgroundColor: 'transparent',
+            }}
+          >
+            <SectionHeader className={SECTION_HEADER_OVERRIDE_STYLE.toString()}>
+              BOS:311 is unavailable
+            </SectionHeader>
+
+            <div className="t--intro m-v300">
+              The BOS:311 website is currently down for maintenance.
+            </div>
+
+            <TelephoneNumbers />
+          </FormDialog>
+        </div>
+
+        <Footer />
+      </div>
+    );
+  }
+}

--- a/services-js/311/components/request/request/SubmitPane.tsx
+++ b/services-js/311/components/request/request/SubmitPane.tsx
@@ -4,6 +4,7 @@ import { css } from 'emotion';
 import SectionHeader from '../../common/SectionHeader';
 import LoadingBuildings from '../../common/LoadingBuildings';
 import Ui from '../../../data/store/Ui';
+import TelephoneNumbers from '../../common/TelephoneNumbers';
 
 export type Props =
   | {
@@ -60,13 +61,15 @@ export default function SubmitPane(props: Props) {
             {messages.map((msg, i) => <div key={i}>{msg}</div>)}
           </div>
 
-          <p className="m-v500">
+          <p className="m-v500 t--s500 lh--400">
             You can{' '}
             <Link href={backUrl} as={backUrlAs}>
               <a>go back and update your request</a>
             </Link>{' '}
             and try again.
           </p>
+
+          <TelephoneNumbers />
         </div>
       );
     }

--- a/services-js/311/components/request/request/__snapshots__/RequestDialog.test.tsx.snap
+++ b/services-js/311/components/request/request/__snapshots__/RequestDialog.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`methods submitRequest graphql failure 1`] = `
               </div>
             </div>
             <p
-              className="m-v500"
+              className="m-v500 t--s500 lh--400"
             >
               You can
                
@@ -217,6 +217,34 @@ exports[`methods submitRequest graphql failure 1`] = `
                
               and try again.
             </p>
+            <TelephoneNumbers>
+              <div
+                className="css-70qvj9"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="css-suvs8w"
+                >
+                  <use
+                    height="36"
+                    xlinkHref="/assets/img/svg/faq-icons.svg#Phone_off"
+                  />
+                </svg>
+                <div
+                  className="t--info"
+                >
+                  You can always report non-emergency issues to us by calling BOS:311 at 311 or
+                   
+                  <a
+                    className="css-dbrpw0"
+                    href="tel:+16176354500"
+                  >
+                    617-635-4500
+                  </a>
+                  .
+                </div>
+              </div>
+            </TelephoneNumbers>
           </div>
         </SubmitPane>
       </div>

--- a/services-js/311/components/request/translate/TranslateDialog.tsx
+++ b/services-js/311/components/request/translate/TranslateDialog.tsx
@@ -32,6 +32,12 @@ const TELEPHONE_STYLE = css({
   },
 });
 
+const TELEPHONE_LINK_STYLE = css({
+  color: 'inherit',
+  textDecoration: 'underline',
+  whiteSpace: 'nowrap',
+});
+
 const CONTINUE_LINK_STYLE = css({
   fontStyle: 'normal',
   flex: 1,
@@ -61,54 +67,70 @@ const MESSAGES = {
     <span>
       If you need to report a non-emergency issue with the City of Boston,
       please call BOS:311 at 311 or{' '}
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   es: (
     <span>
       Si necesita reportar un problema que no sea de emergencia a la Ciudad de
       Boston, por favor llame a BOS:311 al 3-1-1 o al{' '}
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   'zh-TW': (
     <span>
       向波士頓市府舉報非緊急事項, 請致電 BOS:311辦公室,撥 3-1-1或{' '}
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   'zh-CN': (
     <span>
-      向波士顿市府举报非紧急事项,请致电BOS:311办公室, 拨 3-1-1 或
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      向波士顿市府举报非紧急事项,请致电BOS:311办公室, 拨 3-1-1 或{' '}
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   ht: (
     <span>
       Si’w ta vle repòte yon pwoblem ki pa yon ijans pou Vil Boston an, souple
       rele BOS:311 nan 3-1-1 oswa{' '}
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   vi: (
     <span>
       Nếu cần báo cáo vấn đề không khẩn cấp đến thành phố Boston, xin gọi
       BOS:311 tại 3-1-1 hoạc{' '}
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   kea: (
     <span>
       Si bu prisiza di kumunika un asuntu ki ê ka di imerjênsia pa Cidadi di
       Boston, pur favor telifona pa BOS:311 pa númeru 3-1-1 ô pa{' '}
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
   pt: (
     <span>
       Se você precisa comunicar algum assunto que não é de emergência à Cidade
-      de Boston, por favor telefone para BOS:311, para o número 3-1-1 ou para
-      <span style={{ whiteSpace: 'nowrap' }}>617-635-4500</span>.
+      de Boston, por favor telefone para BOS:311, para o número 3-1-1 ou para{' '}
+      <a href="tel:+16176354500" className={TELEPHONE_LINK_STYLE}>
+        617-635-4500
+      </a>.
     </span>
   ),
 };
@@ -168,7 +190,7 @@ export default class TranslateDialog extends React.Component<Props> {
 
             <div className="g m-v500 p-a500" style={{ alignItems: 'center' }}>
               <div className="g--3">
-                <svg role="img" className={TELEPHONE_STYLE}>
+                <svg aria-hidden className={TELEPHONE_STYLE}>
                   <use xlinkHref={`${SPRITE_URL}#Phone_off`} height="100%" />
                 </svg>
               </div>

--- a/services-js/311/components/style-constants.ts
+++ b/services-js/311/components/style-constants.ts
@@ -9,6 +9,7 @@ export const MEDIA_X_LARGE = '@media screen and (min-width: 980px)';
 export const MEDIA_XX_LARGE = '@media screen and (min-width: 1280px)';
 
 export const HEADER_HEIGHT = 119;
+export const NAV_HEIGHT = 54;
 export const IPHONE_FOOTER_HEIGHT = 64;
 
 export const YELLOW = '#fcb61a';

--- a/services-js/311/pages/sorry.ts
+++ b/services-js/311/pages/sorry.ts
@@ -1,0 +1,2 @@
+import SorryLayout from '../components/error/SorryLayout';
+export default SorryLayout;


### PR DESCRIPTION
Adds the ability to do "maintenance mode" on 311 and includes the
telephone numbers on that page and any error reporting. That way if
constituents can’t use the site they’re prompted to give a call.

Also removes unused "store" prop from ErrorLayout.

Fixes #192
Fixes CityOfBoston/311#929