### PR TITLE
Changes the browser URL for 311 suggest pane

### DIFF
--- a/services-js/311/components/request/home/HomeDialog.tsx
+++ b/services-js/311/components/request/home/HomeDialog.tsx
@@ -155,7 +155,7 @@ export default class HomeDialog extends React.Component<Props> {
       `/request?stage=choose&description=${encodeURIComponent(
         this.description.trim()
       )}`,
-      '/request'
+      `/request?description=${encodeURIComponent(this.description.trim())}`
     ).then(() => window.scrollTo(0, 0));
   }
 


### PR DESCRIPTION
Next.js treats any location changes where the browser URL looks the same
as replaceState rather than pushState, so we need to change the URL to
make the back button work.