### PR TITLE
Generalizes CostSummary component

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -7256,6 +7256,27 @@ exports[`Storyshots Checkout/ReviewContent cart has pending certs 1`] = `
                     }
                   }
                 >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
                   <tbody>
                     <tr>
                       <td>
@@ -7945,6 +7966,27 @@ exports[`Storyshots Checkout/ReviewContent default 1`] = `
                     }
                   }
                 >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
                   <tbody>
                     <tr>
                       <td>
@@ -8607,6 +8649,27 @@ exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
                     }
                   }
                 >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
                   <tbody>
                     <tr>
                       <td>
@@ -11773,6 +11836,27 @@ exports[`Storyshots Common Components/CostSummary default credit card 1`] = `
         }
       }
     >
+      <caption
+        className="css-1dv1kvn"
+      >
+        Cost Summary
+      </caption>
+      <thead
+        className="css-1dv1kvn"
+      >
+        <tr>
+          <th
+            scope="col"
+          >
+            Item
+          </th>
+          <th
+            scope="col"
+          >
+            Amount
+          </th>
+        </tr>
+      </thead>
       <tbody>
         <tr>
           <td>
@@ -11885,6 +11969,27 @@ exports[`Storyshots Common Components/CostSummary default debit card 1`] = `
         }
       }
     >
+      <caption
+        className="css-1dv1kvn"
+      >
+        Cost Summary
+      </caption>
+      <thead
+        className="css-1dv1kvn"
+      >
+        <tr>
+          <th
+            scope="col"
+          >
+            Item
+          </th>
+          <th
+            scope="col"
+          >
+            Amount
+          </th>
+        </tr>
+      </thead>
       <tbody>
         <tr>
           <td>
@@ -11997,6 +12102,27 @@ exports[`Storyshots Common Components/CostSummary only credit card 1`] = `
         }
       }
     >
+      <caption
+        className="css-1dv1kvn"
+      >
+        Cost Summary
+      </caption>
+      <thead
+        className="css-1dv1kvn"
+      >
+        <tr>
+          <th
+            scope="col"
+          >
+            Item
+          </th>
+          <th
+            scope="col"
+          >
+            Amount
+          </th>
+        </tr>
+      </thead>
       <tbody>
         <tr>
           <td>
@@ -12080,6 +12206,27 @@ exports[`Storyshots Common Components/CostSummary only debit card 1`] = `
         }
       }
     >
+      <caption
+        className="css-1dv1kvn"
+      >
+        Cost Summary
+      </caption>
+      <thead
+        className="css-1dv1kvn"
+      >
+        <tr>
+          <th
+            scope="col"
+          >
+            Item
+          </th>
+          <th
+            scope="col"
+          >
+            Amount
+          </th>
+        </tr>
+      </thead>
       <tbody>
         <tr>
           <td>
@@ -12142,6 +12289,150 @@ exports[`Storyshots Common Components/CostSummary only debit card 1`] = `
           >
             $
             71.32
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Common Components/CostSummary with research fee 1`] = `
+<div>
+  <div
+    className="css-5x1uzq"
+  >
+    <table
+      className="t--info ta-r"
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      <caption
+        className="css-1dv1kvn"
+      >
+        Cost Summary
+      </caption>
+      <thead
+        className="css-1dv1kvn"
+      >
+        <tr>
+          <th
+            scope="col"
+          >
+            Item
+          </th>
+          <th
+            scope="col"
+          >
+            Amount
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            1
+             
+            certificate
+             ×
+             
+            $14.00
+          </td>
+          <td
+            className="css-1698s6w"
+          >
+            $
+            14.00
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Research fee
+          </td>
+          <td
+            className="css-1698s6w"
+          >
+            $
+            10.00
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <div>
+              <div
+                className="sel sel--thin css-15550l6"
+              >
+                <div
+                  className="sel-c css-sa8vax"
+                >
+                  <select
+                    aria-label="Payment type"
+                    className="sel-f css-18w0ib3"
+                    id="serviceFeeTypeSelect"
+                    onChange={[Function]}
+                    value="DEBIT"
+                  >
+                    <option
+                      value="CREDIT"
+                    >
+                      Credit card
+                    </option>
+                    <option
+                      value="DEBIT"
+                    >
+                      Debit card
+                    </option>
+                  </select>
+                </div>
+              </div>
+               
+              service fee
+               
+              <a
+                aria-label="About the service fee"
+                href="#service-fee"
+              >
+                *
+              </a>
+            </div>
+          </td>
+          <td
+            className="css-1698s6w"
+          >
+            $
+            0.62
+          </td>
+        </tr>
+        <tr>
+          <td>
+            U.S. shipping included
+          </td>
+          <td
+            className="css-1698s6w"
+          >
+            <i>
+              $0.00
+            </i>
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="sh-title css-1ujpul8"
+          >
+            <span
+              className="css-1tg3jta"
+            >
+              Total
+            </span>
+          </td>
+          <td
+            className="cost-cell cost br br-t100 p-v200"
+          >
+            $
+            24.62
           </td>
         </tr>
       </tbody>
@@ -13222,6 +13513,27 @@ exports[`Storyshots Death/CartPage loading 1`] = `
                     }
                   }
                 >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
                   <tbody>
                     <tr>
                       <td>
@@ -13846,6 +14158,27 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
                     }
                   }
                 >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
                   <tbody>
                     <tr>
                       <td>

--- a/services-js/registry-certs/client/common/CostSummary.stories.tsx
+++ b/services-js/registry-certs/client/common/CostSummary.stories.tsx
@@ -24,21 +24,40 @@ function makeCart() {
 storiesOf('Common Components/CostSummary', module)
   .add('default credit card', () => (
     <CostSummary
-      cart={makeCart()}
+      certificateType="death"
+      certificateQuantity={makeCart().size}
       allowServiceFeeTypeChoice
       serviceFeeType="CREDIT"
     />
   ))
   .add('default debit card', () => (
     <CostSummary
-      cart={makeCart()}
+      certificateType="death"
+      certificateQuantity={makeCart().size}
       allowServiceFeeTypeChoice
       serviceFeeType="DEBIT"
     />
   ))
   .add('only credit card', () => (
-    <CostSummary cart={makeCart()} serviceFeeType="CREDIT" />
+    <CostSummary
+      certificateType="death"
+      certificateQuantity={makeCart().size}
+      serviceFeeType="CREDIT"
+    />
   ))
   .add('only debit card', () => (
-    <CostSummary cart={makeCart()} serviceFeeType="DEBIT" />
+    <CostSummary
+      certificateType="death"
+      certificateQuantity={makeCart().size}
+      serviceFeeType="DEBIT"
+    />
+  ))
+  .add('with research fee', () => (
+    <CostSummary
+      certificateType="birth"
+      certificateQuantity={1}
+      allowServiceFeeTypeChoice
+      serviceFeeType="DEBIT"
+      hasResearchFee
+    />
   ));

--- a/services-js/registry-certs/client/death/cart/CartPage.tsx
+++ b/services-js/registry-certs/client/death/cart/CartPage.tsx
@@ -88,7 +88,8 @@ class CartPage extends React.Component<Props> {
             {deathCertificateCart.entries.length > 0 && (
               <div className="m-t700">
                 <CostSummary
-                  cart={deathCertificateCart}
+                  certificateType="death"
+                  certificateQuantity={deathCertificateCart.size}
                   allowServiceFeeTypeChoice
                   serviceFeeType="CREDIT"
                 />

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.tsx
@@ -189,7 +189,8 @@ export default class ReviewContent extends React.Component<Props, State> {
 
             <div className="m-v500">
               <CostSummary
-                cart={cart}
+                certificateType="death"
+                certificateQuantity={cart.size}
                 serviceFeeType={cardFunding === 'debit' ? 'DEBIT' : 'CREDIT'}
               />
             </div>


### PR DESCRIPTION
- Refactored CostSummary component to receive the number of certificates for an order instead of a `DeathCertificateCart` instance
- Added birth cert costs, research fee
- Enhanced component’s `<table>` element for better a11y support
- Moved CSS to bottom of file for easier readability