### PR TITLE
Adds sourcemap generation for registry-certs

### DIFF
--- a/services-js/registry-certs/next.config.js
+++ b/services-js/registry-certs/next.config.js
@@ -1,19 +1,22 @@
 const path = require('path');
 const withTypescript = require('@zeit/next-typescript');
+const withSourceMaps = require('@zeit/next-source-maps')();
 
-module.exports = withTypescript({
-  distDir: path.join('build', '.next'),
-  assetPrefix:
-    process.env.ASSET_HOST && process.env.ASSET_HOST !== '.'
-      ? `https://${process.env.ASSET_HOST}`
-      : '',
+module.exports = withTypescript(
+  withSourceMaps({
+    distDir: path.join('build', '.next'),
+    assetPrefix:
+      process.env.ASSET_HOST && process.env.ASSET_HOST !== '.'
+        ? `https://${process.env.ASSET_HOST}`
+        : '',
 
-  webpack: function(config) {
-    config.module.rules.push({
-      test: /\.html$/,
-      use: 'raw-loader',
-    });
+    webpack: function(config) {
+      config.module.rules.push({
+        test: /\.html$/,
+        use: 'raw-loader',
+      });
 
-    return config;
-  },
-});
+      return config;
+    },
+  })
+);

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -42,6 +42,7 @@
     "@cityofboston/next-client-common": "^0.0.0",
     "@cityofboston/react-fleet": "^0.0.0",
     "@cityofboston/srv-decrypt-env": "^0.0.0",
+    "@zeit/next-source-maps": "^0.0.4-canary.1",
     "address-rfc2822": "^2.0.3",
     "apollo-server-hapi": "^1.4.0",
     "aws-sdk": "^2.100.0",

--- a/services-js/registry-certs/pages/_document.tsx
+++ b/services-js/registry-certs/pages/_document.tsx
@@ -61,6 +61,7 @@ export default class extends Document {
       rollbarAccessToken,
       rollbarEnvironment,
       css,
+      __NEXT_DATA__: { buildId },
     } = this.props;
 
     return (
@@ -83,7 +84,14 @@ export default class extends Document {
                 captureUncaught: true,
                 captureUnhandledRejections: true,
                 payload: {
-                    environment: "${rollbarEnvironment}"
+                    environment: "${rollbarEnvironment}",
+                    client: {
+                      javascript: {
+                        source_map_enabled: true,
+                        code_version: "${buildId}",
+                        guess_uncaught_frames: true
+                      }
+                    }
                 }
             };
             // Rollbar Snippet

--- a/services-js/registry-certs/tsconfig.json
+++ b/services-js/registry-certs/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDir": ".",
     "outDir": "build",
     "allowJs": true,
+    "sourceMap": true,
     "declaration": false
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,6 +2560,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz#33d1dbb659a23b81f87f048762b35a446172add3"
 
+"@zeit/next-source-maps@^0.0.4-canary.1":
+  version "0.0.4-canary.1"
+  resolved "https://registry.yarnpkg.com/@zeit/next-source-maps/-/next-source-maps-0.0.4-canary.1.tgz#5051ff8425e5f615da2d21dd08a99284fbb63d7d"
+  integrity sha512-SPQCLs7ToaqzQnqXqGSCoL7KTlnOAao+1F5hy7Hkuq85TjHsUC3eeLsmVrBIraIhXG/ARHmZ0JHOesPDtBfpzw==
+
 "@zeit/next-typescript@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@zeit/next-typescript/-/next-typescript-1.1.1.tgz#0b0ddfbb13ca04cde52ac2718473f1b9c40ba0ee"


### PR DESCRIPTION
Useful so that Rollbar can show us better stack traces for production
errors. Currently we’re not doing any fancy pre-loading of sourcemaps to
Rollbar. If it turns out we’d like that extra reliability we can
implement it.

And we don’t care that it’s all public because we’re open source
anyway!

Note we have to use the 0.0.4 canary for the source map plugin because
it’s the version that supports Terser, rather than UglifyJS. (Next
switched at some point.)