### PR TITLE
Waits for the React app to start in TestCafe

### DIFF
--- a/services-js/access-boston/src/integration/models/LoginFormModel.ts
+++ b/services-js/access-boston/src/integration/models/LoginFormModel.ts
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe';
 import PageModel from './PageModel';
+import { isReactRunning } from '../testcafe-helpers';
 
 export default class LoginFormModel extends PageModel {
   root = Selector('form');
@@ -7,10 +8,15 @@ export default class LoginFormModel extends PageModel {
   submitButton = this.root.find('input[type=submit]');
 
   logIn(t: TestController, userId: string): Promise<TestController> {
-    return t
-      .typeText(this.userIdField, userId, {
-        replace: true,
-      })
-      .click(this.submitButton);
+    return (
+      t
+        .typeText(this.userIdField, userId, {
+          replace: true,
+        })
+        .click(this.submitButton)
+        // Make sure the app is going after we’ve submitted
+        .expect(isReactRunning())
+        .ok()
+    );
   }
 }


### PR DESCRIPTION
Part of our TestCafe flakiness is that the forms are getting filled out
before React is done starting up, so when it does the form fields get
wiped out by the empty values.

This makes sure that the isReactRunning function is returning true
before we exit out of the logIn helper.