### PR TITLE
Adds resiliency when localStorage is not available in the browser

### DIFF
--- a/services-js/registry-certs/client/death/checkout/PaymentContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/PaymentContent.tsx
@@ -188,6 +188,7 @@ export default class PaymentContent extends React.Component<Props, State> {
 
     const {
       paymentIsComplete,
+      localStorageAvailable,
       cardElementError,
       cardElementComplete,
       processing,
@@ -458,20 +459,22 @@ export default class PaymentContent extends React.Component<Props, State> {
                   </div>
 
                   <div className="m-t700">
-                    <label className="cb">
-                      <input
-                        id="store-billing"
-                        name="store-billing"
-                        type="checkbox"
-                        value="true"
-                        checked={storeBilling}
-                        {...this.fieldListeners('storeBilling')}
-                        className="cb-f"
-                      />{' '}
-                      <span className="cb-l">
-                        Save billing address on this computer
-                      </span>
-                    </label>
+                    {localStorageAvailable && (
+                      <label className="cb">
+                        <input
+                          id="store-billing"
+                          name="store-billing"
+                          type="checkbox"
+                          value="true"
+                          checked={storeBilling}
+                          {...this.fieldListeners('storeBilling')}
+                          className="cb-f"
+                        />{' '}
+                        <span className="cb-l">
+                          Save billing address on this computer
+                        </span>
+                      </label>
+                    )}
                   </div>
                 </div>
               )}

--- a/services-js/registry-certs/client/death/checkout/ShippingContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ShippingContent.tsx
@@ -101,6 +101,7 @@ export default class ShippingContent extends React.Component<Props, State> {
 
     const {
       shippingIsComplete,
+      localStorageAvailable,
       info: {
         storeContactAndShipping,
 
@@ -387,20 +388,22 @@ export default class ShippingContent extends React.Component<Props, State> {
             </fieldset>
 
             <div className="m-v700">
-              <label className="cb">
-                <input
-                  id="store-contact-and-shipping"
-                  name="store-contact-and-shipping"
-                  type="checkbox"
-                  value="true"
-                  checked={storeContactAndShipping}
-                  {...this.fieldListeners('storeContactAndShipping')}
-                  className="cb-f"
-                />
-                <span className="cb-l">
-                  Save contact and shipping info on this computer
-                </span>
-              </label>
+              {localStorageAvailable && (
+                <label className="cb">
+                  <input
+                    id="store-contact-and-shipping"
+                    name="store-contact-and-shipping"
+                    type="checkbox"
+                    value="true"
+                    checked={storeContactAndShipping}
+                    {...this.fieldListeners('storeContactAndShipping')}
+                    className="cb-f"
+                  />
+                  <span className="cb-l">
+                    Save contact and shipping info on this computer
+                  </span>
+                </label>
+              )}
             </div>
 
             <div className="g g--r g--vc">

--- a/services-js/registry-certs/client/models/Order.ts
+++ b/services-js/registry-certs/client/models/Order.ts
@@ -59,7 +59,11 @@ export default class Order {
 
   updateStorageDisposer: Function | null = null;
 
-  constructor(info: OrderInfo | null = null) {
+  readonly localStorageAvailable: boolean;
+
+  constructor(info: OrderInfo | null = null, localStorageAvailable = true) {
+    this.localStorageAvailable = localStorageAvailable;
+
     this.info = info || {
       storeContactAndShipping: false,
       storeBilling: false,

--- a/services-js/registry-certs/client/store/DeathCertificateCart.ts
+++ b/services-js/registry-certs/client/store/DeathCertificateCart.ts
@@ -26,7 +26,7 @@ export default class DeathCertificateCart {
   siteAnalytics: GaSiteAnalytics | null = null;
 
   attach(
-    localStorage: Storage,
+    localStorage: Storage | null,
     deathCertificatesDao: DeathCertificatesDao,
     siteAnalytics: GaSiteAnalytics
   ) {

--- a/services-js/registry-certs/client/store/OrderProvider.ts
+++ b/services-js/registry-certs/client/store/OrderProvider.ts
@@ -28,7 +28,7 @@ export default class OrderProvider {
       }
     }
 
-    const order = new Order(orderInfo);
+    const order = new Order(orderInfo, !!localStorage);
 
     autorun(() => {
       const { localStorage } = this;

--- a/services-js/registry-certs/pages/_app.tsx
+++ b/services-js/registry-certs/pages/_app.tsx
@@ -181,12 +181,24 @@ export default class RegistryCertsApp extends App {
       // We attach to localStorage in the constructor, rather than
       // componentDidMount, so that the information is available on first
       // render.
+
+      // We need to ensure localStorage is available in the browser,
+      // otherwise an error could be thrown:
+      // https://github.com/CityOfBoston/digital/issues/199
+      let localStorage: Storage | null = null;
+
+      try {
+        localStorage = window.localStorage;
+      } catch {
+        //  possible security error; ignore.
+      }
+
       deathCertificateCart.attach(
-        window.localStorage,
+        localStorage,
         initialPageDependencies.deathCertificatesDao,
         siteAnalytics
       );
-      orderProvider.attach(window.localStorage);
+      orderProvider.attach(localStorage);
     }
 
     const config = getConfig();


### PR DESCRIPTION
- Prevents uncaught error if localStorage is not available in the browser
- Hides “save contact info on computer” option on shipping information page in checkout