### PR TITLE
Fixes for mobile UI for 311 search

### DIFF
--- a/services-js/311/.storybook/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/311/.storybook/__snapshots__/Storyshots.test.ts.snap
@@ -11297,6 +11297,17 @@ exports[`Storyshots SearchLayout List View 1`] = `
             />
           </div>
         </div>
+        <div
+          className="g p-a300 css-jfggi0 "
+        >
+          <button
+            className="btn g--12"
+            onClick={[Function]}
+            type="button"
+          >
+            Map View
+          </button>
+        </div>
       </div>
       <footer
         className="ft"

--- a/services-js/311/components/search/RecentRequestRow.tsx
+++ b/services-js/311/components/search/RecentRequestRow.tsx
@@ -81,6 +81,7 @@ export type Props = {
   request: SearchCase;
   requestSearch: RequestSearch;
   ui: Ui;
+  hoverEffects: boolean;
 };
 
 @observer
@@ -140,7 +141,7 @@ export default class RecentRequestRow extends React.Component<Props> {
   }
 
   render() {
-    const { request } = this.props;
+    const { request, hoverEffects } = this.props;
 
     const defaultUrl = this.selected
       ? assetUrl('img/311-logo-grey-on-white.svg')
@@ -172,8 +173,8 @@ export default class RecentRequestRow extends React.Component<Props> {
           ref={this.setEl}
           data-request-id={request.id}
           className={`p-a300 br ${REQUEST_STYLE.toString()}`}
-          onMouseEnter={this.handleHover}
-          onMouseLeave={this.handleUnhover}
+          onMouseEnter={hoverEffects ? this.handleHover : undefined}
+          onMouseLeave={hoverEffects ? this.handleUnhover : undefined}
           style={{
             backgroundColor: this.selected ? GRAY_100 : 'transparent',
             color: 'inherit',

--- a/services-js/311/components/search/RecentRequests.tsx
+++ b/services-js/311/components/search/RecentRequests.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { action, autorun } from 'mobx';
+import { action, autorun, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import { css } from 'emotion';
 
@@ -92,13 +92,18 @@ const LOADING_REQUEST_LIST_STYLE = css({
 export type Props = {
   requestSearch: RequestSearch;
   ui: Ui;
+  isMobile: boolean;
 };
 
 @observer
 export default class RecentRequests extends React.Component<Props> {
-  mainEl: HTMLElement | null = null;
+  @observable mainEl: HTMLElement | null = null;
 
   mobxDisposers: Array<Function> = [];
+
+  static defaultProps = {
+    isMobile: false,
+  };
 
   componentDidMount() {
     this.mobxDisposers.push(
@@ -111,9 +116,10 @@ export default class RecentRequests extends React.Component<Props> {
     this.mobxDisposers.forEach(d => d());
   }
 
-  setMainEl = (mainEl: HTMLElement | null) => {
+  @action.bound
+  setMainEl(mainEl: HTMLElement | null) {
     this.mainEl = mainEl;
-  };
+  }
 
   @action.bound
   clearSearch() {
@@ -121,11 +127,10 @@ export default class RecentRequests extends React.Component<Props> {
   }
 
   scrollSelectedIntoView = () => {
-    const { ui, requestSearch } = this.props;
-    const { belowMediaLarge } = ui;
+    const { isMobile, requestSearch } = this.props;
 
     // don't scroll on mobile
-    if (belowMediaLarge) {
+    if (isMobile) {
       return;
     }
 
@@ -144,11 +149,10 @@ export default class RecentRequests extends React.Component<Props> {
   };
 
   scrollOnResultsChange = () => {
-    const { ui, requestSearch } = this.props;
-    const { belowMediaLarge } = ui;
+    const { isMobile, requestSearch } = this.props;
 
     // don't scroll on mobile
-    if (belowMediaLarge) {
+    if (isMobile) {
       return;
     }
 
@@ -165,7 +169,7 @@ export default class RecentRequests extends React.Component<Props> {
   };
 
   render() {
-    const { requestSearch, ui } = this.props;
+    const { requestSearch, isMobile, ui } = this.props;
     const { results, loading, resultsQuery, resultsError } = requestSearch;
 
     return (
@@ -264,6 +268,7 @@ export default class RecentRequests extends React.Component<Props> {
               request={request}
               requestSearch={requestSearch}
               ui={ui}
+              hoverEffects={!isMobile}
             />
           ))}
         </div>

--- a/services-js/311/components/search/SearchLayout.tsx
+++ b/services-js/311/components/search/SearchLayout.tsx
@@ -125,9 +125,10 @@ export default class SearchLayout extends React.Component<Props> {
   private locationUpdateDisposer: Function | null = null;
   private currentLocationMonitorDisposer: Function | null = null;
 
-  private container: HTMLElement | null = null;
-  private locationMap: LocationMap | null = null;
-  private locationMapContainer: HTMLElement | null = null;
+  // These are all observable because they’re used in @computed methods.
+  @observable private container: HTMLElement | null = null;
+  @observable private locationMap: LocationMap | null = null;
+  @observable private locationMapContainer: HTMLElement | null = null;
   @observable private mapViewButtonContainer: HTMLElement | null = null;
 
   static getInitialProps: GetInitialProps<InitialProps, 'query'> = async (
@@ -252,17 +253,20 @@ export default class SearchLayout extends React.Component<Props> {
     }
   }
 
-  setContainer = (container: HTMLElement | null) => {
+  @action.bound
+  setContainer(container: HTMLElement | null) {
     this.container = container;
-  };
+  }
 
-  setLocationMap = (locationMap: LocationMap | null) => {
+  @action.bound
+  setLocationMap(locationMap: LocationMap | null) {
     this.locationMap = locationMap;
-  };
+  }
 
-  setLocationMapContainer = (locationMapContainer: HTMLElement | null) => {
+  @action.bound
+  setLocationMapContainer(locationMapContainer: HTMLElement | null) {
     this.locationMapContainer = locationMapContainer;
-  };
+  }
 
   @action.bound
   setMapViewButtonContainer(mapViewButtonContainer: HTMLElement | null) {
@@ -311,12 +315,9 @@ export default class SearchLayout extends React.Component<Props> {
     const { ui } = this.props;
     const { locationMapContainer } = this;
 
-    if (!locationMapContainer) {
-      return false;
-    }
-
-    return (
+    return !!(
       ui.scrollY > -1 &&
+      locationMapContainer &&
       locationMapContainer.getBoundingClientRect().bottom <
         HEADER_HEIGHT + SEARCH_HEIGHT
     );
@@ -395,7 +396,11 @@ export default class SearchLayout extends React.Component<Props> {
 
           {!mapView && (
             <div ref={this.setContainer}>
-              <RecentRequests requestSearch={requestSearch} ui={ui} />
+              <RecentRequests
+                requestSearch={requestSearch}
+                ui={ui}
+                isMobile={ui.belowMediaLarge}
+              />
             </div>
           )}
 

--- a/services-js/311/server/graphql/index.ts
+++ b/services-js/311/server/graphql/index.ts
@@ -18,7 +18,7 @@ import {
 import { Open311 } from '../services/Open311';
 import { ArcGIS } from '../services/ArcGIS';
 import { Prediction } from '../services/Prediction';
-import { Elasticsearch } from '../services/Elasticsearch';
+import Elasticsearch from '../services/Elasticsearch';
 
 export interface Context {
   open311: Open311;

--- a/services-js/311/server/server.ts
+++ b/services-js/311/server/server.ts
@@ -21,7 +21,7 @@ import { nextHandler, nextDefaultHandler } from './next-handlers';
 import { Open311 } from './services/Open311';
 import { ArcGIS } from './services/ArcGIS';
 import { Prediction } from './services/Prediction';
-import { Elasticsearch } from './services/Elasticsearch';
+import Elasticsearch from './services/Elasticsearch';
 import { Salesforce } from './services/Salesforce';
 
 import schema, { Context } from './graphql';
@@ -38,6 +38,7 @@ import {
   PublicRuntimeConfig,
   ServerRuntimeConfig,
 } from '../lib/config';
+import ElasticsearchFake from './services/ElasticsearchFake';
 
 const port = parseInt(process.env.PORT || '3000', 10);
 
@@ -100,10 +101,13 @@ export default async function startServer({ rollbar }: { rollbar: Rollbar }) {
     Elasticsearch.configureAws(process.env.AWS_REGION);
   }
 
-  const elasticsearch = new Elasticsearch(
-    process.env.ELASTICSEARCH_URL,
-    process.env.ELASTICSEARCH_INDEX
-  );
+  const elasticsearch =
+    process.env.NODE_ENV === 'production' || process.env.ELASTICSEARCH_URL
+      ? new Elasticsearch(
+          process.env.ELASTICSEARCH_URL,
+          process.env.ELASTICSEARCH_INDEX
+        )
+      : new ElasticsearchFake();
 
   // If we're in maintenance mode we don’t try to connect to Salesforce because
   // it being down is likely the reason we're in maintenance mode to begin with.

--- a/services-js/311/server/services/Elasticsearch.ts
+++ b/services-js/311/server/services/Elasticsearch.ts
@@ -4,31 +4,31 @@ import HttpAwsEs from 'http-aws-es';
 import HttpsProxyAgent from 'https-proxy-agent';
 
 // This needs to be kept up-to-date with the 311-indexer
+//
+// TODO(finh): Factor this out to a place where they can share it directly.
 interface CaseDocument {
   status: string;
-  location:
-    | {
-        lat: number;
-        lon: number;
-      }
-    | undefined;
+  location: {
+    lat: number;
+    lon: number;
+  } | null;
 
   address: string;
   description: string;
   service_name: string;
-  service_code: string | undefined;
+  service_code: string | null;
   status_notes: string;
-  requested_datetime: string | undefined;
-  updated_datetime: string | undefined;
+  requested_datetime: string | null;
+  updated_datetime: string | null;
   replay_id: number;
-  media_url: string | undefined;
+  media_url: string | null;
 }
 
 export interface IndexedCase extends CaseDocument {
   service_request_id: string;
 }
 
-export class Elasticsearch {
+export default class Elasticsearch {
   private readonly client: elasticsearch.Client;
   private readonly index: string;
 

--- a/services-js/311/server/services/ElasticsearchFake.ts
+++ b/services-js/311/server/services/ElasticsearchFake.ts
@@ -1,0 +1,28 @@
+import Elasticsearch, { IndexedCase } from './Elasticsearch';
+
+import ELASTICSEARCH_FIXTURE from './__fixtures__/elasticsearch.json';
+
+export default class ElasticsearchFake implements Required<Elasticsearch> {
+  public async searchCases(
+    query: string | undefined,
+    topLeft: { lat: number; lng: number } | undefined,
+    bottomRight: { lat: number; lng: number } | undefined
+  ): Promise<IndexedCase[]> {
+    if (query) {
+      return [];
+    } else {
+      return ELASTICSEARCH_FIXTURE.map(
+        c =>
+          topLeft && bottomRight
+            ? {
+                ...c,
+                location: {
+                  lat: (topLeft.lat + bottomRight.lat) / 2,
+                  lon: (topLeft.lng + bottomRight.lng) / 2,
+                },
+              }
+            : c
+      );
+    }
+  }
+}

--- a/services-js/311/server/services/__fixtures__/elasticsearch.json
+++ b/services-js/311/server/services/__fixtures__/elasticsearch.json
@@ -1,0 +1,44 @@
+[
+  {
+    "service_request_id": "200012223",
+    "status": "open",
+    "location": null,
+    "address": "50 Milk St.",
+    "description": "There are large rats here. They’re biting.",
+    "service_name": "Rat bite",
+    "service_code": "RATBITE",
+    "status_notes": "",
+    "requested_datetime": "2018-12-07T16:26:46+0000",
+    "updated_datetime": "2018-12-07T16:26:46+0000",
+    "replay_id": 3,
+    "media_url": null
+  },
+  {
+    "service_request_id": "200012224",
+    "status": "closed",
+    "location": null,
+    "address": "50 Milk St.",
+    "description": "Needles in the park",
+    "service_name": "Needle pickup",
+    "service_code": "NEEDLES",
+    "status_notes": "",
+    "requested_datetime": "2018-12-07T16:26:46+0000",
+    "updated_datetime": "2018-12-07T16:26:46+0000",
+    "replay_id": 3,
+    "media_url": "https://pbs.twimg.com/media/C22X9ODXgAABGKS.jpg"
+  },
+  {
+    "service_request_id": "200012225",
+    "status": "closed",
+    "location": null,
+    "address": "50 Milk St.",
+    "description": "Take my refridgerator, please",
+    "service_name": "Bulk Item Pickup",
+    "service_code": "SCHDBLKITM",
+    "status_notes": "",
+    "requested_datetime": "2018-12-07T16:26:46+0000",
+    "updated_datetime": "2018-12-07T16:26:46+0000",
+    "replay_id": 3,
+    "media_url": null
+  }
+]


### PR DESCRIPTION
 - Adds @observable back in on some HTML elements because @computed
   functions rely on them and need to re-compute when they become
   not-null.
 - Just removes hover handlers when doing the mobile UI so that tapping
   on a search result will go to it, rather than (potentially) show the
   map pop-up and scroll it (which then causes another search, which
   changes the list).

Adds an Elasticsearch fake so that this part of the UI can be exercised
without AWS credentials.