### PR TITLE
Uploads screenshots from Travis branch failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,14 @@ jobs:
   include:
   - stage: test
     if: type IN (push)
-    install: yarn install --frozen-lockfile
+    install:
+    - curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+    - yarn install --frozen-lockfile
     script:
     - yarn run test
     - yarn run test:templates
+    after_failure:
+    - artifacts upload --target-paths travis/screenshots/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID services-js/*/screenshots
     deploy:
       provider: script
       skip_cleanup: true


### PR DESCRIPTION
Previously we only uploaded screenshots from failures during pull
requests. This adds it for branch updates (e.g. develop) as well.