### PR TITLE
Allows partial case numbers for legacy cases

### DIFF
--- a/services-js/311/components/request/home/HomePane.tsx
+++ b/services-js/311/components/request/home/HomePane.tsx
@@ -155,10 +155,10 @@ export default class HomePane extends React.Component<Props> {
   @action.bound
   handleSearchSubmit(ev: FormEvent) {
     ev.preventDefault();
+    const caseUrls = RequestSearch.caseUrlsForSearchQuery(this.searchValue);
 
-    if (RequestSearch.isCaseId(this.searchValue)) {
-      const id = this.searchValue.trim();
-      Router.push(`/reports?id=${id}`, `/reports/${id}`);
+    if (caseUrls) {
+      Router.push(caseUrls.url, caseUrls.as);
     } else {
       const encodedSearch = encodeURIComponent(this.searchValue);
       Router.push(`/search?q=${encodedSearch}`);

--- a/services-js/311/components/search/SearchLayout.tsx
+++ b/services-js/311/components/search/SearchLayout.tsx
@@ -211,10 +211,10 @@ export default class SearchLayout extends React.Component<Props> {
       }),
       ({ query, resultsQuery, location, zoom }) => {
         const params = new URLSearchParams();
+        const caseUrls = RequestSearch.caseUrlsForSearchQuery(query);
 
-        if (RequestSearch.isCaseId(query)) {
-          const id = query.trim();
-          Router.push(`/reports?id=${id}`, `/reports/${id}`);
+        if (caseUrls) {
+          Router.push(caseUrls.url, caseUrls.as);
         } else {
           if (resultsQuery) {
             params.append('q', resultsQuery);

--- a/services-js/311/data/store/RequestSearch.test.ts
+++ b/services-js/311/data/store/RequestSearch.test.ts
@@ -62,20 +62,36 @@ describe('results', () => {
   });
 });
 
-describe('isCaseId', () => {
-  it('is true for a Lagan case', () => {
-    expect(RequestSearch.isCaseId('101002184571')).toEqual(true);
+describe('caseUrlsForSearchQuery', () => {
+  it('finds a full Lagan case', () => {
+    expect(RequestSearch.caseUrlsForSearchQuery('101002184571')!.as).toEqual(
+      '/reports/101002184571'
+    );
   });
 
-  it('is true for a new case', () => {
-    expect(RequestSearch.isCaseId('17-00001162')).toEqual(true);
+  it('finds a new case ID', () => {
+    expect(RequestSearch.caseUrlsForSearchQuery('3123123')!.as).toEqual(
+      '/reports/3123123'
+    );
   });
 
-  it('is false for another number', () => {
-    expect(RequestSearch.isCaseId('1989')).toEqual(false);
+  it('ignores # signs and whitespace', () => {
+    expect(RequestSearch.caseUrlsForSearchQuery('#3123123 ')!.as).toEqual(
+      '/reports/3123123'
+    );
   });
 
-  it('is false in general', () => {
-    expect(RequestSearch.isCaseId('sidewalk')).toEqual(false);
+  it('adds legacy prefix to old case numbers', () => {
+    expect(RequestSearch.caseUrlsForSearchQuery('2123123')!.as).toEqual(
+      '/reports/101002123123'
+    );
+  });
+
+  it('is null for another number', () => {
+    expect(RequestSearch.caseUrlsForSearchQuery('1989')).toEqual(null);
+  });
+
+  it('is null in general', () => {
+    expect(RequestSearch.caseUrlsForSearchQuery('sidewalk')).toEqual(null);
   });
 });


### PR DESCRIPTION
If the user searches for a 7-digit case ID that’s in the range used for
Lagan, we automatically add the prefix to fill it out to the full Lagan
case ID format.

Fixes CityOfBoston/311#888