### PR TITLE
Switches web component JS URL and removes polyfill

### DIFF
--- a/services-js/311/pages/_document.tsx
+++ b/services-js/311/pages/_document.tsx
@@ -183,7 +183,7 @@ export default class extends Document {
           </div>
           <script
             src={`${process.env.WEB_COMPONENTS_URI ||
-              'https://patterns.boston.gov/web-components/all.js'}?k=${cacheParam}`}
+              'https://patterns.boston.gov/web-components/fleetcomponents.js'}?k=${cacheParam}`}
           />
           <NextScript />
           <ContactForm

--- a/services-js/commissions-app/src/pages/_document.tsx
+++ b/services-js/commissions-app/src/pages/_document.tsx
@@ -92,7 +92,7 @@ var _rollbarConfig = {
 
           <script
             src={`${process.env.WEB_COMPONENTS_URI ||
-              'https://patterns.boston.gov/web-components/all.js'}`}
+              'https://patterns.boston.gov/web-components/fleetcomponents.js'}`}
           />
 
           <NextScript />

--- a/services-js/registry-certs/pages/_document.tsx
+++ b/services-js/registry-certs/pages/_document.tsx
@@ -102,60 +102,6 @@ export default class extends Document {
             />
           )}
 
-          {/* short-term fix for https://github.com/ionic-team/stencil/issues/606 */}
-          <script
-            type="text/javascript"
-            dangerouslySetInnerHTML={{
-              __html: `
-            if (!Array.prototype.find) {
-              Object.defineProperty(Array.prototype, 'find', {
-                writable: true,
-                value: function(predicate) {
-                 // 1. Let O be ? ToObject(this value).
-                  if (this == null) {
-                    throw new TypeError('"this" is null or not defined');
-                  }
-            
-                  var o = Object(this);
-            
-                  // 2. Let len be ? ToLength(? Get(O, "length")).
-                  var len = o.length >>> 0;
-            
-                  // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-                  if (typeof predicate !== 'function') {
-                    throw new TypeError('predicate must be a function');
-                  }
-            
-                  // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-                  var thisArg = arguments[1];
-            
-                  // 5. Let k be 0.
-                  var k = 0;
-            
-                  // 6. Repeat, while k < len
-                  while (k < len) {
-                    // a. Let Pk be ! ToString(k).
-                    // b. Let kValue be ? Get(O, Pk).
-                    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-                    // d. If testResult is true, return kValue.
-                    var kValue = o[k];
-                    if (predicate.call(thisArg, kValue, k, o)) {
-                      return kValue;
-                    }
-                    // e. Increase k by 1.
-                    k++;
-                  }
-            
-                  // 7. Return undefined.
-                  return undefined;
-                }
-              });
-            }
-            
-            `,
-            }}
-          />
-
           {styleTags({ cacheParam, additionalCss: css })}
 
           {process.env.GOOGLE_TRACKING_ID && (
@@ -186,7 +132,7 @@ export default class extends Document {
 
           <script
             src={`${process.env.WEB_COMPONENTS_URI ||
-              'https://patterns.boston.gov/web-components/all.js'}?k=${cacheParam}`}
+              'https://patterns.boston.gov/web-components/fleetcomponents.js'}?k=${cacheParam}`}
           />
 
           <script src="https://js.stripe.com/v3/" />


### PR DESCRIPTION
all.js is an old URL. New versions are published at fleetcomponents.js.

Also the polyfill issue was fixed, so we don’t need it any more.

Fixes #6
Fixes #7