### PR TITLE
Adjusts allocation code based on order type

### DIFF
--- a/services-js/payment-webhooks/server/services/INovah.test.ts
+++ b/services-js/payment-webhooks/server/services/INovah.test.ts
@@ -224,6 +224,7 @@ describe('INovah', () => {
           'REG-DC-20171214-abcd123',
           'chg_testcharge',
           'txn_testtxn',
+          'DC',
           {
             amountInDollars: 28.0,
             unitPriceInDollars: 14.0,

--- a/services-js/payment-webhooks/server/services/INovah.ts
+++ b/services-js/payment-webhooks/server/services/INovah.ts
@@ -263,6 +263,17 @@ export interface INovahClient {
   ): Promise<VoidTransactionOutput>;
 }
 
+/**
+ * iNovah allocation codes for our different order types.
+ *
+ * Keys of this hash match the OrderType enum in registry-certs’ RegistryDb.ts
+ * file.
+ */
+const ORDER_TYPE_TO_ALLOCATION_CODE = {
+  DC: 'REG13',
+  BC: 'REG14',
+};
+
 export class INovahFactory {
   client: INovahClient;
   username: string;
@@ -372,6 +383,7 @@ export default class INovah {
     registryOrderId: string,
     stripeChargeId: string,
     stripeTransactionId: string,
+    orderType: string,
     { quantity, amountInDollars, unitPriceInDollars }: TransactionPayment,
     {
       cardholderName,
@@ -383,6 +395,9 @@ export default class INovah {
     }: TransactionCustomer
   ): Promise<AddTransactionReturn> {
     const { client, securityKey, paymentOrigin } = this;
+    const allocationCode =
+      ORDER_TYPE_TO_ALLOCATION_CODE[orderType] ||
+      ORDER_TYPE_TO_ALLOCATION_CODE['DC'];
 
     const output = await client.AddTransactionAsync({
       strSecurityKey: securityKey,
@@ -398,9 +413,9 @@ export default class INovah {
               ? undefined
               : stripeTransactionId,
           Payment: {
-            PaymentCode: 'REG13',
+            PaymentCode: allocationCode,
             PaymentAllocation: {
-              AllocationCode: 'REG13',
+              AllocationCode: allocationCode,
               Quantity: quantity.toString(),
               Amount: amountInDollars.toFixed(4),
               UnitCharge: unitPriceInDollars.toString(),

--- a/services-js/payment-webhooks/server/stripe-events.test.ts
+++ b/services-js/payment-webhooks/server/stripe-events.test.ts
@@ -45,6 +45,7 @@ describe('processStripeEvent', () => {
         'DC-20171215-yg4lk',
         'ch_00000000000000',
         'txn_1BYfsgHEIqCf0Nlg2VWuyvMI',
+        'DC',
         {
           amountInDollars: 14.0,
           quantity: 1,

--- a/services-js/payment-webhooks/server/stripe-events.ts
+++ b/services-js/payment-webhooks/server/stripe-events.ts
@@ -37,6 +37,7 @@ async function processChargeSucceeded(
   }
 
   const balanceTransaction = latestCharge.balance_transaction;
+  const orderType = charge.metadata['order.orderType'] || 'DC';
 
   const {
     transactionId,
@@ -47,6 +48,7 @@ async function processChargeSucceeded(
     charge.metadata['order.orderId'] || 'unknown',
     charge.id,
     balanceTransaction.id,
+    orderType,
     {
       // Stripe works in cents, iNovah in floating-point dollars.
       amountInDollars: balanceTransaction.net / 100,


### PR DESCRIPTION
Birth certificates will have a different allocation code from death
certificates. The order.orderType is currently being sent by
registry-certs.