### PR TITLE
Rework of error handling in checkout flow

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -2925,26 +2925,44 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
               </div>
             </fieldset>
             <div
-              className="m-v500 p-a300 br br-a100 br--r"
-              id="processing-error"
+              className="md "
             >
               <div
-                className="t--intro t--err"
+                className="md-c br br-t400 css-1y2scv5"
               >
-                There’s a problem: 
-                The card could not be tokenized.
-              </div>
-              <div
-                className="t--info"
-              >
-                You can try again. If this keeps happening, please email
-                 
-                <a
-                  href="mailto:digital@boston.gov"
+                <div
+                  className="md-b p-a300"
                 >
-                  digital@boston.gov
-                </a>
-                .
+                  <div
+                    className="t--intro t--err"
+                  >
+                    There’s a problem: The card could not be tokenized
+                  </div>
+                  <div
+                    className="t--info m-t300"
+                  >
+                    You can try again. If this keeps happening, please email
+                     
+                    <a
+                      href="mailto:digital@boston.gov"
+                    >
+                      digital@boston.gov
+                    </a>
+                    .
+                  </div>
+                  <div
+                    className="m-t300 ta-r"
+                  >
+                    <button
+                      autoFocus={true}
+                      className="btn btn--sm btn--100"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Close
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
             <div
@@ -2954,7 +2972,6 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  aria-describedby="processing-error"
                   className="btn btn--b"
                   disabled={true}
                   type="submit"
@@ -7921,6 +7938,730 @@ exports[`Storyshots Checkout/ReviewContent default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Checkout/ReviewContent payment error 1`] = `
+<div>
+  <a
+    className="btn a11y--h a11y--f"
+    href="#content-start"
+    onClick={[Function]}
+    style={
+      Object {
+        "margin": 4,
+      }
+    }
+    tabIndex={1}
+  >
+    Jump to content
+  </a>
+  <input
+    aria-label="Open Boston.gov menu"
+    checked={undefined}
+    className="brg-tr"
+    id="brg-tr"
+    onKeyDown={[Function]}
+    type="checkbox"
+  />
+  <nav
+    aria-label="Boston.gov menu"
+    className="nv-m"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+  <div class=\\"nv-m-h\\">
+      <div class=\\"nv-m-h-ic\\">
+        <a href=\\"https://www.boston.gov/\\" title=\\"Go to home page\\">
+          <img src=\\"https://patterns.boston.gov/images/b-dark.svg\\" title=\\"B\\" aria-hidden=\\"true\\" class=\\"nv-m-h-i\\">
+        </a>
+      </div>
+      <div id=\\"nv-m-h-t\\" class=\\"nv-m-h-t\\">&#xA0;</div>
+  </div>
+  <div class=\\"nv-m-c\\">
+    
+
+<ul class=\\"nv-m-c-l\\"><li class=\\"nv-m-c-l-i is-l first leaf menu-mlid-763366 nv-m-c-a--y\\"><a href=\\"http://www.cityofboston.gov/311/\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p three-one-one\\">Help / 311</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-210101\\"><a href=\\"https://www.boston.gov/homepage\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Home</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-171721\\"><a href=\\"https://www.boston.gov/guides\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Guides to Boston</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-171726\\"><a href=\\"https://www.boston.gov/departments\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Departments</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-1675906\\"><a href=\\"https://www.boston.gov/public-notices\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Public Notices</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-2354776\\"><a href=\\"https://www.boston.gov/pay-and-apply\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Pay and apply</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-2354781\\"><a href=\\"https://www.boston.gov/career-center\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Work for the City</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-885866\\"><a href=\\"https://www.boston.gov/events\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Events</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-202946\\"><a href=\\"https://www.boston.gov/news\\" class=\\"nv-m-c-a nv-m-c-a--p\\">News</a></li>
+<li class=\\"nv-m-c-l-i is-e expanded menu-mlid-171731\\"><a href=\\"https://www.boston.gov/#\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p nolink\\">Places</a><ul class=\\"nv-m-c-l-l\\"><li class=\\"nv-m-c-bc nv-m-c-b--h\\"><button class=\\"nv-m-c-b\\">Back</button></li><li class=\\"nv-m-c-l-l-i is-l first leaf menu-mlid-2354766\\"><a href=\\"https://www.boston.gov/cemeteries\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Cemeteries</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354751\\"><a href=\\"https://www.boston.gov/community-centers\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Community centers</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-184086\\"><a href=\\"https://www.boston.gov/departments/landmarks-commission#historic-districts\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Historic Districts</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171801\\"><a href=\\"http://www.bpl.org/general/branch.htm\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Libraries</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354771\\"><a href=\\"https://www.boston.gov/neighborhoods\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Neighborhoods</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354761\\"><a href=\\"https://www.boston.gov/parks-and-playgrounds\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Parks and playgrounds</a></li>
+<li class=\\"nv-m-c-l-l-i is-l last leaf menu-mlid-652731\\"><a href=\\"http://www.bostonpublicschools.org/Page/628\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Schools</a></li>
+</ul></li>
+<li class=\\"nv-m-c-l-i is-e last expanded menu-mlid-171741\\"><a href=\\"https://www.boston.gov/#\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p nolink\\">Government</a><ul class=\\"nv-m-c-l-l\\"><li class=\\"nv-m-c-bc nv-m-c-b--h\\"><button class=\\"nv-m-c-b\\">Back</button></li><li class=\\"nv-m-c-l-l-i is-l first leaf menu-mlid-171851\\"><a href=\\"https://www.boston.gov/departments/mayors-office\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">The Mayor&apos;s Office</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171856\\"><a href=\\"https://www.boston.gov/departments/city-council\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City Council</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171861\\"><a href=\\"https://www.boston.gov/departments/city-clerk\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City Clerk</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171866\\"><a href=\\"https://www.boston.gov/departments/election\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Elections</a></li>
+<li class=\\"nv-m-c-l-l-i is-l last leaf menu-mlid-178041\\"><a href=\\"https://www.boston.gov/departments/311/city-boston-government\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City government</a></li>
+</ul></li>
+</ul>  </div>
+",
+      }
+    }
+  />
+  <div
+    className="mn--full-ie"
+  >
+    <div
+      className="mn mn--full "
+    >
+      <input
+        aria-hidden="true"
+        className="s-tr"
+        id="s-tr"
+        type="checkbox"
+      />
+      <header
+        className="h"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "
+    <label for=\\"brg-tr\\" class=\\"brg-b\\">
+  <div class=\\"brg\\">
+    <span class=\\"brg-c\\">
+      <span class=\\"brg-c-i\\"></span>
+    </span>
+    <span class=\\"brg-t\\"><span class=\\"a11y--h\\">Toggle </span>Menu</span>
+  </div>
+</label>
+      <div class=\\"lo lo--abs\\">
+    <div class=\\"lo-l\\">
+      <a href=\\"https://www.boston.gov/\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+      </a>
+              <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
+          </div>
+  </div>
+    <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+</a>
+    <nav class=\\"nv-h\\">
+  <ul class=\\"nv-h-l\\">
+              <li class=\\"nv-h-l-i\\"><a href=\\"https://www.boston.gov/pay-and-apply\\" title=\\"Pay and apply\\" class=\\"nv-h-l-a\\">Pay and apply</a></li>
+          <li class=\\"nv-h-l-i\\"><a href=\\"https://www.boston.gov/public-notices\\" title=\\"Public notices\\" class=\\"nv-h-l-a\\">Public notices</a></li>
+          <li class=\\"nv-h-l-i\\"><a href=\\"mailto:feedback@boston.gov\\" title=\\"Feedback\\" class=\\"nv-h-l-a\\" onClick=\\"document.getElementById(&quot;contactForm&quot;).show(); return false;\\">Feedback</a></li>
+        <li class=\\"tr nv-h-l-i\\">
+      <a href=\\"https://www.boston.gov/#translate\\" title=\\"Translate\\" class=\\"nv-h-l-a nv-h-l-a--k--s tr-link\\">Translate</a>
+      <ul class=\\"tr-dd\\">
+        <li><span class=\\"notranslate tr-dd-link tr-dd-link--message\\">Loading...</span></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"ht\\">Krey&#xF2;l Ayisyen</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"pt\\">Portugese</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"es\\">Espa&#xF1;ol</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"vi\\">Ti&#x1EBF;ng Vi&#x1EC7;t</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link tr-dd-link--hidden\\" data-ln=\\"en\\">English</a></li>
+      </ul>
+    </li>
+    <li class=\\"nv-h-l-i\\">
+      <label for=\\"s-tr\\" title=\\"Search\\" class=\\"nv-h-l-a nv-h-l-a--k nv-h-l-a-ic\\" id=\\"searchIcon\\">
+        <svg id=\\"Layer_2\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 40 41\\"><title>Search</title><path class=\\"nv-h-l-a-i\\" d=\\"M24.2.6C15.8.6 9 7.4 9 15.8c0 3.7 1.4 7.2 3.6 9.8L1.2 37c-.8.8-.8 2 0 2.8.4.4.9.6 1.4.6s1-.2 1.4-.6l11.5-11.5C18 30 21 31 24.2 31c8.4 0 15.2-6.8 15.2-15.2C39.4 7.4 32.6.6 24.2.6zm0 26.5c-6.2 0-11.2-5-11.2-11.2S18 4.6 24.2 4.6s11.2 5 11.2 11.2-5 11.3-11.2 11.3z\\"/></svg>
+      </label>
+    </li>
+  </ul>
+</nav>
+    <div class=\\"h-s\\">
+  <form class=\\"sf\\" action=\\"https://www.boston.gov/search\\" accept-charset=\\"UTF-8\\" method=\\"get\\">
+    <input name=\\"utf8\\" type=\\"hidden\\" value=\\"&#x2713;\\">
+    <div class=\\"sf-i\\">
+      <input type=\\"text\\" name=\\"query\\" id=\\"query\\" value=\\"\\" placeholder=\\"Search&#x2026;\\" class=\\"sf-i-f\\" autocomplete=\\"off\\">
+      <button class=\\"sf-i-b\\">Search</button>
+    </div>
+  </form>
+</div>
+  ",
+          }
+        }
+        role="banner"
+      />
+      <nav
+        aria-label="Breadcrumbs"
+        className="brc css-1bakzg2 p-a300"
+      >
+        <ul
+          className="brc-l"
+        >
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/"
+            >
+              Home
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/departments"
+            >
+              Departments
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/departments/registry"
+            >
+              Registry: Birth, death, and marriage
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              aria-current="page"
+              className="css-xtnqqy"
+              href="/death"
+            >
+              Death certificates
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        className="a11y--content-start"
+        id="content-start"
+      />
+      <main
+        className="b-ff"
+      >
+        <div
+          className="b-c b-c--hsm b-c--nbp"
+        >
+          <div
+            className="sh sh--b0"
+          >
+            <h1
+              className="sh-title"
+            >
+              Review Order
+            </h1>
+          </div>
+          <div
+            className="t--info m-v500"
+          >
+            Your order is not yet complete. Please check the information below, then click the 
+            <b>
+              Submit Order
+            </b>
+             button.
+          </div>
+          <form
+            acceptCharset="UTF-8"
+            method="post"
+            onSubmit={[Function]}
+          >
+            <div
+              className="m-v700"
+            >
+              <div
+                className="fs-l"
+              >
+                <div
+                  className="fs-l-c"
+                >
+                  Order Details
+                  <span
+                    className="t--reset"
+                  >
+                     — 
+                    <span
+                      className="t--subinfo"
+                    >
+                      <a
+                        aria-label="Edit cart"
+                        href="/death/cart"
+                        onClick={[Function]}
+                      >
+                        edit
+                      </a>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div>
+                <div
+                  className="p-v200 br b--w css-p2blui "
+                >
+                  <div
+                    className="t--sans p-a300"
+                    style={
+                      Object {
+                        "fontWeight": "bold",
+                      }
+                    }
+                  >
+                    <span
+                      aria-label="Quantity"
+                    >
+                      1
+                    </span>
+                     ×
+                  </div>
+                  <div
+                    className="css-1rr4qq7"
+                  >
+                    <div
+                      className="t--sans m-v100 css-1s592rj"
+                    >
+                      BRUCE
+                       
+                      BANNER
+                    </div>
+                    <div
+                      className="css-19r4q7b"
+                    >
+                      Died: 
+                      3/4/2016
+                       — Age: 53
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="p-v200 br b--w css-p2blui "
+                >
+                  <div
+                    className="t--sans p-a300"
+                    style={
+                      Object {
+                        "fontWeight": "bold",
+                      }
+                    }
+                  >
+                    <span
+                      aria-label="Quantity"
+                    >
+                      5
+                    </span>
+                     ×
+                  </div>
+                  <div
+                    className="css-1rr4qq7"
+                  >
+                    <div
+                      className="t--sans m-v100 css-1s592rj"
+                    >
+                      MONKEY
+                       
+                      JOE
+                    </div>
+                    <div
+                      className="css-19r4q7b"
+                    >
+                      Died: 
+                      2004
+                       — Age: 6
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="m-v700"
+            >
+              <div
+                className="fs-l"
+              >
+                <div
+                  className="fs-l-c"
+                >
+                  Shipping Address
+                  <span
+                    className="t--reset"
+                  >
+                     — 
+                    <span
+                      className="t--subinfo"
+                    >
+                      <a
+                        aria-label="Edit shipping address"
+                        href="/death/checkout"
+                        onClick={[Function]}
+                      >
+                        edit
+                      </a>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
+              >
+                Doreen Green
+                <br />
+                Empire State University
+                <br />
+                Dorm Hall, Apt 5
+                <br />
+                10 College Avenue
+                <br />
+                New York, NY 12345
+              </div>
+            </div>
+            <div
+              className="fs m-v700"
+            >
+              <div
+                className="fs-l"
+              >
+                <div
+                  className="fs-l-c"
+                >
+                  Payment Information
+                  <span
+                    className="t--reset"
+                  >
+                     — 
+                    <span
+                      className="t--subinfo"
+                    >
+                      <a
+                        aria-label="Edit payment information"
+                        href="/death/checkout"
+                        onClick={[Function]}
+                      >
+                        edit
+                      </a>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
+              >
+                Nancy Whitehead
+                <br />
+                **** **** **** 
+                4040
+                <br />
+                3 Avengers Towers
+                <br />
+                New York
+                , 
+                NY
+                 
+                12223
+              </div>
+            </div>
+            <div
+              className="m-v500"
+            >
+              <div
+                className="css-5x1uzq"
+              >
+                <table
+                  className="t--info ta-r"
+                  style={
+                    Object {
+                      "float": "right",
+                    }
+                  }
+                >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        6
+                         
+                        certificates
+                         ×
+                         
+                        $14.00
+                      </td>
+                      <td
+                        className="css-1698s6w"
+                      >
+                        $
+                        84.00
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span>
+                          Credit card service fee 
+                          <a
+                            href="#service-fee"
+                          >
+                            *
+                          </a>
+                        </span>
+                      </td>
+                      <td
+                        className="css-1698s6w"
+                      >
+                        $
+                        2.06
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        U.S. shipping included
+                      </td>
+                      <td
+                        className="css-1698s6w"
+                      >
+                        <i>
+                          $0.00
+                        </i>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td
+                        className="sh-title css-1ujpul8"
+                      >
+                        <span
+                          className="css-1tg3jta"
+                        >
+                          Total
+                        </span>
+                      </td>
+                      <td
+                        className="cost-cell cost br br-t100 p-v200"
+                      >
+                        $
+                        86.06
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="m-v700"
+            >
+              <div
+                className="t--info"
+              >
+                You have to read and accept this checkbox before you place your order:
+              </div>
+              <div
+                className="m-v300"
+              >
+                <label
+                  className="cb"
+                >
+                  <input
+                    checked={false}
+                    className="cb-f"
+                    id="acceptNonRefundableInput"
+                    name="acceptNonRefundable"
+                    onChange={[Function]}
+                    type="checkbox"
+                    value="true"
+                  />
+                  <span
+                    className="cb-l"
+                  >
+                    I understand that
+                     
+                    <strong>
+                      death certificates are non-refundable
+                    </strong>
+                    .
+                  </span>
+                </label>
+              </div>
+            </div>
+            <div
+              className="t--info m-v300"
+              id="charge-message"
+            >
+              Pressing the “Submit Order” button will charge the total amount to your credit card and place an order with the Registry.
+            </div>
+            <div
+              className="md "
+            >
+              <div
+                className="md-c br br-t400 css-1y2scv5"
+              >
+                <div
+                  className="md-b p-a300"
+                >
+                  <div
+                    className="t--intro t--err"
+                  >
+                    Your card's security code is incorrect
+                  </div>
+                  <div
+                    className="t--info m-t300"
+                  >
+                    You can update your payment information and try to submit this order again.
+                  </div>
+                  <div
+                    className="m-v500 ta-c"
+                  >
+                    <a
+                      className="btn"
+                      href="/death/checkout"
+                      onClick={[Function]}
+                    >
+                      Update Payment Information
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="m-v300"
+            >
+              <button
+                aria-describedby="charge-message"
+                className="btn"
+                disabled={true}
+                style={
+                  Object {
+                    "display": "block",
+                    "width": "100%",
+                  }
+                }
+                type="submit"
+              >
+                Submit Order
+              </button>
+            </div>
+            <div
+              className="ta-c t--info m-v700"
+            >
+              <a
+                href="/death"
+                onClick={[Function]}
+              >
+                I’m not done yet, go back to search
+              </a>
+            </div>
+          </form>
+        </div>
+        <div
+          className="b--g m-t700"
+        >
+          <div
+            className="b-c b-c--smv b-c--hsm t--subinfo"
+            id="service-fee"
+          >
+            * You are charged an extra service fee of not more than
+             
+            $0.25
+             plus 
+            2.15%
+            . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+             
+            <a
+              href="https://www.cityofboston.gov/payments/faqs.asp"
+            >
+              credit card service fees
+            </a>
+             at the City of Boston.
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+  <footer
+    className="ft"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+    <div class=\\"ft-c\\">
+      <ul class=\\"ft-ll ft-ll--r\\">
+        <li class=\\"ft-ll-i\\"><a href=\\"http://www.cityofboston.gov/311/\\" class=\\"ft-ll-a lnk--yellow\\"><span class=\\"ft-ll-311\\">BOS:311</span><span class=\\"tablet--hidden\\"> - </span>Report an issue</a></li>
+      </ul>
+      
+
+<ul class=\\"ft-ll\\"><li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/innovation-and-technology/privacy-and-security-statement\\" target=\\"_blank\\" title=\\"\\" class=\\"ft-ll-a\\">Privacy Policy</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/mayors-office/contact-boston-city-hall\\" title=\\"\\" class=\\"ft-ll-a\\">Contact us</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/digital-team/city-boston-alerts-and-notifications\\" title=\\"\\" class=\\"ft-ll-a\\">Alerts and notifications</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/public-records\\" title=\\"\\" class=\\"ft-ll-a\\">Public records requests</a></li>
+</ul>    </div>
+  ",
+      }
+    }
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 2,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
 <div>
   <a
@@ -8529,33 +9270,764 @@ exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
               Pressing the “Submit Order” button will charge the total amount to your credit card and place an order with the Registry.
             </div>
             <div
-              className="m-v500 p-a300 br br-a100 br--r"
-              id="processing-error"
+              className="md "
             >
               <div
-                className="t--intro t--err"
+                className="md-c br br-t400 css-1y2scv5"
               >
-                There’s a problem: 
-                The order could not be processed.
-              </div>
-              <div
-                className="t--info"
-              >
-                You can try again. If this keeps happening, please email
-                 
-                <a
-                  href="mailto:digital@boston.gov"
+                <div
+                  className="md-b p-a300"
                 >
-                  digital@boston.gov
-                </a>
-                .
+                  <div
+                    className="t--intro t--err"
+                  >
+                    There’s a problem: The order could not be processed.
+                  </div>
+                  <div
+                    className="t--info m-t300"
+                  >
+                    You can try again. If this keeps happening, please email
+                     
+                    <a
+                      href="mailto:digital@boston.gov"
+                    >
+                      digital@boston.gov
+                    </a>
+                    .
+                  </div>
+                  <div
+                    className="m-t300 ta-r"
+                  >
+                    <button
+                      autoFocus={true}
+                      className="btn btn--sm btn--100"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Close
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
             <div
               className="m-v300"
             >
               <button
-                aria-describedby="processing-error"
+                aria-describedby="charge-message"
+                className="btn"
+                disabled={true}
+                style={
+                  Object {
+                    "display": "block",
+                    "width": "100%",
+                  }
+                }
+                type="submit"
+              >
+                Submit Order
+              </button>
+            </div>
+            <div
+              className="ta-c t--info m-v700"
+            >
+              <a
+                href="/death"
+                onClick={[Function]}
+              >
+                I’m not done yet, go back to search
+              </a>
+            </div>
+          </form>
+        </div>
+        <div
+          className="b--g m-t700"
+        >
+          <div
+            className="b-c b-c--smv b-c--hsm t--subinfo"
+            id="service-fee"
+          >
+            * You are charged an extra service fee of not more than
+             
+            $0.25
+             plus 
+            2.15%
+            . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+             
+            <a
+              href="https://www.cityofboston.gov/payments/faqs.asp"
+            >
+              credit card service fees
+            </a>
+             at the City of Boston.
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+  <footer
+    className="ft"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+    <div class=\\"ft-c\\">
+      <ul class=\\"ft-ll ft-ll--r\\">
+        <li class=\\"ft-ll-i\\"><a href=\\"http://www.cityofboston.gov/311/\\" class=\\"ft-ll-a lnk--yellow\\"><span class=\\"ft-ll-311\\">BOS:311</span><span class=\\"tablet--hidden\\"> - </span>Report an issue</a></li>
+      </ul>
+      
+
+<ul class=\\"ft-ll\\"><li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/innovation-and-technology/privacy-and-security-statement\\" target=\\"_blank\\" title=\\"\\" class=\\"ft-ll-a\\">Privacy Policy</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/mayors-office/contact-boston-city-hall\\" title=\\"\\" class=\\"ft-ll-a\\">Contact us</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/digital-team/city-boston-alerts-and-notifications\\" title=\\"\\" class=\\"ft-ll-a\\">Alerts and notifications</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/public-records\\" title=\\"\\" class=\\"ft-ll-a\\">Public records requests</a></li>
+</ul>    </div>
+  ",
+      }
+    }
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 2,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Storyshots Checkout/ReviewContent submitting 1`] = `
+<div>
+  <a
+    className="btn a11y--h a11y--f"
+    href="#content-start"
+    onClick={[Function]}
+    style={
+      Object {
+        "margin": 4,
+      }
+    }
+    tabIndex={1}
+  >
+    Jump to content
+  </a>
+  <input
+    aria-label="Open Boston.gov menu"
+    checked={undefined}
+    className="brg-tr"
+    id="brg-tr"
+    onKeyDown={[Function]}
+    type="checkbox"
+  />
+  <nav
+    aria-label="Boston.gov menu"
+    className="nv-m"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+  <div class=\\"nv-m-h\\">
+      <div class=\\"nv-m-h-ic\\">
+        <a href=\\"https://www.boston.gov/\\" title=\\"Go to home page\\">
+          <img src=\\"https://patterns.boston.gov/images/b-dark.svg\\" title=\\"B\\" aria-hidden=\\"true\\" class=\\"nv-m-h-i\\">
+        </a>
+      </div>
+      <div id=\\"nv-m-h-t\\" class=\\"nv-m-h-t\\">&#xA0;</div>
+  </div>
+  <div class=\\"nv-m-c\\">
+    
+
+<ul class=\\"nv-m-c-l\\"><li class=\\"nv-m-c-l-i is-l first leaf menu-mlid-763366 nv-m-c-a--y\\"><a href=\\"http://www.cityofboston.gov/311/\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p three-one-one\\">Help / 311</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-210101\\"><a href=\\"https://www.boston.gov/homepage\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Home</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-171721\\"><a href=\\"https://www.boston.gov/guides\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Guides to Boston</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-171726\\"><a href=\\"https://www.boston.gov/departments\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Departments</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-1675906\\"><a href=\\"https://www.boston.gov/public-notices\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Public Notices</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-2354776\\"><a href=\\"https://www.boston.gov/pay-and-apply\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Pay and apply</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-2354781\\"><a href=\\"https://www.boston.gov/career-center\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Work for the City</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-885866\\"><a href=\\"https://www.boston.gov/events\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Events</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-202946\\"><a href=\\"https://www.boston.gov/news\\" class=\\"nv-m-c-a nv-m-c-a--p\\">News</a></li>
+<li class=\\"nv-m-c-l-i is-e expanded menu-mlid-171731\\"><a href=\\"https://www.boston.gov/#\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p nolink\\">Places</a><ul class=\\"nv-m-c-l-l\\"><li class=\\"nv-m-c-bc nv-m-c-b--h\\"><button class=\\"nv-m-c-b\\">Back</button></li><li class=\\"nv-m-c-l-l-i is-l first leaf menu-mlid-2354766\\"><a href=\\"https://www.boston.gov/cemeteries\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Cemeteries</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354751\\"><a href=\\"https://www.boston.gov/community-centers\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Community centers</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-184086\\"><a href=\\"https://www.boston.gov/departments/landmarks-commission#historic-districts\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Historic Districts</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171801\\"><a href=\\"http://www.bpl.org/general/branch.htm\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Libraries</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354771\\"><a href=\\"https://www.boston.gov/neighborhoods\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Neighborhoods</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354761\\"><a href=\\"https://www.boston.gov/parks-and-playgrounds\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Parks and playgrounds</a></li>
+<li class=\\"nv-m-c-l-l-i is-l last leaf menu-mlid-652731\\"><a href=\\"http://www.bostonpublicschools.org/Page/628\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Schools</a></li>
+</ul></li>
+<li class=\\"nv-m-c-l-i is-e last expanded menu-mlid-171741\\"><a href=\\"https://www.boston.gov/#\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p nolink\\">Government</a><ul class=\\"nv-m-c-l-l\\"><li class=\\"nv-m-c-bc nv-m-c-b--h\\"><button class=\\"nv-m-c-b\\">Back</button></li><li class=\\"nv-m-c-l-l-i is-l first leaf menu-mlid-171851\\"><a href=\\"https://www.boston.gov/departments/mayors-office\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">The Mayor&apos;s Office</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171856\\"><a href=\\"https://www.boston.gov/departments/city-council\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City Council</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171861\\"><a href=\\"https://www.boston.gov/departments/city-clerk\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City Clerk</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171866\\"><a href=\\"https://www.boston.gov/departments/election\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Elections</a></li>
+<li class=\\"nv-m-c-l-l-i is-l last leaf menu-mlid-178041\\"><a href=\\"https://www.boston.gov/departments/311/city-boston-government\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City government</a></li>
+</ul></li>
+</ul>  </div>
+",
+      }
+    }
+  />
+  <div
+    className="mn--full-ie"
+  >
+    <div
+      className="mn mn--full "
+    >
+      <input
+        aria-hidden="true"
+        className="s-tr"
+        id="s-tr"
+        type="checkbox"
+      />
+      <header
+        className="h"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "
+    <label for=\\"brg-tr\\" class=\\"brg-b\\">
+  <div class=\\"brg\\">
+    <span class=\\"brg-c\\">
+      <span class=\\"brg-c-i\\"></span>
+    </span>
+    <span class=\\"brg-t\\"><span class=\\"a11y--h\\">Toggle </span>Menu</span>
+  </div>
+</label>
+      <div class=\\"lo lo--abs\\">
+    <div class=\\"lo-l\\">
+      <a href=\\"https://www.boston.gov/\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+      </a>
+              <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
+          </div>
+  </div>
+    <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+</a>
+    <nav class=\\"nv-h\\">
+  <ul class=\\"nv-h-l\\">
+              <li class=\\"nv-h-l-i\\"><a href=\\"https://www.boston.gov/pay-and-apply\\" title=\\"Pay and apply\\" class=\\"nv-h-l-a\\">Pay and apply</a></li>
+          <li class=\\"nv-h-l-i\\"><a href=\\"https://www.boston.gov/public-notices\\" title=\\"Public notices\\" class=\\"nv-h-l-a\\">Public notices</a></li>
+          <li class=\\"nv-h-l-i\\"><a href=\\"mailto:feedback@boston.gov\\" title=\\"Feedback\\" class=\\"nv-h-l-a\\" onClick=\\"document.getElementById(&quot;contactForm&quot;).show(); return false;\\">Feedback</a></li>
+        <li class=\\"tr nv-h-l-i\\">
+      <a href=\\"https://www.boston.gov/#translate\\" title=\\"Translate\\" class=\\"nv-h-l-a nv-h-l-a--k--s tr-link\\">Translate</a>
+      <ul class=\\"tr-dd\\">
+        <li><span class=\\"notranslate tr-dd-link tr-dd-link--message\\">Loading...</span></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"ht\\">Krey&#xF2;l Ayisyen</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"pt\\">Portugese</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"es\\">Espa&#xF1;ol</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"vi\\">Ti&#x1EBF;ng Vi&#x1EC7;t</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link tr-dd-link--hidden\\" data-ln=\\"en\\">English</a></li>
+      </ul>
+    </li>
+    <li class=\\"nv-h-l-i\\">
+      <label for=\\"s-tr\\" title=\\"Search\\" class=\\"nv-h-l-a nv-h-l-a--k nv-h-l-a-ic\\" id=\\"searchIcon\\">
+        <svg id=\\"Layer_2\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 40 41\\"><title>Search</title><path class=\\"nv-h-l-a-i\\" d=\\"M24.2.6C15.8.6 9 7.4 9 15.8c0 3.7 1.4 7.2 3.6 9.8L1.2 37c-.8.8-.8 2 0 2.8.4.4.9.6 1.4.6s1-.2 1.4-.6l11.5-11.5C18 30 21 31 24.2 31c8.4 0 15.2-6.8 15.2-15.2C39.4 7.4 32.6.6 24.2.6zm0 26.5c-6.2 0-11.2-5-11.2-11.2S18 4.6 24.2 4.6s11.2 5 11.2 11.2-5 11.3-11.2 11.3z\\"/></svg>
+      </label>
+    </li>
+  </ul>
+</nav>
+    <div class=\\"h-s\\">
+  <form class=\\"sf\\" action=\\"https://www.boston.gov/search\\" accept-charset=\\"UTF-8\\" method=\\"get\\">
+    <input name=\\"utf8\\" type=\\"hidden\\" value=\\"&#x2713;\\">
+    <div class=\\"sf-i\\">
+      <input type=\\"text\\" name=\\"query\\" id=\\"query\\" value=\\"\\" placeholder=\\"Search&#x2026;\\" class=\\"sf-i-f\\" autocomplete=\\"off\\">
+      <button class=\\"sf-i-b\\">Search</button>
+    </div>
+  </form>
+</div>
+  ",
+          }
+        }
+        role="banner"
+      />
+      <nav
+        aria-label="Breadcrumbs"
+        className="brc css-1bakzg2 p-a300"
+      >
+        <ul
+          className="brc-l"
+        >
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/"
+            >
+              Home
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/departments"
+            >
+              Departments
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/departments/registry"
+            >
+              Registry: Birth, death, and marriage
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              aria-current="page"
+              className="css-xtnqqy"
+              href="/death"
+            >
+              Death certificates
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        className="a11y--content-start"
+        id="content-start"
+      />
+      <main
+        className="b-ff"
+      >
+        <div
+          className="b-c b-c--hsm b-c--nbp"
+        >
+          <div
+            className="sh sh--b0"
+          >
+            <h1
+              className="sh-title"
+            >
+              Review Order
+            </h1>
+          </div>
+          <div
+            className="t--info m-v500"
+          >
+            Your order is not yet complete. Please check the information below, then click the 
+            <b>
+              Submit Order
+            </b>
+             button.
+          </div>
+          <form
+            acceptCharset="UTF-8"
+            method="post"
+            onSubmit={[Function]}
+          >
+            <div
+              className="m-v700"
+            >
+              <div
+                className="fs-l"
+              >
+                <div
+                  className="fs-l-c"
+                >
+                  Order Details
+                  <span
+                    className="t--reset"
+                  >
+                     — 
+                    <span
+                      className="t--subinfo"
+                    >
+                      <a
+                        aria-label="Edit cart"
+                        href="/death/cart"
+                        onClick={[Function]}
+                      >
+                        edit
+                      </a>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div>
+                <div
+                  className="p-v200 br b--w css-p2blui "
+                >
+                  <div
+                    className="t--sans p-a300"
+                    style={
+                      Object {
+                        "fontWeight": "bold",
+                      }
+                    }
+                  >
+                    <span
+                      aria-label="Quantity"
+                    >
+                      1
+                    </span>
+                     ×
+                  </div>
+                  <div
+                    className="css-1rr4qq7"
+                  >
+                    <div
+                      className="t--sans m-v100 css-1s592rj"
+                    >
+                      BRUCE
+                       
+                      BANNER
+                    </div>
+                    <div
+                      className="css-19r4q7b"
+                    >
+                      Died: 
+                      3/4/2016
+                       — Age: 53
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="p-v200 br b--w css-p2blui "
+                >
+                  <div
+                    className="t--sans p-a300"
+                    style={
+                      Object {
+                        "fontWeight": "bold",
+                      }
+                    }
+                  >
+                    <span
+                      aria-label="Quantity"
+                    >
+                      5
+                    </span>
+                     ×
+                  </div>
+                  <div
+                    className="css-1rr4qq7"
+                  >
+                    <div
+                      className="t--sans m-v100 css-1s592rj"
+                    >
+                      MONKEY
+                       
+                      JOE
+                    </div>
+                    <div
+                      className="css-19r4q7b"
+                    >
+                      Died: 
+                      2004
+                       — Age: 6
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="m-v700"
+            >
+              <div
+                className="fs-l"
+              >
+                <div
+                  className="fs-l-c"
+                >
+                  Shipping Address
+                  <span
+                    className="t--reset"
+                  >
+                     — 
+                    <span
+                      className="t--subinfo"
+                    >
+                      <a
+                        aria-label="Edit shipping address"
+                        href="/death/checkout"
+                        onClick={[Function]}
+                      >
+                        edit
+                      </a>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
+              >
+                Doreen Green
+                <br />
+                Empire State University
+                <br />
+                Dorm Hall, Apt 5
+                <br />
+                10 College Avenue
+                <br />
+                New York, NY 12345
+              </div>
+            </div>
+            <div
+              className="fs m-v700"
+            >
+              <div
+                className="fs-l"
+              >
+                <div
+                  className="fs-l-c"
+                >
+                  Payment Information
+                  <span
+                    className="t--reset"
+                  >
+                     — 
+                    <span
+                      className="t--subinfo"
+                    >
+                      <a
+                        aria-label="Edit payment information"
+                        href="/death/checkout"
+                        onClick={[Function]}
+                      >
+                        edit
+                      </a>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
+              >
+                Nancy Whitehead
+                <br />
+                **** **** **** 
+                4040
+                <br />
+                3 Avengers Towers
+                <br />
+                New York
+                , 
+                NY
+                 
+                12223
+              </div>
+            </div>
+            <div
+              className="m-v500"
+            >
+              <div
+                className="css-5x1uzq"
+              >
+                <table
+                  className="t--info ta-r"
+                  style={
+                    Object {
+                      "float": "right",
+                    }
+                  }
+                >
+                  <caption
+                    className="css-1dv1kvn"
+                  >
+                    Cost Summary
+                  </caption>
+                  <thead
+                    className="css-1dv1kvn"
+                  >
+                    <tr>
+                      <th
+                        scope="col"
+                      >
+                        Item
+                      </th>
+                      <th
+                        scope="col"
+                      >
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        6
+                         
+                        certificates
+                         ×
+                         
+                        $14.00
+                      </td>
+                      <td
+                        className="css-1698s6w"
+                      >
+                        $
+                        84.00
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <span>
+                          Credit card service fee 
+                          <a
+                            href="#service-fee"
+                          >
+                            *
+                          </a>
+                        </span>
+                      </td>
+                      <td
+                        className="css-1698s6w"
+                      >
+                        $
+                        2.06
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        U.S. shipping included
+                      </td>
+                      <td
+                        className="css-1698s6w"
+                      >
+                        <i>
+                          $0.00
+                        </i>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td
+                        className="sh-title css-1ujpul8"
+                      >
+                        <span
+                          className="css-1tg3jta"
+                        >
+                          Total
+                        </span>
+                      </td>
+                      <td
+                        className="cost-cell cost br br-t100 p-v200"
+                      >
+                        $
+                        86.06
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="m-v700"
+            >
+              <div
+                className="t--info"
+              >
+                You have to read and accept this checkbox before you place your order:
+              </div>
+              <div
+                className="m-v300"
+              >
+                <label
+                  className="cb"
+                >
+                  <input
+                    checked={false}
+                    className="cb-f"
+                    id="acceptNonRefundableInput"
+                    name="acceptNonRefundable"
+                    onChange={[Function]}
+                    type="checkbox"
+                    value="true"
+                  />
+                  <span
+                    className="cb-l"
+                  >
+                    I understand that
+                     
+                    <strong>
+                      death certificates are non-refundable
+                    </strong>
+                    .
+                  </span>
+                </label>
+              </div>
+            </div>
+            <div
+              className="t--info m-v300"
+              id="charge-message"
+            >
+              Pressing the “Submit Order” button will charge the total amount to your credit card and place an order with the Registry.
+            </div>
+            <div
+              className="md "
+            >
+              <div
+                className="md-c br br-t400 css-1y2scv5"
+              >
+                <div
+                  className="md-b p-a300"
+                >
+                  <div
+                    className="t--intro "
+                  >
+                    Submitting your order…
+                  </div>
+                  <div
+                    className="t--info m-t300"
+                  >
+                    Please be patient and don’t refresh your browser. This might take a bit.
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="m-v300"
+            >
+              <button
+                aria-describedby="charge-message"
                 className="btn"
                 disabled={true}
                 style={

--- a/services-js/registry-certs/client/dao/CheckoutDao.test.ts
+++ b/services-js/registry-certs/client/dao/CheckoutDao.test.ts
@@ -2,6 +2,7 @@ import { FetchGraphql } from '@cityofboston/next-client-common';
 
 import DeathCertificateCart from '../store/DeathCertificateCart';
 import Order from '../models/Order';
+import { OrderErrorCause } from '../queries/graphql-types';
 
 import CheckoutDao from './CheckoutDao';
 
@@ -45,9 +46,8 @@ describe('tokenizeCard', () => {
     const tokenizePromise = dao.tokenizeCard(order, cardElement);
     expect(order.processing).toEqual(true);
 
-    const success = await tokenizePromise;
+    await expect(tokenizePromise).resolves.toBeUndefined();
 
-    expect(success).toEqual(true);
     expect(order.cardToken).toEqual('tok_id');
     expect(order.cardFunding).toEqual('debit');
     expect(order.info.cardLast4).toEqual('4040');
@@ -64,12 +64,10 @@ describe('tokenizeCard', () => {
     const tokenizePromise = dao.tokenizeCard(order, cardElement);
     expect(order.processing).toEqual(true);
 
-    const success = await tokenizePromise;
+    await expect(tokenizePromise).rejects.toMatchObject({
+      message: 'The credit card could not be tokenized.',
+    });
 
-    expect(success).toEqual(false);
-    expect(order.processingError).toEqual(
-      'The credit card could not be tokenized.'
-    );
     expect(order.processing).toEqual(false);
   });
 
@@ -81,12 +79,10 @@ describe('tokenizeCard', () => {
     const tokenizePromise = dao.tokenizeCard(order, cardElement);
     expect(order.processing).toEqual(true);
 
-    const success = await tokenizePromise;
+    await expect(tokenizePromise).rejects.toMatchObject({
+      message: 'Internet exploded. It’s for the best.',
+    });
 
-    expect(success).toEqual(false);
-    expect(order.processingError).toEqual(
-      'Internet exploded. It’s for the best.'
-    );
     expect(order.processing).toEqual(false);
   });
 });
@@ -94,7 +90,12 @@ describe('tokenizeCard', () => {
 describe('submit', () => {
   test('submit success path', async () => {
     submitDeathCertificateOrder.mockReturnValueOnce(
-      Promise.resolve('order-id')
+      Promise.resolve({
+        order: {
+          id: 'order-id',
+        },
+        error: null,
+      })
     );
 
     const orderIdPromise = dao.submit(cart, order);
@@ -105,7 +106,7 @@ describe('submit', () => {
     expect(order.processing).toEqual(false);
   });
 
-  test('submit failure path', async () => {
+  test('submit network failure path', async () => {
     submitDeathCertificateOrder.mockReturnValueOnce(
       Promise.reject(new Error('I’m not dead yet!'))
     );
@@ -113,9 +114,28 @@ describe('submit', () => {
     const orderIdPromise = dao.submit(cart, order);
     expect(order.processing).toEqual(true);
 
-    const orderId = await orderIdPromise;
-    expect(orderId).toEqual(null);
-    expect(order.processing).toEqual(false);
-    expect(order.processingError).toEqual('I’m not dead yet!');
+    await expect(orderIdPromise).rejects.toMatchObject({
+      message: 'I’m not dead yet!',
+    });
+  });
+
+  test('user payment failure path', async () => {
+    submitDeathCertificateOrder.mockReturnValueOnce(
+      Promise.resolve({
+        order: null,
+        error: {
+          message: 'Your credit card is well expired',
+          cause: OrderErrorCause.USER_PAYMENT,
+        },
+      })
+    );
+
+    const orderIdPromise = dao.submit(cart, order);
+    expect(order.processing).toEqual(true);
+
+    await expect(orderIdPromise).rejects.toMatchObject({
+      message: 'Your credit card is well expired',
+      cause: OrderErrorCause.USER_PAYMENT,
+    });
   });
 });

--- a/services-js/registry-certs/client/death/checkout/PaymentContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/PaymentContent.stories.tsx
@@ -111,14 +111,10 @@ storiesOf('Checkout/PaymentContent', module)
     <PaymentContent
       cart={makeCart()}
       stripe={makeStripe()}
-      order={(() => {
-        const order = makeBillingCompleteOrder();
-        order.processingError = 'The card could not be tokenized.';
-
-        return order;
-      })()}
+      order={makeBillingCompleteOrder()}
       submit={action('submit')}
       showErrorsForTest
+      tokenizationErrorForTest="The card could not be tokenized"
     />
   ))
   .add('existing billing', () => (

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.stories.tsx
@@ -6,6 +6,9 @@ import { DeathCertificate } from '../../types.js';
 import Cart from '../../store/DeathCertificateCart';
 import Order from '../../models/Order';
 
+import { SubmissionError } from '../../dao/CheckoutDao';
+import { OrderErrorCause } from '../../queries/graphql-types';
+
 import ReviewContent from './ReviewContent';
 
 import {
@@ -62,26 +65,52 @@ storiesOf('Checkout/ReviewContent', module)
     <ReviewContent
       cart={makeCart()}
       order={makeOrder()}
-      submit={action('submit')}
+      submit={action('submit') as any}
     />
   ))
   .add('cart has pending certs', () => (
     <ReviewContent
       cart={makeCart([PENDING_CERTIFICATE])}
       order={makeOrder()}
-      submit={action('submit')}
+      submit={action('submit') as any}
+    />
+  ))
+  .add('submitting', () => (
+    <ReviewContent
+      cart={makeCart()}
+      order={(() => {
+        const order = makeOrder();
+        order.processing = true;
+
+        return order;
+      })()}
+      submit={action('submit') as any}
+      showErrorsForTest
     />
   ))
   .add('submission error', () => (
     <ReviewContent
       cart={makeCart()}
-      order={(() => {
-        const order = makeOrder();
-        order.processingError = 'The order could not be processed.';
-
-        return order;
-      })()}
-      submit={action('submit')}
-      showErrorsForTest
+      order={makeOrder()}
+      submit={action('submit') as any}
+      testSubmissionError={
+        new SubmissionError(
+          'The order could not be processed.',
+          OrderErrorCause.INTERNAL
+        )
+      }
+    />
+  ))
+  .add('payment error', () => (
+    <ReviewContent
+      cart={makeCart()}
+      order={makeOrder()}
+      submit={action('submit') as any}
+      testSubmissionError={
+        new SubmissionError(
+          "Your card's security code is incorrect",
+          OrderErrorCause.USER_PAYMENT
+        )
+      }
     />
   ));

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.test.tsx
@@ -3,13 +3,15 @@ import { shallow } from 'enzyme';
 
 import Order from '../../models/Order';
 import Cart from '../../store/DeathCertificateCart';
+import { OrderErrorCause } from '../../queries/graphql-types';
+import { SubmissionError } from '../../dao/CheckoutDao';
 
 import ReviewContent from './ReviewContent';
 
 describe('submitting', () => {
   let order;
   let cart;
-  let submit: any;
+  let submit: jest.Mock<void>;
   let wrapper;
 
   beforeEach(() => {
@@ -25,13 +27,13 @@ describe('submitting', () => {
   it('reuses the idempotency key for overlapping requests', async () => {
     const form = wrapper.find('form');
 
-    submit.mockReturnValue(Promise.resolve(true));
+    submit.mockReturnValue(Promise.resolve());
     form.simulate('submit', { preventDefault: jest.fn() });
     await Promise.resolve();
 
     const idempotencyKey = order.idempotencyKey;
 
-    submit.mockReturnValue(Promise.resolve(true));
+    submit.mockReturnValue(Promise.resolve());
     form.simulate('submit', { preventDefault: jest.fn() });
     await Promise.resolve();
 
@@ -41,13 +43,24 @@ describe('submitting', () => {
   it('generates a new idempotency key if the first request failed', async () => {
     const form = wrapper.find('form');
 
-    submit.mockReturnValue(Promise.resolve(false));
+    submit.mockReturnValue(
+      Promise.reject(
+        new SubmissionError('Card processing failed', OrderErrorCause.INTERNAL)
+      )
+    );
     form.simulate('submit', { preventDefault: jest.fn() });
     await Promise.resolve();
 
     const idempotencyKey = order.idempotencyKey;
 
-    submit.mockReturnValue(Promise.resolve(false));
+    submit.mockReturnValue(
+      Promise.reject(
+        new SubmissionError(
+          'Card processing failed again',
+          OrderErrorCause.INTERNAL
+        )
+      )
+    );
     form.simulate('submit', { preventDefault: jest.fn() });
     await Promise.resolve();
 

--- a/services-js/registry-certs/client/death/checkout/ReviewContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ReviewContent.tsx
@@ -3,6 +3,8 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { observer } from 'mobx-react';
 
+import { StatusModal } from '@cityofboston/react-fleet';
+
 import PageLayout from '../../PageLayout';
 
 import { BreadcrumbNavLinks } from '../breadcrumbs';
@@ -18,25 +20,41 @@ import Order from '../../models/Order';
 
 import CostSummary from '../../common/CostSummary';
 import { DeathOrderDetails } from '../../common/checkout/OrderDetails';
+import { OrderErrorCause } from '../../queries/graphql-types';
+import { SubmissionError } from '../../dao/CheckoutDao';
 
 export interface Props {
-  submit: (cardElement?: stripe.elements.Element) => unknown;
+  submit: (cardElement?: stripe.elements.Element) => Promise<void>;
   cart: Cart;
   order: Order;
   showErrorsForTest?: boolean;
+  testSubmissionError?: SubmissionError;
 }
 
 export interface State {
   acceptNonRefundable: boolean;
   acceptPendingCertificates: boolean;
+  submissionError: string | null;
+  submissionErrorIsForPayment: boolean;
 }
 
 @observer
 export default class ReviewContent extends React.Component<Props, State> {
-  state: State = {
-    acceptNonRefundable: false,
-    acceptPendingCertificates: false,
-  };
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      acceptNonRefundable: false,
+      acceptPendingCertificates: false,
+      submissionError:
+        (props.testSubmissionError && props.testSubmissionError.message) ||
+        null,
+      submissionErrorIsForPayment:
+        (props.testSubmissionError &&
+          props.testSubmissionError.cause === OrderErrorCause.USER_PAYMENT) ||
+        false,
+    };
+  }
 
   componentWillMount() {
     // When we land on this page we create a new idempotency key so that our
@@ -59,24 +77,43 @@ export default class ReviewContent extends React.Component<Props, State> {
     ev.preventDefault();
 
     const { submit, order } = this.props;
-    const success = await submit();
 
-    if (!success) {
+    try {
+      await submit();
+    } catch (err) {
       // If there's an error we need to regenerate the key to allow another
       // submission to occur.
       order.regenerateIdempotencyKey();
+
+      if (err instanceof SubmissionError) {
+        this.setState({
+          submissionError: err.message,
+          submissionErrorIsForPayment:
+            err.cause === OrderErrorCause.USER_PAYMENT,
+        });
+      } else {
+        this.setState({
+          submissionError: err.message || 'An unknown error occurred',
+          submissionErrorIsForPayment: false,
+        });
+      }
     }
   };
 
   render() {
     const { cart, order } = this.props;
-    const { acceptNonRefundable, acceptPendingCertificates } = this.state;
+
+    const {
+      acceptNonRefundable,
+      acceptPendingCertificates,
+      submissionError,
+      submissionErrorIsForPayment,
+    } = this.state;
 
     const {
       paymentIsComplete,
       shippingIsComplete,
       processing,
-      processingError,
       info: {
         shippingName,
         shippingCompanyName,
@@ -261,20 +298,51 @@ export default class ReviewContent extends React.Component<Props, State> {
               your credit card and place an order with the Registry.
             </div>
 
-            {processingError && (
-              <div
-                className="m-v500 p-a300 br br-a100 br--r"
-                id="processing-error"
-              >
-                <div className="t--intro t--err">
-                  There’s a problem: {processingError}
+            {processing && (
+              <StatusModal message="Submitting your order…">
+                <div className="t--info m-t300">
+                  Please be patient and don’t refresh your browser. This might
+                  take a bit.
                 </div>
-                <div className="t--info">
-                  You can try again. If this keeps happening, please email{' '}
-                  <a href="mailto:digital@boston.gov">digital@boston.gov</a>.
-                </div>
-              </div>
+              </StatusModal>
             )}
+
+            {submissionError &&
+              !submissionErrorIsForPayment && (
+                <StatusModal
+                  message={`There’s a problem: ${submissionError}`}
+                  error
+                  onClose={() => {
+                    this.setState({
+                      submissionError: null,
+                    });
+                  }}
+                >
+                  <div className="t--info m-t300">
+                    You can try again. If this keeps happening, please email{' '}
+                    <a href="mailto:digital@boston.gov">digital@boston.gov</a>.
+                  </div>
+                </StatusModal>
+              )}
+
+            {submissionError &&
+              submissionErrorIsForPayment && (
+                <StatusModal message={submissionError} error>
+                  <div className="t--info m-t300">
+                    You can update your payment information and try to submit
+                    this order again.
+                  </div>
+
+                  <div className="m-v500 ta-c">
+                    <Link
+                      href="/death/checkout?page=payment"
+                      as="/death/checkout"
+                    >
+                      <a className="btn">Update Payment Information</a>
+                    </Link>
+                  </div>
+                </StatusModal>
+              )}
 
             <div className="m-v300">
               <button
@@ -285,11 +353,10 @@ export default class ReviewContent extends React.Component<Props, State> {
                   !paymentIsComplete ||
                   !shippingIsComplete ||
                   needsAccepting ||
-                  processing
+                  processing ||
+                  !!submissionError
                 }
-                aria-describedby={
-                  processingError ? 'processing-error' : 'charge-message'
-                }
+                aria-describedby="charge-message"
               >
                 Submit Order
               </button>

--- a/services-js/registry-certs/client/models/Order.ts
+++ b/services-js/registry-certs/client/models/Order.ts
@@ -53,10 +53,6 @@ export default class Order {
   // backend.
   @observable processing: boolean = false;
 
-  // An error string arising from a network operation, suck as tokenizing the
-  // card with Stripe or submitting the order to the backend.
-  @observable processingError: string | null = null;
-
   updateStorageDisposer: Function | null = null;
 
   readonly localStorageAvailable: boolean;

--- a/services-js/registry-certs/client/queries/graphql-types.ts
+++ b/services-js/registry-certs/client/queries/graphql-types.ts
@@ -128,8 +128,18 @@ export interface SearchDeathCertificatesVariables {
 // GraphQL mutation operation: SubmitDeathCertificateOrder
 // ====================================================
 
-export interface SubmitDeathCertificateOrder_submitDeathCertificateOrder {
+export interface SubmitDeathCertificateOrder_submitDeathCertificateOrder_order {
   id: string;
+}
+
+export interface SubmitDeathCertificateOrder_submitDeathCertificateOrder_error {
+  message: string;
+  cause: OrderErrorCause;
+}
+
+export interface SubmitDeathCertificateOrder_submitDeathCertificateOrder {
+  order: SubmitDeathCertificateOrder_submitDeathCertificateOrder_order | null;
+  error: SubmitDeathCertificateOrder_submitDeathCertificateOrder_error | null;
 }
 
 export interface SubmitDeathCertificateOrder {
@@ -165,6 +175,11 @@ export interface SubmitDeathCertificateOrderVariables {
 //==============================================================
 // START Enums and Input Objects
 //==============================================================
+
+export enum OrderErrorCause {
+  INTERNAL = 'INTERNAL',
+  USER_PAYMENT = 'USER_PAYMENT',
+}
 
 // undefined
 export interface DeathCertificateOrderItemInput {

--- a/services-js/registry-certs/client/queries/submit-death-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-death-certificate-order.ts
@@ -5,6 +5,7 @@ import Order from '../models/Order';
 import {
   SubmitDeathCertificateOrder,
   SubmitDeathCertificateOrderVariables,
+  SubmitDeathCertificateOrder_submitDeathCertificateOrder,
 } from './graphql-types';
 
 const QUERY = gql`
@@ -52,7 +53,13 @@ const QUERY = gql`
       items: $items
       idempotencyKey: $idempotencyKey
     ) {
-      id
+      order {
+        id
+      }
+      error {
+        message
+        cause
+      }
     }
   }
 `;
@@ -61,7 +68,7 @@ export default async function submitDeathCertificateOrder(
   fetchGraphql: FetchGraphql,
   cart: Cart,
   order: Order
-): Promise<string> {
+): Promise<SubmitDeathCertificateOrder_submitDeathCertificateOrder> {
   const {
     info: {
       contactName,
@@ -130,5 +137,5 @@ export default async function submitDeathCertificateOrder(
     queryVariables
   );
 
-  return response.submitDeathCertificateOrder.id;
+  return response.submitDeathCertificateOrder;
 }

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -23,7 +23,7 @@
     "prepare-deploy": "build-storybook -s static",
     "clear-babel-cache": "rm -rf node_modules/.cache/babel-loader",
     "generate-graphql-schema": "mkdir -p graphql && ts2gql server/graphql/index.ts > graphql/schema.graphql",
-    "generate-graphql-types": "apollo-codegen generate client/queries/*.ts --project-name registry-certs --target typescript --output client/queries/graphql-types.d.ts && prettier --write client/queries/graphql-types.d.ts",
+    "generate-graphql-types": "apollo-codegen generate client/queries/*.ts --project-name registry-certs --target typescript --output client/queries/graphql-types.ts && prettier --write client/queries/graphql-types.ts",
     "generate-fixtures": "ts-node ./scripts/generate-fixtures"
   },
   "jest": {

--- a/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
+++ b/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
@@ -80,6 +80,9 @@ GraphQLSchema {
     "Float": "Float",
     "Int": "Int",
     "Mutation": "Mutation",
+    "OrderError": "OrderError",
+    "OrderErrorCause": "OrderErrorCause",
+    "OrderResult": "OrderResult",
     "Query": "Query",
     "String": "String",
     "SubmittedOrder": "SubmittedOrder",
@@ -96,28 +99,28 @@ GraphQLSchema {
     "directives": Array [],
     "kind": "SchemaDefinition",
     "loc": Object {
-      "end": 3093,
-      "start": 3047,
+      "end": 3271,
+      "start": 3225,
     },
     "operationTypes": Array [
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3076,
-          "start": 3058,
+          "end": 3254,
+          "start": 3236,
         },
         "operation": "mutation",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3076,
-            "start": 3068,
+            "end": 3254,
+            "start": 3246,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3076,
-              "start": 3068,
+              "end": 3254,
+              "start": 3246,
             },
             "value": "Mutation",
           },
@@ -126,21 +129,21 @@ GraphQLSchema {
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3091,
-          "start": 3079,
+          "end": 3269,
+          "start": 3257,
         },
         "operation": "query",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3091,
-            "start": 3086,
+            "end": 3269,
+            "start": 3264,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3091,
-              "start": 3086,
+              "end": 3269,
+              "start": 3264,
             },
             "value": "Query",
           },


### PR DESCRIPTION
 - Keeps Stripe card errors (e.g. incorrect CVV code) from being logged
   Rollbar
 - Changes to use StatusModal for both in-progress status and error
   messages, so we don’t need a custom screen reader announcement
 - If the order failed because of a credit card error, takes the user
   back to the payment information part of the flow

Removes the "processingError" from Order because it hangs around between
Content pages unless we purposefully remember to clear it out. Changes
tokenization and submission to throw errors instead, which are kept in
State in the Payment and Review Content components, respectively.

Also:
 - Changes the auto-generated types file to be .ts instead of .d.ts so
   that its enums can be imported.
 - Removes quirky and unnecessary re-exporting of CheckoutPage, which I
   think was a holdover from some Flow type checking.