### PR TITLE
Updates logout behavior

### DIFF
--- a/services-js/access-boston/src/server/forgot-password-auth.ts
+++ b/services-js/access-boston/src/server/forgot-password-auth.ts
@@ -70,7 +70,6 @@ export async function addForgotPasswordAuth(
     );
   } else {
     samlAuth = new SamlAuthFake({
-      assertUrl: FORGOT_ASSERT_PATH,
       loginFormUrl: FAKE_FORGOT_LOGIN_FORM_PATH,
     }) as any;
   }
@@ -116,7 +115,7 @@ export async function addForgotPasswordAuth(
     },
     handler: async (request, h) => {
       const assertResult = await samlAuth.handlePostAssert(
-        request.payload as string
+        request.payload as any
       );
 
       if (assertResult.type !== 'login') {


### PR DESCRIPTION
 - Redirect to Ping to start single logout process, rather than making a
   SAML request
 - Handle logout requests coming in via POST
 - Pass RelayState when creating logout success responses

See: #228

Also:
 - Fixes incorrect assumption / typecast that payload was a string
   during POST assert processing (Hapi parses the form encoding and
   generates an object)