### PR TITLE
Adds birth cert submission to CheckoutDao

### DIFF
--- a/services-js/registry-certs/client/dao/CheckoutDao.test.ts
+++ b/services-js/registry-certs/client/dao/CheckoutDao.test.ts
@@ -98,7 +98,7 @@ describe('submit', () => {
       })
     );
 
-    const orderIdPromise = dao.submit(cart, order);
+    const orderIdPromise = dao.submitDeathCertificateCart(cart, order);
     expect(order.processing).toEqual(true);
 
     const orderId = await orderIdPromise;
@@ -111,7 +111,7 @@ describe('submit', () => {
       Promise.reject(new Error('I’m not dead yet!'))
     );
 
-    const orderIdPromise = dao.submit(cart, order);
+    const orderIdPromise = dao.submitDeathCertificateCart(cart, order);
     expect(order.processing).toEqual(true);
 
     await expect(orderIdPromise).rejects.toMatchObject({
@@ -130,7 +130,7 @@ describe('submit', () => {
       })
     );
 
-    const orderIdPromise = dao.submit(cart, order);
+    const orderIdPromise = dao.submitDeathCertificateCart(cart, order);
     expect(order.processing).toEqual(true);
 
     await expect(orderIdPromise).rejects.toMatchObject({

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.test.tsx
@@ -213,7 +213,7 @@ describe('operations', () => {
 
   describe('submitOrder', () => {
     it('redirects on success', async () => {
-      (checkoutDao.submit as jest.Mock).mockReturnValue(
+      (checkoutDao.submitDeathCertificateCart as jest.Mock).mockReturnValue(
         Promise.resolve('test-order-id')
       );
       await component.submitOrder();
@@ -221,7 +221,7 @@ describe('operations', () => {
     });
 
     it('stays on the same page on failure', async () => {
-      (checkoutDao.submit as jest.Mock).mockReturnValue(
+      (checkoutDao.submitDeathCertificateCart as jest.Mock).mockReturnValue(
         Promise.reject(
           new SubmissionError(
             'The card is expired',

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
@@ -196,7 +196,10 @@ export default class CheckoutPageController extends React.Component<Props> {
       orderProvider,
     } = this.props;
 
-    const orderId = await checkoutDao.submit(deathCertificateCart, order);
+    const orderId = await checkoutDao.submitDeathCertificateCart(
+      deathCertificateCart,
+      order
+    );
 
     deathCertificateCart.trackCartItems();
     siteAnalytics.setProductAction('purchase', {

--- a/services-js/registry-certs/client/queries/graphql-types.ts
+++ b/services-js/registry-certs/client/queries/graphql-types.ts
@@ -125,6 +125,54 @@ export interface SearchDeathCertificatesVariables {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL mutation operation: SubmitBirthCertificateOrder
+// ====================================================
+
+export interface SubmitBirthCertificateOrder_submitBirthCertificateOrder_order {
+  id: string;
+}
+
+export interface SubmitBirthCertificateOrder_submitBirthCertificateOrder_error {
+  message: string;
+  cause: OrderErrorCause;
+}
+
+export interface SubmitBirthCertificateOrder_submitBirthCertificateOrder {
+  order: SubmitBirthCertificateOrder_submitBirthCertificateOrder_order | null;
+  error: SubmitBirthCertificateOrder_submitBirthCertificateOrder_error | null;
+}
+
+export interface SubmitBirthCertificateOrder {
+  submitBirthCertificateOrder: SubmitBirthCertificateOrder_submitBirthCertificateOrder;
+}
+
+export interface SubmitBirthCertificateOrderVariables {
+  contactName: string;
+  contactEmail: string;
+  contactPhone: string;
+  shippingName: string;
+  shippingCompanyName: string;
+  shippingAddress1: string;
+  shippingAddress2: string;
+  shippingCity: string;
+  shippingState: string;
+  shippingZip: string;
+  cardToken: string;
+  cardLast4: string;
+  cardholderName: string;
+  billingAddress1: string;
+  billingAddress2: string;
+  billingCity: string;
+  billingState: string;
+  billingZip: string;
+  item: BirthCertificateOrderItemInput;
+  idempotencyKey: string;
+}
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL mutation operation: SubmitDeathCertificateOrder
 // ====================================================
 
@@ -179,6 +227,20 @@ export interface SubmitDeathCertificateOrderVariables {
 export enum OrderErrorCause {
   INTERNAL = 'INTERNAL',
   USER_PAYMENT = 'USER_PAYMENT',
+}
+
+// undefined
+export interface BirthCertificateOrderItemInput {
+  alternateSpellings: string;
+  birthDate: any;
+  firstName: string;
+  lastName: string;
+  parent1FirstName: string;
+  parent1LastName: string;
+  parent2FirstName: string;
+  parent2LastName: string;
+  quantity: number;
+  relationship: string;
 }
 
 // undefined

--- a/services-js/registry-certs/client/types.ts
+++ b/services-js/registry-certs/client/types.ts
@@ -2,6 +2,8 @@ import {
   FetchDeathCertificates,
   SearchDeathCertificates,
   LookupDeathCertificateOrder,
+  SubmitDeathCertificateOrder_submitDeathCertificateOrder,
+  SubmitBirthCertificateOrder_submitBirthCertificateOrder,
 } from './queries/graphql-types';
 
 export type CertificateType = 'death' | 'birth';
@@ -19,6 +21,9 @@ export interface DeathCertificateOrder
   extends NonNullable<
       LookupDeathCertificateOrder['deathCertificates']['order']
     > {}
+
+export type DeathCertificateOrderResult = SubmitDeathCertificateOrder_submitDeathCertificateOrder;
+export type BirthCertificateOrderResult = SubmitBirthCertificateOrder_submitBirthCertificateOrder;
 
 // Birth-specific
 export type Question =

--- a/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
+++ b/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
@@ -97,28 +97,28 @@ GraphQLSchema {
     "directives": Array [],
     "kind": "SchemaDefinition",
     "loc": Object {
-      "end": 3018,
-      "start": 2972,
+      "end": 3132,
+      "start": 3086,
     },
     "operationTypes": Array [
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3001,
-          "start": 2983,
+          "end": 3115,
+          "start": 3097,
         },
         "operation": "mutation",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3001,
-            "start": 2993,
+            "end": 3115,
+            "start": 3107,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3001,
-              "start": 2993,
+              "end": 3115,
+              "start": 3107,
             },
             "value": "Mutation",
           },
@@ -127,21 +127,21 @@ GraphQLSchema {
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3016,
-          "start": 3004,
+          "end": 3130,
+          "start": 3118,
         },
         "operation": "query",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3016,
-            "start": 3011,
+            "end": 3130,
+            "start": 3125,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3016,
-              "start": 3011,
+              "end": 3130,
+              "start": 3125,
             },
             "value": "Query",
           },

--- a/services-js/registry-certs/server/graphql/mutation.test.ts
+++ b/services-js/registry-certs/server/graphql/mutation.test.ts
@@ -40,9 +40,13 @@ const DEFAULT_DEATH_ITEMS = [
 const DEFAULT_BIRTH_ITEM = {
   firstName: 'Danielle',
   lastName: 'Cage',
-  dob: new Date('01 March 2006 00:00:00 GMT'),
+  relationship: 'parent',
+  alternateSpellings: '',
+  birthDate: new Date('01 March 2006 00:00:00 GMT'),
   parent1FirstName: 'Jessica',
+  parent1LastName: 'Jones',
   parent2FirstName: 'Luke',
+  parent2LastName: 'Cage',
   quantity: 10,
 };
 

--- a/services-js/registry-certs/server/graphql/mutation.ts
+++ b/services-js/registry-certs/server/graphql/mutation.ts
@@ -30,18 +30,20 @@ interface DeathCertificateOrderItemInput {
 }
 
 /**
- * You have to know the search terms for a birth certificate in order to buy it.
- * If we just allowed an ID here then one could use the API to purchase
- * arbitrary certificates.
+ * This is the data registry needs to process a birth certificate request.
  *
  * @graphql input
  */
 interface BirthCertificateOrderItemInput {
   firstName: string;
   lastName: string;
-  dob: Date;
+  alternateSpellings: string;
+  birthDate: Date;
   parent1FirstName: string;
+  parent1LastName: string;
   parent2FirstName: string;
+  parent2LastName: string;
+  relationship: string;
   quantity: Int;
 }
 


### PR DESCRIPTION
 - Adds a mutation query function for the client to use
 - Factors out submission response / error handling so that it can be
   shared by death and birth
 - Updates the GraphQL mutation args to take more of the data that’s
   being requested in the question flow