### PR TITLE
Updates Access Boston workflows

### DIFF
--- a/services-js/access-boston/src/client/AccessBostonHeader.stories.tsx
+++ b/services-js/access-boston/src/client/AccessBostonHeader.stories.tsx
@@ -9,6 +9,7 @@ const ACCOUNT: Account = {
   registered: true,
   needsMfaDevice: false,
   needsNewPassword: false,
+  resetPasswordToken: '',
 };
 
 storiesOf('AccessBostonHeader', module).add('default', () => (

--- a/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
@@ -11,6 +11,7 @@ const QUERY = gql`
       registered
       needsMfaDevice
       needsNewPassword
+      resetPasswordToken
     }
 
     apps {

--- a/services-js/access-boston/src/client/graphql/fetch-account.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account.ts
@@ -10,6 +10,7 @@ const QUERY = gql`
       registered
       needsMfaDevice
       needsNewPassword
+      resetPasswordToken
     }
   }
 `;

--- a/services-js/access-boston/src/client/graphql/queries.ts
+++ b/services-js/access-boston/src/client/graphql/queries.ts
@@ -56,6 +56,7 @@ export interface FetchAccountAndApps_account {
   registered: boolean;
   needsMfaDevice: boolean;
   needsNewPassword: boolean;
+  resetPasswordToken: string;
 }
 
 export interface FetchAccountAndApps_apps_categories_apps {
@@ -93,6 +94,7 @@ export interface FetchAccount_account {
   registered: boolean;
   needsMfaDevice: boolean;
   needsNewPassword: boolean;
+  resetPasswordToken: string;
 }
 
 export interface FetchAccount {
@@ -120,6 +122,7 @@ export interface ResetPassword {
 export interface ResetPasswordVariables {
   newPassword: string;
   confirmPassword: string;
+  token: string;
 }
 
 /* tslint:disable */

--- a/services-js/access-boston/src/client/graphql/reset-password.ts
+++ b/services-js/access-boston/src/client/graphql/reset-password.ts
@@ -2,10 +2,15 @@ import { FetchGraphql, gql } from '@cityofboston/next-client-common';
 import { ResetPassword, ResetPasswordVariables } from './queries';
 
 const QUERY = gql`
-  mutation ResetPassword($newPassword: String!, $confirmPassword: String!) {
+  mutation ResetPassword(
+    $newPassword: String!
+    $confirmPassword: String!
+    $token: String!
+  ) {
     resetPassword(
       newPassword: $newPassword
       confirmPassword: $confirmPassword
+      token: $token
     ) {
       caseId
       status
@@ -17,12 +22,14 @@ const QUERY = gql`
 
 export default async function resetPassword(
   fetchGraphql: FetchGraphql,
-  newPassword,
-  confirmPassword
+  newPassword: string,
+  confirmPassword: string,
+  token: string
 ) {
   const args: ResetPasswordVariables = {
     newPassword,
     confirmPassword,
+    token,
   };
 
   return ((await fetchGraphql(QUERY, args)) as ResetPassword).resetPassword;

--- a/services-js/access-boston/src/pages/forgot.tsx
+++ b/services-js/access-boston/src/pages/forgot.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
-import { Formik, FormikProps } from 'formik';
+import { Formik, FormikProps, FormikActions } from 'formik';
 
 import { SectionHeader, PUBLIC_CSS_URL } from '@cityofboston/react-fleet';
 
@@ -44,6 +44,7 @@ interface FormValues {
   username: string;
   newPassword: string;
   confirmPassword: string;
+  token: string;
 }
 
 export default class ForgotPasswordPage extends React.Component<Props, State> {
@@ -67,8 +68,8 @@ export default class ForgotPasswordPage extends React.Component<Props, State> {
   }
 
   private handleSubmit = async (
-    { newPassword, confirmPassword }: FormValues,
-    { setSubmitting, setErrors }
+    { newPassword, confirmPassword, token }: FormValues,
+    { setSubmitting, setErrors }: FormikActions<FormValues>
   ) => {
     this.setState({ showSubmittingModal: true, showNetworkError: false });
 
@@ -76,7 +77,8 @@ export default class ForgotPasswordPage extends React.Component<Props, State> {
       const { status, error } = await resetPassword(
         this.props.fetchGraphql,
         newPassword,
-        confirmPassword
+        confirmPassword,
+        token
       );
 
       switch (status) {
@@ -106,6 +108,7 @@ export default class ForgotPasswordPage extends React.Component<Props, State> {
 
     const initialValues: FormValues = {
       username: account.employeeId,
+      token: account.resetPasswordToken,
       newPassword: '',
       confirmPassword: '',
     };

--- a/services-js/access-boston/src/server/Session.ts
+++ b/services-js/access-boston/src/server/Session.ts
@@ -16,6 +16,7 @@ export interface LoginAuth {
 export interface ForgotPasswordAuth {
   type: 'forgotPassword';
   userId: string;
+  resetPasswordToken: string;
 }
 
 declare module 'hapi' {

--- a/services-js/access-boston/src/server/forgot-password-auth.ts
+++ b/services-js/access-boston/src/server/forgot-password-auth.ts
@@ -127,6 +127,7 @@ export async function addForgotPasswordAuth(
       setSessionAuth(request, {
         type: 'forgotPassword',
         userId: assertResult.nameId,
+        resetPasswordToken: assertResult.userAccessToken,
       });
 
       return h.redirect(forgotPath);

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -61,6 +61,7 @@ export interface Mutation {
   resetPassword(args: {
     newPassword: string;
     confirmPassword: string;
+    token: string;
   }): Workflow;
 
   addMfaDevice(args: {
@@ -80,6 +81,7 @@ export interface Account {
   registered: boolean;
   needsNewPassword: boolean;
   needsMfaDevice: boolean;
+  resetPasswordToken: string;
 }
 
 export interface Apps {
@@ -135,6 +137,7 @@ const queryRootResolvers: QueryRootResolvers = {
         registered: !needsMfaDevice && !needsNewPassword,
         needsMfaDevice,
         needsNewPassword,
+        resetPasswordToken: '',
       };
     } else if (forgotPasswordAuth) {
       return {
@@ -144,6 +147,7 @@ const queryRootResolvers: QueryRootResolvers = {
         registered: false,
         needsMfaDevice: false,
         needsNewPassword: false,
+        resetPasswordToken: forgotPasswordAuth.resetPasswordToken,
       };
     } else {
       throw Boom.forbidden();

--- a/services-js/access-boston/src/server/graphql/workflows.ts
+++ b/services-js/access-boston/src/server/graphql/workflows.ts
@@ -53,7 +53,7 @@ export const changePasswordMutation: MutationResolvers['changePassword'] = async
 
 export const resetPasswordMutation: MutationResolvers['resetPassword'] = async (
   _root,
-  { newPassword, confirmPassword },
+  { newPassword, confirmPassword, token },
   { identityIq, session }
 ) => {
   const { forgotPasswordAuth } = session;
@@ -73,7 +73,8 @@ export const resetPasswordMutation: MutationResolvers['resetPassword'] = async (
 
   const workflowResponse = await identityIq.resetPassword(
     forgotPasswordAuth.userId,
-    newPassword
+    newPassword,
+    token
   );
 
   if (workflowResponse.completionStatus === 'Success') {

--- a/services-js/access-boston/src/server/services/IdentityIqFake.ts
+++ b/services-js/access-boston/src/server/services/IdentityIqFake.ts
@@ -25,7 +25,15 @@ export default class IdentityIqFake implements Required<IdentityIq> {
 
   async updateUserRegistration(): Promise<any> {}
 
-  async resetPassword(): Promise<LaunchedWorkflowResponse> {
+  async resetPassword(
+    _userId,
+    _password,
+    token
+  ): Promise<LaunchedWorkflowResponse> {
+    if (!token) {
+      throw new Error('Reset password token was not provided');
+    }
+
     return this.loadFixture('LaunchWorkflow-ResetPassword-success');
   }
 

--- a/services-js/access-boston/src/server/services/SamlAuth.ts
+++ b/services-js/access-boston/src/server/services/SamlAuth.ts
@@ -29,6 +29,7 @@ interface SamlAuthAssertion {
       email?: string[];
       changePasswordRequired?: string[];
       mfaRegistrationRequired?: string[];
+      userAccessToken?: string[];
     };
   };
 }
@@ -67,6 +68,7 @@ export interface SamlLoginResult {
   groups: string[];
   needsNewPassword: boolean;
   needsMfaDevice: boolean;
+  userAccessToken: string;
 }
 
 export interface SamlLogoutRequestResult {
@@ -283,6 +285,8 @@ export default class SamlAuth {
           groups: parseGroupsAttribute(attributes.groups || []),
           needsNewPassword: attributeIsTrue(attributes.changePasswordRequired),
           needsMfaDevice: attributeIsTrue(attributes.mfaRegistrationRequired),
+          userAccessToken:
+            (attributes.userAccessToken && attributes.userAccessToken[0]) || '',
         };
       }
       case 'logout_request':

--- a/services-js/access-boston/src/server/services/SamlAuthFake.ts
+++ b/services-js/access-boston/src/server/services/SamlAuthFake.ts
@@ -51,6 +51,7 @@ export default class SamlAuthFake implements Required<SamlAuth> {
       ],
       needsNewPassword: isNewUser,
       needsMfaDevice: isNewUser && userId !== 'NEW88888',
+      userAccessToken: 'jfqWE7DExC4nUa7pvkABezkM4oNT',
     };
 
     return Promise.resolve(result);

--- a/services-js/access-boston/src/stories/ChangePasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ChangePasswordPage.stories.tsx
@@ -9,6 +9,7 @@ const ACCOUNT: Account = {
   registered: true,
   needsMfaDevice: false,
   needsNewPassword: false,
+  resetPasswordToken: '',
 };
 
 storiesOf('ChangePasswordPage', module)

--- a/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
+++ b/services-js/access-boston/src/stories/ForgotPasswordPage.stories.tsx
@@ -9,6 +9,7 @@ const ACCOUNT: Account = {
   registered: true,
   needsMfaDevice: false,
   needsNewPassword: false,
+  resetPasswordToken: 'jfqWE7DExC4nUa7pvkABezkM4oNT',
 };
 
 storiesOf('ForgotPasswordPage', module)

--- a/services-js/access-boston/src/stories/IndexPage.stories.tsx
+++ b/services-js/access-boston/src/stories/IndexPage.stories.tsx
@@ -9,6 +9,7 @@ const ACCOUNT: Account = {
   registered: true,
   needsMfaDevice: false,
   needsNewPassword: false,
+  resetPasswordToken: '',
 };
 
 const APPS: Apps = {

--- a/services-js/access-boston/src/stories/RegisterMfaPage.stories.tsx
+++ b/services-js/access-boston/src/stories/RegisterMfaPage.stories.tsx
@@ -9,6 +9,7 @@ const ACCOUNT: Account = {
   registered: true,
   needsMfaDevice: false,
   needsNewPassword: false,
+  resetPasswordToken: '',
 };
 
 storiesOf('RegisterMfaPage', module)

--- a/services-js/access-boston/src/stories/RegisterPage.stories.tsx
+++ b/services-js/access-boston/src/stories/RegisterPage.stories.tsx
@@ -11,6 +11,7 @@ storiesOf('RegisterPage', module)
         registered: false,
         needsMfaDevice: true,
         needsNewPassword: true,
+        resetPasswordToken: '',
       }}
     />
   ))
@@ -21,6 +22,7 @@ storiesOf('RegisterPage', module)
         registered: false,
         needsMfaDevice: true,
         needsNewPassword: false,
+        resetPasswordToken: '',
       }}
     />
   ));


### PR DESCRIPTION
 - Gets the userAccessToken from forgot password login assertions and
   passes it through to the reset password workflow
 - Changes user registration to use a workflow rather that PUTting to
   the user endpoint directly

Fixes #227