### PR TITLE
registry-certs checkout flow fixes

### DIFF
--- a/services-js/registry-certs/client/Storyshots.test.ts
+++ b/services-js/registry-certs/client/Storyshots.test.ts
@@ -2,6 +2,4 @@ import initStoryshots from '@storybook/addon-storyshots';
 
 require('babel-plugin-require-context-hook/register')();
 
-// eslint-disable-next-line
-debugger;
 initStoryshots({});

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -1646,6 +1646,275 @@ exports[`Storyshots Birth/ReviewRequest default page 1`] = `
 </div>
 `;
 
+exports[`Storyshots Checkout/CheckoutPage server-side render 1`] = `
+<div>
+  <a
+    className="btn a11y--h a11y--f"
+    href="#content-start"
+    onClick={[Function]}
+    style={
+      Object {
+        "margin": 4,
+      }
+    }
+    tabIndex={1}
+  >
+    Jump to content
+  </a>
+  <input
+    aria-label="Open Boston.gov menu"
+    checked={undefined}
+    className="brg-tr"
+    id="brg-tr"
+    onKeyDown={[Function]}
+    type="checkbox"
+  />
+  <nav
+    aria-label="Boston.gov menu"
+    className="nv-m"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+  <div class=\\"nv-m-h\\">
+      <div class=\\"nv-m-h-ic\\">
+        <a href=\\"https://www.boston.gov/\\" title=\\"Go to home page\\">
+          <img src=\\"https://patterns.boston.gov/images/b-dark.svg\\" title=\\"B\\" aria-hidden=\\"true\\" class=\\"nv-m-h-i\\">
+        </a>
+      </div>
+      <div id=\\"nv-m-h-t\\" class=\\"nv-m-h-t\\">&#xA0;</div>
+  </div>
+  <div class=\\"nv-m-c\\">
+    
+
+<ul class=\\"nv-m-c-l\\"><li class=\\"nv-m-c-l-i is-l first leaf menu-mlid-763366 nv-m-c-a--y\\"><a href=\\"http://www.cityofboston.gov/311/\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p three-one-one\\">Help / 311</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-210101\\"><a href=\\"https://www.boston.gov/homepage\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Home</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-171721\\"><a href=\\"https://www.boston.gov/guides\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Guides to Boston</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-171726\\"><a href=\\"https://www.boston.gov/departments\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Departments</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-1675906\\"><a href=\\"https://www.boston.gov/public-notices\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Public Notices</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-2354776\\"><a href=\\"https://www.boston.gov/pay-and-apply\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Pay and apply</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-2354781\\"><a href=\\"https://www.boston.gov/career-center\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Work for the City</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-885866\\"><a href=\\"https://www.boston.gov/events\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Events</a></li>
+<li class=\\"nv-m-c-l-i is-l leaf menu-mlid-202946\\"><a href=\\"https://www.boston.gov/news\\" class=\\"nv-m-c-a nv-m-c-a--p\\">News</a></li>
+<li class=\\"nv-m-c-l-i is-e expanded menu-mlid-171731\\"><a href=\\"https://www.boston.gov/#\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p nolink\\">Places</a><ul class=\\"nv-m-c-l-l\\"><li class=\\"nv-m-c-bc nv-m-c-b--h\\"><button class=\\"nv-m-c-b\\">Back</button></li><li class=\\"nv-m-c-l-l-i is-l first leaf menu-mlid-2354766\\"><a href=\\"https://www.boston.gov/cemeteries\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Cemeteries</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354751\\"><a href=\\"https://www.boston.gov/community-centers\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Community centers</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-184086\\"><a href=\\"https://www.boston.gov/departments/landmarks-commission#historic-districts\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Historic Districts</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171801\\"><a href=\\"http://www.bpl.org/general/branch.htm\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Libraries</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354771\\"><a href=\\"https://www.boston.gov/neighborhoods\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Neighborhoods</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-2354761\\"><a href=\\"https://www.boston.gov/parks-and-playgrounds\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Parks and playgrounds</a></li>
+<li class=\\"nv-m-c-l-l-i is-l last leaf menu-mlid-652731\\"><a href=\\"http://www.bostonpublicschools.org/Page/628\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Schools</a></li>
+</ul></li>
+<li class=\\"nv-m-c-l-i is-e last expanded menu-mlid-171741\\"><a href=\\"https://www.boston.gov/#\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p nolink\\">Government</a><ul class=\\"nv-m-c-l-l\\"><li class=\\"nv-m-c-bc nv-m-c-b--h\\"><button class=\\"nv-m-c-b\\">Back</button></li><li class=\\"nv-m-c-l-l-i is-l first leaf menu-mlid-171851\\"><a href=\\"https://www.boston.gov/departments/mayors-office\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">The Mayor&apos;s Office</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171856\\"><a href=\\"https://www.boston.gov/departments/city-council\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City Council</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171861\\"><a href=\\"https://www.boston.gov/departments/city-clerk\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City Clerk</a></li>
+<li class=\\"nv-m-c-l-l-i is-l leaf menu-mlid-171866\\"><a href=\\"https://www.boston.gov/departments/election\\" title=\\"\\" class=\\"nv-m-c-a nv-m-c-a--p\\">Elections</a></li>
+<li class=\\"nv-m-c-l-l-i is-l last leaf menu-mlid-178041\\"><a href=\\"https://www.boston.gov/departments/311/city-boston-government\\" class=\\"nv-m-c-a nv-m-c-a--p\\">City government</a></li>
+</ul></li>
+</ul>  </div>
+",
+      }
+    }
+  />
+  <div
+    className="mn--full-ie"
+  >
+    <div
+      className="mn mn--full "
+    >
+      <input
+        aria-hidden="true"
+        className="s-tr"
+        id="s-tr"
+        type="checkbox"
+      />
+      <header
+        className="h"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "
+    <label for=\\"brg-tr\\" class=\\"brg-b\\">
+  <div class=\\"brg\\">
+    <span class=\\"brg-c\\">
+      <span class=\\"brg-c-i\\"></span>
+    </span>
+    <span class=\\"brg-t\\"><span class=\\"a11y--h\\">Toggle </span>Menu</span>
+  </div>
+</label>
+      <div class=\\"lo lo--abs\\">
+    <div class=\\"lo-l\\">
+      <a href=\\"https://www.boston.gov/\\">
+        <img src=\\"https://patterns.boston.gov/images/public/logo.svg\\" alt=\\"Boston.gov\\" class=\\"lo-i\\">
+      </a>
+              <span class=\\"lo-t\\"><a href=\\"https://www.boston.gov/mayor\\">Mayor Martin J. Walsh</a></span>
+          </div>
+  </div>
+    <a id=\\"seal\\" href=\\"https://www.boston.gov/\\" title=\\"Home\\" rel=\\"home\\" class=\\"s\\">
+  <img src=\\"https://patterns.boston.gov/images/public/seal.svg\\" alt=\\"City of Boston Seal\\" class=\\"s-i\\">
+</a>
+    <nav class=\\"nv-h\\">
+  <ul class=\\"nv-h-l\\">
+              <li class=\\"nv-h-l-i\\"><a href=\\"https://www.boston.gov/pay-and-apply\\" title=\\"Pay and apply\\" class=\\"nv-h-l-a\\">Pay and apply</a></li>
+          <li class=\\"nv-h-l-i\\"><a href=\\"https://www.boston.gov/public-notices\\" title=\\"Public notices\\" class=\\"nv-h-l-a\\">Public notices</a></li>
+          <li class=\\"nv-h-l-i\\"><a href=\\"mailto:feedback@boston.gov\\" title=\\"Feedback\\" class=\\"nv-h-l-a\\" onClick=\\"document.getElementById(&quot;contactForm&quot;).show(); return false;\\">Feedback</a></li>
+        <li class=\\"tr nv-h-l-i\\">
+      <a href=\\"https://www.boston.gov/#translate\\" title=\\"Translate\\" class=\\"nv-h-l-a nv-h-l-a--k--s tr-link\\">Translate</a>
+      <ul class=\\"tr-dd\\">
+        <li><span class=\\"notranslate tr-dd-link tr-dd-link--message\\">Loading...</span></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"ht\\">Krey&#xF2;l Ayisyen</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"pt\\">Portugese</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"es\\">Espa&#xF1;ol</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link\\" data-ln=\\"vi\\">Ti&#x1EBF;ng Vi&#x1EC7;t</a></li>
+        <li><a href=\\"https://www.boston.gov/#\\" class=\\"notranslate tr-dd-link tr-dd-link--hidden\\" data-ln=\\"en\\">English</a></li>
+      </ul>
+    </li>
+    <li class=\\"nv-h-l-i\\">
+      <label for=\\"s-tr\\" title=\\"Search\\" class=\\"nv-h-l-a nv-h-l-a--k nv-h-l-a-ic\\" id=\\"searchIcon\\">
+        <svg id=\\"Layer_2\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 40 41\\"><title>Search</title><path class=\\"nv-h-l-a-i\\" d=\\"M24.2.6C15.8.6 9 7.4 9 15.8c0 3.7 1.4 7.2 3.6 9.8L1.2 37c-.8.8-.8 2 0 2.8.4.4.9.6 1.4.6s1-.2 1.4-.6l11.5-11.5C18 30 21 31 24.2 31c8.4 0 15.2-6.8 15.2-15.2C39.4 7.4 32.6.6 24.2.6zm0 26.5c-6.2 0-11.2-5-11.2-11.2S18 4.6 24.2 4.6s11.2 5 11.2 11.2-5 11.3-11.2 11.3z\\"/></svg>
+      </label>
+    </li>
+  </ul>
+</nav>
+    <div class=\\"h-s\\">
+  <form class=\\"sf\\" action=\\"https://www.boston.gov/search\\" accept-charset=\\"UTF-8\\" method=\\"get\\">
+    <input name=\\"utf8\\" type=\\"hidden\\" value=\\"&#x2713;\\">
+    <div class=\\"sf-i\\">
+      <input type=\\"text\\" name=\\"query\\" id=\\"query\\" value=\\"\\" placeholder=\\"Search&#x2026;\\" class=\\"sf-i-f\\" autocomplete=\\"off\\">
+      <button class=\\"sf-i-b\\">Search</button>
+    </div>
+  </form>
+</div>
+  ",
+          }
+        }
+        role="banner"
+      />
+      <nav
+        aria-label="Breadcrumbs"
+        className="brc css-1bakzg2 p-a300"
+      >
+        <ul
+          className="brc-l"
+        >
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/"
+            >
+              Home
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/departments"
+            >
+              Departments
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              href="https://www.boston.gov/departments/registry"
+            >
+              Registry: Birth, death, and marriage
+            </a>
+            <span
+              aria-hidden="true"
+              className="brc-s"
+              style={
+                Object {
+                  "cursor": "default",
+                }
+              }
+            >
+               
+              ›
+               
+            </span>
+          </li>
+          <li
+            className="brc-l-i"
+          >
+            <a
+              aria-current="page"
+              className="css-xtnqqy"
+              href="/death"
+            >
+              Death certificates
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        className="a11y--content-start"
+        id="content-start"
+      />
+      <main
+        className="b-ff"
+      >
+        <div
+          className="b-c b-c--hsm"
+        />
+      </main>
+    </div>
+  </div>
+  <footer
+    className="ft"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+    <div class=\\"ft-c\\">
+      <ul class=\\"ft-ll ft-ll--r\\">
+        <li class=\\"ft-ll-i\\"><a href=\\"http://www.cityofboston.gov/311/\\" class=\\"ft-ll-a lnk--yellow\\"><span class=\\"ft-ll-311\\">BOS:311</span><span class=\\"tablet--hidden\\"> - </span>Report an issue</a></li>
+      </ul>
+      
+
+<ul class=\\"ft-ll\\"><li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/innovation-and-technology/privacy-and-security-statement\\" target=\\"_blank\\" title=\\"\\" class=\\"ft-ll-a\\">Privacy Policy</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/mayors-office/contact-boston-city-hall\\" title=\\"\\" class=\\"ft-ll-a\\">Contact us</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/digital-team/city-boston-alerts-and-notifications\\" title=\\"\\" class=\\"ft-ll-a\\">Alerts and notifications</a></li>
+<li class=\\"ft-ll-i\\"><a href=\\"https://www.boston.gov/departments/public-records\\" title=\\"\\" class=\\"ft-ll-a\\">Public records requests</a></li>
+</ul>    </div>
+  ",
+      }
+    }
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 2,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`Storyshots Checkout/ConfirmationContent default 1`] = `
 <div>
   <a
@@ -2435,7 +2704,7 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={true}
+                      checked={false}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -2453,7 +2722,7 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={false}
+                      checked={true}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -2465,6 +2734,468 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
                       className="ra-l"
                     >
                       Use a different address
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="m-t500"
+              >
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress1"
+                  >
+                    Address Line 1
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-line1"
+                    className="txt-f "
+                    id="billingAddress1"
+                    name="billingAddress1"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 1"
+                    type="text"
+                    value="3 Avengers Towers"
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress2"
+                  >
+                    Address Line 2 (optional)
+                  </label>
+                  <input
+                    autoComplete="billing address-line2"
+                    className="txt-f "
+                    id="billingAddress2"
+                    name="billingAddress2"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 2"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingCity"
+                  >
+                    City
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-level2"
+                    className="txt-f "
+                    id="billingCity"
+                    name="billingCity"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="City"
+                    type="text"
+                    value="New York"
+                  />
+                </div>
+                <div
+                  className="sel txt"
+                >
+                  <label
+                    className="sel-l txt-l--sm"
+                    htmlFor="billingState"
+                  >
+                    State / Territory
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <div
+                    className="sel-c"
+                  >
+                    <select
+                      aria-required="true"
+                      autoComplete="billing address-level1"
+                      className="sel-f "
+                      id="billingState"
+                      name="billingState"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      value="NY"
+                    >
+                      <option
+                        value="AL"
+                      >
+                        Alabama
+                      </option>
+                      <option
+                        value="AK"
+                      >
+                        Alaska
+                      </option>
+                      <option
+                        value="AS"
+                      >
+                        American Samoa
+                      </option>
+                      <option
+                        value="AZ"
+                      >
+                        Arizona
+                      </option>
+                      <option
+                        value="AR"
+                      >
+                        Arkansas
+                      </option>
+                      <option
+                        value="CA"
+                      >
+                        California
+                      </option>
+                      <option
+                        value="CO"
+                      >
+                        Colorado
+                      </option>
+                      <option
+                        value="CT"
+                      >
+                        Connecticut
+                      </option>
+                      <option
+                        value="DE"
+                      >
+                        Delaware
+                      </option>
+                      <option
+                        value="DC"
+                      >
+                        District Of Columbia
+                      </option>
+                      <option
+                        value="FM"
+                      >
+                        Federated States Of Micronesia
+                      </option>
+                      <option
+                        value="FL"
+                      >
+                        Florida
+                      </option>
+                      <option
+                        value="GA"
+                      >
+                        Georgia
+                      </option>
+                      <option
+                        value="GU"
+                      >
+                        Guam
+                      </option>
+                      <option
+                        value="HI"
+                      >
+                        Hawaii
+                      </option>
+                      <option
+                        value="ID"
+                      >
+                        Idaho
+                      </option>
+                      <option
+                        value="IL"
+                      >
+                        Illinois
+                      </option>
+                      <option
+                        value="IN"
+                      >
+                        Indiana
+                      </option>
+                      <option
+                        value="IA"
+                      >
+                        Iowa
+                      </option>
+                      <option
+                        value="KS"
+                      >
+                        Kansas
+                      </option>
+                      <option
+                        value="KY"
+                      >
+                        Kentucky
+                      </option>
+                      <option
+                        value="LA"
+                      >
+                        Louisiana
+                      </option>
+                      <option
+                        value="ME"
+                      >
+                        Maine
+                      </option>
+                      <option
+                        value="MH"
+                      >
+                        Marshall Islands
+                      </option>
+                      <option
+                        value="MD"
+                      >
+                        Maryland
+                      </option>
+                      <option
+                        value="MA"
+                      >
+                        Massachusetts
+                      </option>
+                      <option
+                        value="MI"
+                      >
+                        Michigan
+                      </option>
+                      <option
+                        value="MN"
+                      >
+                        Minnesota
+                      </option>
+                      <option
+                        value="MS"
+                      >
+                        Mississippi
+                      </option>
+                      <option
+                        value="MO"
+                      >
+                        Missouri
+                      </option>
+                      <option
+                        value="MT"
+                      >
+                        Montana
+                      </option>
+                      <option
+                        value="NE"
+                      >
+                        Nebraska
+                      </option>
+                      <option
+                        value="NV"
+                      >
+                        Nevada
+                      </option>
+                      <option
+                        value="NH"
+                      >
+                        New Hampshire
+                      </option>
+                      <option
+                        value="NJ"
+                      >
+                        New Jersey
+                      </option>
+                      <option
+                        value="NM"
+                      >
+                        New Mexico
+                      </option>
+                      <option
+                        value="NY"
+                      >
+                        New York
+                      </option>
+                      <option
+                        value="NC"
+                      >
+                        North Carolina
+                      </option>
+                      <option
+                        value="ND"
+                      >
+                        North Dakota
+                      </option>
+                      <option
+                        value="MP"
+                      >
+                        Northern Mariana Islands
+                      </option>
+                      <option
+                        value="OH"
+                      >
+                        Ohio
+                      </option>
+                      <option
+                        value="OK"
+                      >
+                        Oklahoma
+                      </option>
+                      <option
+                        value="OR"
+                      >
+                        Oregon
+                      </option>
+                      <option
+                        value="PW"
+                      >
+                        Palau
+                      </option>
+                      <option
+                        value="PA"
+                      >
+                        Pennsylvania
+                      </option>
+                      <option
+                        value="PR"
+                      >
+                        Puerto Rico
+                      </option>
+                      <option
+                        value="RI"
+                      >
+                        Rhode Island
+                      </option>
+                      <option
+                        value="SC"
+                      >
+                        South Carolina
+                      </option>
+                      <option
+                        value="SD"
+                      >
+                        South Dakota
+                      </option>
+                      <option
+                        value="TN"
+                      >
+                        Tennessee
+                      </option>
+                      <option
+                        value="TX"
+                      >
+                        Texas
+                      </option>
+                      <option
+                        value="UT"
+                      >
+                        Utah
+                      </option>
+                      <option
+                        value="VT"
+                      >
+                        Vermont
+                      </option>
+                      <option
+                        value="VI"
+                      >
+                        Virgin Islands
+                      </option>
+                      <option
+                        value="VA"
+                      >
+                        Virginia
+                      </option>
+                      <option
+                        value="WA"
+                      >
+                        Washington
+                      </option>
+                      <option
+                        value="WV"
+                      >
+                        West Virginia
+                      </option>
+                      <option
+                        value="WI"
+                      >
+                        Wisconsin
+                      </option>
+                      <option
+                        value="WY"
+                      >
+                        Wyoming
+                      </option>
+                    </select>
+                  </div>
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingZip"
+                  >
+                    ZIP Code
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing postal-code"
+                    className="txt-f txt-f--50 "
+                    id="billingZip"
+                    name="billingZip"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="ZIP code"
+                    value="12223"
+                  />
+                </div>
+                <div
+                  className="m-t700"
+                >
+                  <label
+                    className="cb"
+                  >
+                    <input
+                      checked={false}
+                      className="cb-f"
+                      id="storeBilling"
+                      name="storeBilling"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="true"
+                    />
+                     
+                    <span
+                      className="cb-l"
+                    >
+                      Save billing address on this computer
                     </span>
                   </label>
                 </div>
@@ -2994,7 +3725,7 @@ exports[`Storyshots Checkout/PaymentContent ZIP code error 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={true}
+                      checked={false}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -3012,7 +3743,7 @@ exports[`Storyshots Checkout/PaymentContent ZIP code error 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={false}
+                      checked={true}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -3024,6 +3755,468 @@ exports[`Storyshots Checkout/PaymentContent ZIP code error 1`] = `
                       className="ra-l"
                     >
                       Use a different address
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="m-t500"
+              >
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress1"
+                  >
+                    Address Line 1
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-line1"
+                    className="txt-f "
+                    id="billingAddress1"
+                    name="billingAddress1"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 1"
+                    type="text"
+                    value="3 Avengers Towers"
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress2"
+                  >
+                    Address Line 2 (optional)
+                  </label>
+                  <input
+                    autoComplete="billing address-line2"
+                    className="txt-f "
+                    id="billingAddress2"
+                    name="billingAddress2"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 2"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingCity"
+                  >
+                    City
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-level2"
+                    className="txt-f "
+                    id="billingCity"
+                    name="billingCity"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="City"
+                    type="text"
+                    value="New York"
+                  />
+                </div>
+                <div
+                  className="sel txt"
+                >
+                  <label
+                    className="sel-l txt-l--sm"
+                    htmlFor="billingState"
+                  >
+                    State / Territory
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <div
+                    className="sel-c"
+                  >
+                    <select
+                      aria-required="true"
+                      autoComplete="billing address-level1"
+                      className="sel-f "
+                      id="billingState"
+                      name="billingState"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      value="NY"
+                    >
+                      <option
+                        value="AL"
+                      >
+                        Alabama
+                      </option>
+                      <option
+                        value="AK"
+                      >
+                        Alaska
+                      </option>
+                      <option
+                        value="AS"
+                      >
+                        American Samoa
+                      </option>
+                      <option
+                        value="AZ"
+                      >
+                        Arizona
+                      </option>
+                      <option
+                        value="AR"
+                      >
+                        Arkansas
+                      </option>
+                      <option
+                        value="CA"
+                      >
+                        California
+                      </option>
+                      <option
+                        value="CO"
+                      >
+                        Colorado
+                      </option>
+                      <option
+                        value="CT"
+                      >
+                        Connecticut
+                      </option>
+                      <option
+                        value="DE"
+                      >
+                        Delaware
+                      </option>
+                      <option
+                        value="DC"
+                      >
+                        District Of Columbia
+                      </option>
+                      <option
+                        value="FM"
+                      >
+                        Federated States Of Micronesia
+                      </option>
+                      <option
+                        value="FL"
+                      >
+                        Florida
+                      </option>
+                      <option
+                        value="GA"
+                      >
+                        Georgia
+                      </option>
+                      <option
+                        value="GU"
+                      >
+                        Guam
+                      </option>
+                      <option
+                        value="HI"
+                      >
+                        Hawaii
+                      </option>
+                      <option
+                        value="ID"
+                      >
+                        Idaho
+                      </option>
+                      <option
+                        value="IL"
+                      >
+                        Illinois
+                      </option>
+                      <option
+                        value="IN"
+                      >
+                        Indiana
+                      </option>
+                      <option
+                        value="IA"
+                      >
+                        Iowa
+                      </option>
+                      <option
+                        value="KS"
+                      >
+                        Kansas
+                      </option>
+                      <option
+                        value="KY"
+                      >
+                        Kentucky
+                      </option>
+                      <option
+                        value="LA"
+                      >
+                        Louisiana
+                      </option>
+                      <option
+                        value="ME"
+                      >
+                        Maine
+                      </option>
+                      <option
+                        value="MH"
+                      >
+                        Marshall Islands
+                      </option>
+                      <option
+                        value="MD"
+                      >
+                        Maryland
+                      </option>
+                      <option
+                        value="MA"
+                      >
+                        Massachusetts
+                      </option>
+                      <option
+                        value="MI"
+                      >
+                        Michigan
+                      </option>
+                      <option
+                        value="MN"
+                      >
+                        Minnesota
+                      </option>
+                      <option
+                        value="MS"
+                      >
+                        Mississippi
+                      </option>
+                      <option
+                        value="MO"
+                      >
+                        Missouri
+                      </option>
+                      <option
+                        value="MT"
+                      >
+                        Montana
+                      </option>
+                      <option
+                        value="NE"
+                      >
+                        Nebraska
+                      </option>
+                      <option
+                        value="NV"
+                      >
+                        Nevada
+                      </option>
+                      <option
+                        value="NH"
+                      >
+                        New Hampshire
+                      </option>
+                      <option
+                        value="NJ"
+                      >
+                        New Jersey
+                      </option>
+                      <option
+                        value="NM"
+                      >
+                        New Mexico
+                      </option>
+                      <option
+                        value="NY"
+                      >
+                        New York
+                      </option>
+                      <option
+                        value="NC"
+                      >
+                        North Carolina
+                      </option>
+                      <option
+                        value="ND"
+                      >
+                        North Dakota
+                      </option>
+                      <option
+                        value="MP"
+                      >
+                        Northern Mariana Islands
+                      </option>
+                      <option
+                        value="OH"
+                      >
+                        Ohio
+                      </option>
+                      <option
+                        value="OK"
+                      >
+                        Oklahoma
+                      </option>
+                      <option
+                        value="OR"
+                      >
+                        Oregon
+                      </option>
+                      <option
+                        value="PW"
+                      >
+                        Palau
+                      </option>
+                      <option
+                        value="PA"
+                      >
+                        Pennsylvania
+                      </option>
+                      <option
+                        value="PR"
+                      >
+                        Puerto Rico
+                      </option>
+                      <option
+                        value="RI"
+                      >
+                        Rhode Island
+                      </option>
+                      <option
+                        value="SC"
+                      >
+                        South Carolina
+                      </option>
+                      <option
+                        value="SD"
+                      >
+                        South Dakota
+                      </option>
+                      <option
+                        value="TN"
+                      >
+                        Tennessee
+                      </option>
+                      <option
+                        value="TX"
+                      >
+                        Texas
+                      </option>
+                      <option
+                        value="UT"
+                      >
+                        Utah
+                      </option>
+                      <option
+                        value="VT"
+                      >
+                        Vermont
+                      </option>
+                      <option
+                        value="VI"
+                      >
+                        Virgin Islands
+                      </option>
+                      <option
+                        value="VA"
+                      >
+                        Virginia
+                      </option>
+                      <option
+                        value="WA"
+                      >
+                        Washington
+                      </option>
+                      <option
+                        value="WV"
+                      >
+                        West Virginia
+                      </option>
+                      <option
+                        value="WI"
+                      >
+                        Wisconsin
+                      </option>
+                      <option
+                        value="WY"
+                      >
+                        Wyoming
+                      </option>
+                    </select>
+                  </div>
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingZip"
+                  >
+                    ZIP Code
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing postal-code"
+                    className="txt-f txt-f--50 "
+                    id="billingZip"
+                    name="billingZip"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="ZIP code"
+                    value="abc123"
+                  />
+                </div>
+                <div
+                  className="m-t700"
+                >
+                  <label
+                    className="cb"
+                  >
+                    <input
+                      checked={false}
+                      className="cb-f"
+                      id="storeBilling"
+                      name="storeBilling"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="true"
+                    />
+                     
+                    <span
+                      className="cb-l"
+                    >
+                      Save billing address on this computer
                     </span>
                   </label>
                 </div>
@@ -3516,7 +4709,7 @@ exports[`Storyshots Checkout/PaymentContent credit card error 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={true}
+                      checked={false}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -3534,7 +4727,7 @@ exports[`Storyshots Checkout/PaymentContent credit card error 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={false}
+                      checked={true}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -3546,6 +4739,468 @@ exports[`Storyshots Checkout/PaymentContent credit card error 1`] = `
                       className="ra-l"
                     >
                       Use a different address
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="m-t500"
+              >
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress1"
+                  >
+                    Address Line 1
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-line1"
+                    className="txt-f "
+                    id="billingAddress1"
+                    name="billingAddress1"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 1"
+                    type="text"
+                    value="3 Avengers Towers"
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress2"
+                  >
+                    Address Line 2 (optional)
+                  </label>
+                  <input
+                    autoComplete="billing address-line2"
+                    className="txt-f "
+                    id="billingAddress2"
+                    name="billingAddress2"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 2"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingCity"
+                  >
+                    City
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-level2"
+                    className="txt-f "
+                    id="billingCity"
+                    name="billingCity"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="City"
+                    type="text"
+                    value="New York"
+                  />
+                </div>
+                <div
+                  className="sel txt"
+                >
+                  <label
+                    className="sel-l txt-l--sm"
+                    htmlFor="billingState"
+                  >
+                    State / Territory
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <div
+                    className="sel-c"
+                  >
+                    <select
+                      aria-required="true"
+                      autoComplete="billing address-level1"
+                      className="sel-f "
+                      id="billingState"
+                      name="billingState"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      value="NY"
+                    >
+                      <option
+                        value="AL"
+                      >
+                        Alabama
+                      </option>
+                      <option
+                        value="AK"
+                      >
+                        Alaska
+                      </option>
+                      <option
+                        value="AS"
+                      >
+                        American Samoa
+                      </option>
+                      <option
+                        value="AZ"
+                      >
+                        Arizona
+                      </option>
+                      <option
+                        value="AR"
+                      >
+                        Arkansas
+                      </option>
+                      <option
+                        value="CA"
+                      >
+                        California
+                      </option>
+                      <option
+                        value="CO"
+                      >
+                        Colorado
+                      </option>
+                      <option
+                        value="CT"
+                      >
+                        Connecticut
+                      </option>
+                      <option
+                        value="DE"
+                      >
+                        Delaware
+                      </option>
+                      <option
+                        value="DC"
+                      >
+                        District Of Columbia
+                      </option>
+                      <option
+                        value="FM"
+                      >
+                        Federated States Of Micronesia
+                      </option>
+                      <option
+                        value="FL"
+                      >
+                        Florida
+                      </option>
+                      <option
+                        value="GA"
+                      >
+                        Georgia
+                      </option>
+                      <option
+                        value="GU"
+                      >
+                        Guam
+                      </option>
+                      <option
+                        value="HI"
+                      >
+                        Hawaii
+                      </option>
+                      <option
+                        value="ID"
+                      >
+                        Idaho
+                      </option>
+                      <option
+                        value="IL"
+                      >
+                        Illinois
+                      </option>
+                      <option
+                        value="IN"
+                      >
+                        Indiana
+                      </option>
+                      <option
+                        value="IA"
+                      >
+                        Iowa
+                      </option>
+                      <option
+                        value="KS"
+                      >
+                        Kansas
+                      </option>
+                      <option
+                        value="KY"
+                      >
+                        Kentucky
+                      </option>
+                      <option
+                        value="LA"
+                      >
+                        Louisiana
+                      </option>
+                      <option
+                        value="ME"
+                      >
+                        Maine
+                      </option>
+                      <option
+                        value="MH"
+                      >
+                        Marshall Islands
+                      </option>
+                      <option
+                        value="MD"
+                      >
+                        Maryland
+                      </option>
+                      <option
+                        value="MA"
+                      >
+                        Massachusetts
+                      </option>
+                      <option
+                        value="MI"
+                      >
+                        Michigan
+                      </option>
+                      <option
+                        value="MN"
+                      >
+                        Minnesota
+                      </option>
+                      <option
+                        value="MS"
+                      >
+                        Mississippi
+                      </option>
+                      <option
+                        value="MO"
+                      >
+                        Missouri
+                      </option>
+                      <option
+                        value="MT"
+                      >
+                        Montana
+                      </option>
+                      <option
+                        value="NE"
+                      >
+                        Nebraska
+                      </option>
+                      <option
+                        value="NV"
+                      >
+                        Nevada
+                      </option>
+                      <option
+                        value="NH"
+                      >
+                        New Hampshire
+                      </option>
+                      <option
+                        value="NJ"
+                      >
+                        New Jersey
+                      </option>
+                      <option
+                        value="NM"
+                      >
+                        New Mexico
+                      </option>
+                      <option
+                        value="NY"
+                      >
+                        New York
+                      </option>
+                      <option
+                        value="NC"
+                      >
+                        North Carolina
+                      </option>
+                      <option
+                        value="ND"
+                      >
+                        North Dakota
+                      </option>
+                      <option
+                        value="MP"
+                      >
+                        Northern Mariana Islands
+                      </option>
+                      <option
+                        value="OH"
+                      >
+                        Ohio
+                      </option>
+                      <option
+                        value="OK"
+                      >
+                        Oklahoma
+                      </option>
+                      <option
+                        value="OR"
+                      >
+                        Oregon
+                      </option>
+                      <option
+                        value="PW"
+                      >
+                        Palau
+                      </option>
+                      <option
+                        value="PA"
+                      >
+                        Pennsylvania
+                      </option>
+                      <option
+                        value="PR"
+                      >
+                        Puerto Rico
+                      </option>
+                      <option
+                        value="RI"
+                      >
+                        Rhode Island
+                      </option>
+                      <option
+                        value="SC"
+                      >
+                        South Carolina
+                      </option>
+                      <option
+                        value="SD"
+                      >
+                        South Dakota
+                      </option>
+                      <option
+                        value="TN"
+                      >
+                        Tennessee
+                      </option>
+                      <option
+                        value="TX"
+                      >
+                        Texas
+                      </option>
+                      <option
+                        value="UT"
+                      >
+                        Utah
+                      </option>
+                      <option
+                        value="VT"
+                      >
+                        Vermont
+                      </option>
+                      <option
+                        value="VI"
+                      >
+                        Virgin Islands
+                      </option>
+                      <option
+                        value="VA"
+                      >
+                        Virginia
+                      </option>
+                      <option
+                        value="WA"
+                      >
+                        Washington
+                      </option>
+                      <option
+                        value="WV"
+                      >
+                        West Virginia
+                      </option>
+                      <option
+                        value="WI"
+                      >
+                        Wisconsin
+                      </option>
+                      <option
+                        value="WY"
+                      >
+                        Wyoming
+                      </option>
+                    </select>
+                  </div>
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingZip"
+                  >
+                    ZIP Code
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing postal-code"
+                    className="txt-f txt-f--50 "
+                    id="billingZip"
+                    name="billingZip"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="ZIP code"
+                    value="12223"
+                  />
+                </div>
+                <div
+                  className="m-t700"
+                >
+                  <label
+                    className="cb"
+                  >
+                    <input
+                      checked={false}
+                      className="cb-f"
+                      id="storeBilling"
+                      name="storeBilling"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="true"
+                    />
+                     
+                    <span
+                      className="cb-l"
+                    >
+                      Save billing address on this computer
                     </span>
                   </label>
                 </div>
@@ -4552,7 +6207,7 @@ exports[`Storyshots Checkout/PaymentContent existing billing 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={true}
+                      checked={false}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -4570,7 +6225,7 @@ exports[`Storyshots Checkout/PaymentContent existing billing 1`] = `
                     className="ra"
                   >
                     <input
-                      checked={false}
+                      checked={true}
                       className="ra-f"
                       name="billingAddressSameAsShippingAddress"
                       onBlur={[Function]}
@@ -4582,6 +6237,468 @@ exports[`Storyshots Checkout/PaymentContent existing billing 1`] = `
                       className="ra-l"
                     >
                       Use a different address
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="m-t500"
+              >
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress1"
+                  >
+                    Address Line 1
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-line1"
+                    className="txt-f "
+                    id="billingAddress1"
+                    name="billingAddress1"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 1"
+                    type="text"
+                    value="3 Avengers Towers"
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingAddress2"
+                  >
+                    Address Line 2 (optional)
+                  </label>
+                  <input
+                    autoComplete="billing address-line2"
+                    className="txt-f "
+                    id="billingAddress2"
+                    name="billingAddress2"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="Address Line 2"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingCity"
+                  >
+                    City
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing address-level2"
+                    className="txt-f "
+                    id="billingCity"
+                    name="billingCity"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="City"
+                    type="text"
+                    value="New York"
+                  />
+                </div>
+                <div
+                  className="sel txt"
+                >
+                  <label
+                    className="sel-l txt-l--sm"
+                    htmlFor="billingState"
+                  >
+                    State / Territory
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <div
+                    className="sel-c"
+                  >
+                    <select
+                      aria-required="true"
+                      autoComplete="billing address-level1"
+                      className="sel-f "
+                      id="billingState"
+                      name="billingState"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      value="NY"
+                    >
+                      <option
+                        value="AL"
+                      >
+                        Alabama
+                      </option>
+                      <option
+                        value="AK"
+                      >
+                        Alaska
+                      </option>
+                      <option
+                        value="AS"
+                      >
+                        American Samoa
+                      </option>
+                      <option
+                        value="AZ"
+                      >
+                        Arizona
+                      </option>
+                      <option
+                        value="AR"
+                      >
+                        Arkansas
+                      </option>
+                      <option
+                        value="CA"
+                      >
+                        California
+                      </option>
+                      <option
+                        value="CO"
+                      >
+                        Colorado
+                      </option>
+                      <option
+                        value="CT"
+                      >
+                        Connecticut
+                      </option>
+                      <option
+                        value="DE"
+                      >
+                        Delaware
+                      </option>
+                      <option
+                        value="DC"
+                      >
+                        District Of Columbia
+                      </option>
+                      <option
+                        value="FM"
+                      >
+                        Federated States Of Micronesia
+                      </option>
+                      <option
+                        value="FL"
+                      >
+                        Florida
+                      </option>
+                      <option
+                        value="GA"
+                      >
+                        Georgia
+                      </option>
+                      <option
+                        value="GU"
+                      >
+                        Guam
+                      </option>
+                      <option
+                        value="HI"
+                      >
+                        Hawaii
+                      </option>
+                      <option
+                        value="ID"
+                      >
+                        Idaho
+                      </option>
+                      <option
+                        value="IL"
+                      >
+                        Illinois
+                      </option>
+                      <option
+                        value="IN"
+                      >
+                        Indiana
+                      </option>
+                      <option
+                        value="IA"
+                      >
+                        Iowa
+                      </option>
+                      <option
+                        value="KS"
+                      >
+                        Kansas
+                      </option>
+                      <option
+                        value="KY"
+                      >
+                        Kentucky
+                      </option>
+                      <option
+                        value="LA"
+                      >
+                        Louisiana
+                      </option>
+                      <option
+                        value="ME"
+                      >
+                        Maine
+                      </option>
+                      <option
+                        value="MH"
+                      >
+                        Marshall Islands
+                      </option>
+                      <option
+                        value="MD"
+                      >
+                        Maryland
+                      </option>
+                      <option
+                        value="MA"
+                      >
+                        Massachusetts
+                      </option>
+                      <option
+                        value="MI"
+                      >
+                        Michigan
+                      </option>
+                      <option
+                        value="MN"
+                      >
+                        Minnesota
+                      </option>
+                      <option
+                        value="MS"
+                      >
+                        Mississippi
+                      </option>
+                      <option
+                        value="MO"
+                      >
+                        Missouri
+                      </option>
+                      <option
+                        value="MT"
+                      >
+                        Montana
+                      </option>
+                      <option
+                        value="NE"
+                      >
+                        Nebraska
+                      </option>
+                      <option
+                        value="NV"
+                      >
+                        Nevada
+                      </option>
+                      <option
+                        value="NH"
+                      >
+                        New Hampshire
+                      </option>
+                      <option
+                        value="NJ"
+                      >
+                        New Jersey
+                      </option>
+                      <option
+                        value="NM"
+                      >
+                        New Mexico
+                      </option>
+                      <option
+                        value="NY"
+                      >
+                        New York
+                      </option>
+                      <option
+                        value="NC"
+                      >
+                        North Carolina
+                      </option>
+                      <option
+                        value="ND"
+                      >
+                        North Dakota
+                      </option>
+                      <option
+                        value="MP"
+                      >
+                        Northern Mariana Islands
+                      </option>
+                      <option
+                        value="OH"
+                      >
+                        Ohio
+                      </option>
+                      <option
+                        value="OK"
+                      >
+                        Oklahoma
+                      </option>
+                      <option
+                        value="OR"
+                      >
+                        Oregon
+                      </option>
+                      <option
+                        value="PW"
+                      >
+                        Palau
+                      </option>
+                      <option
+                        value="PA"
+                      >
+                        Pennsylvania
+                      </option>
+                      <option
+                        value="PR"
+                      >
+                        Puerto Rico
+                      </option>
+                      <option
+                        value="RI"
+                      >
+                        Rhode Island
+                      </option>
+                      <option
+                        value="SC"
+                      >
+                        South Carolina
+                      </option>
+                      <option
+                        value="SD"
+                      >
+                        South Dakota
+                      </option>
+                      <option
+                        value="TN"
+                      >
+                        Tennessee
+                      </option>
+                      <option
+                        value="TX"
+                      >
+                        Texas
+                      </option>
+                      <option
+                        value="UT"
+                      >
+                        Utah
+                      </option>
+                      <option
+                        value="VT"
+                      >
+                        Vermont
+                      </option>
+                      <option
+                        value="VI"
+                      >
+                        Virgin Islands
+                      </option>
+                      <option
+                        value="VA"
+                      >
+                        Virginia
+                      </option>
+                      <option
+                        value="WA"
+                      >
+                        Washington
+                      </option>
+                      <option
+                        value="WV"
+                      >
+                        West Virginia
+                      </option>
+                      <option
+                        value="WI"
+                      >
+                        Wisconsin
+                      </option>
+                      <option
+                        value="WY"
+                      >
+                        Wyoming
+                      </option>
+                    </select>
+                  </div>
+                </div>
+                <div
+                  className="txt"
+                >
+                  <label
+                    className="txt-l txt-l--sm"
+                    htmlFor="billingZip"
+                  >
+                    ZIP Code
+                     
+                    <span
+                      aria-hidden={true}
+                      className="t--req"
+                    >
+                      Required
+                    </span>
+                  </label>
+                  <input
+                    aria-required="true"
+                    autoComplete="billing postal-code"
+                    className="txt-f txt-f--50 "
+                    id="billingZip"
+                    name="billingZip"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    placeholder="ZIP code"
+                    value="12223"
+                  />
+                </div>
+                <div
+                  className="m-t700"
+                >
+                  <label
+                    className="cb"
+                  >
+                    <input
+                      checked={false}
+                      className="cb-f"
+                      id="storeBilling"
+                      name="storeBilling"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="true"
+                    />
+                     
+                    <span
+                      className="cb-l"
+                    >
+                      Save billing address on this computer
                     </span>
                   </label>
                 </div>
@@ -9633,11 +11750,9 @@ exports[`Storyshots Checkout/ShippingContent email error 1`] = `
                   </span>
                 </label>
                 <input
-                  aria-describedby="contactEmail-error"
-                  aria-invalid={true}
                   aria-required="true"
                   autoComplete="email"
-                  className="txt-f txt-f--100 txt-f--err"
+                  className="txt-f txt-f--100 "
                   id="contactEmail"
                   name="contactEmail"
                   onBlur={[Function]}
@@ -9646,12 +11761,6 @@ exports[`Storyshots Checkout/ShippingContent email error 1`] = `
                   type="email"
                   value="notacompleteaddress@"
                 />
-                <div
-                  className="t--info t--err m-t200"
-                  id="contactEmail-error"
-                >
-                  The email address format is invalid.
-                </div>
               </div>
               <div
                 className="txt"

--- a/services-js/registry-certs/client/common/checkout/OrderDetails.tsx
+++ b/services-js/registry-certs/client/common/checkout/OrderDetails.tsx
@@ -26,6 +26,7 @@ import {
 } from '../FeeDisclosures';
 
 import CertificateRow from '../../common/CertificateRow';
+import { observer } from 'mobx-react';
 
 interface DeathOrderProps {
   cart: DeathCertificateCart;
@@ -36,7 +37,9 @@ interface DeathOrderProps {
  * Displays a list of all death certificates in an order’s cart.
  * Use as child of OrderDetailsDropdown component, or it can be used alone.
  */
-export function DeathOrderDetails(props: DeathOrderProps) {
+export const DeathOrderDetails = observer(function DeathOrderDetails(
+  props: DeathOrderProps
+) {
   const { cart, thin } = props;
 
   const certificateRows = cart.entries.map(
@@ -65,7 +68,7 @@ export function DeathOrderDetails(props: DeathOrderProps) {
   );
 
   return <div>{certificateRows}</div>;
-}
+});
 
 interface DropdownProps {
   orderType: CertificateType;

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import CheckoutPage from './CheckoutPage';
+import Cart from '../../store/DeathCertificateCart';
+import {
+  ScreenReaderSupport,
+  GaSiteAnalytics,
+} from '@cityofboston/next-client-common';
+import CheckoutDao from '../../dao/CheckoutDao';
+
+storiesOf('Checkout/CheckoutPage', module).add('server-side render', () => (
+  <CheckoutPage
+    deathCertificateCart={new Cart()}
+    info={{ page: 'shipping' }}
+    screenReaderSupport={new ScreenReaderSupport()}
+    siteAnalytics={new GaSiteAnalytics()}
+    checkoutDao={new CheckoutDao(null as any, null)}
+    stripe={null}
+    // This never resolves, so we just get the initial render.
+    orderProvider={{ get: () => new Promise(() => {}) } as any}
+  />
+));

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.test.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.test.tsx
@@ -10,6 +10,7 @@ import CheckoutDao, { SubmissionError } from '../../dao/CheckoutDao';
 import OrderProvider from '../../store/OrderProvider';
 import DeathCertificateCart from '../../store/DeathCertificateCart';
 import { OrderErrorCause } from '../../queries/graphql-types';
+import Order from '../../models/Order';
 
 jest.mock('next/router');
 jest.mock('../../dao/CheckoutDao');
@@ -19,54 +20,23 @@ beforeEach(() => {
 });
 
 describe('getInitialProps', () => {
-  let res: any;
-
-  beforeEach(() => {
-    res = {
-      writeHead: jest.fn(),
-      end: jest.fn(),
-    };
-  });
-
   it('treats no page query param as shipping', async () => {
-    const initialProps = await CheckoutPage.getInitialProps(
-      { res, query: {} },
-      {}
-    );
+    const initialProps = await CheckoutPage.getInitialProps({ query: {} }, {});
     expect(initialProps.info.page).toEqual('shipping');
   });
 
   it('process payment on server', async () => {
     const initialProps = await CheckoutPage.getInitialProps(
-      { res, query: { page: 'payment' } },
+      { query: { page: 'payment' } },
       {}
     );
 
     expect(initialProps.info.page).toEqual('payment');
   });
 
-  it('redirects payment on server back to shipping', async () => {
-    await CheckoutPage.getInitialProps({ res, query: { page: 'payment' } }, {});
-
-    expect(res.writeHead).toHaveBeenCalled();
-  });
-
-  it('redirects unknown page query param to shipping on server', async () => {
-    await CheckoutPage.getInitialProps(
-      {
-        res,
-        query: { page: 'not-a-real-page' },
-      },
-      {}
-    );
-
-    expect(res.writeHead).toHaveBeenCalled();
-  });
-
   it('treats unknown page query param as shipping on client', async () => {
     const initialProps = await CheckoutPage.getInitialProps(
       {
-        res: undefined,
         query: { page: 'not-a-real-page' },
       },
       {}
@@ -78,7 +48,6 @@ describe('getInitialProps', () => {
   it('passes confirm props along', async () => {
     const initialProps = await CheckoutPage.getInitialProps(
       {
-        res: undefined,
         query: {
           page: 'confirmation',
           orderId: '123-456-7',
@@ -111,43 +80,59 @@ describe('rendering', () => {
   });
 
   it('renders shipping', () => {
-    expect(
-      new CheckoutPage({
-        info: { page: 'shipping' },
-        ...pageDependenciesProps,
-      }).render()
-    ).toMatchSnapshot();
+    const page = new CheckoutPage({
+      info: { page: 'shipping' },
+      ...pageDependenciesProps,
+    });
+
+    page.state = {
+      order: new Order(),
+    };
+
+    expect(page.render()).toMatchSnapshot();
   });
 
   it('renders payment', () => {
-    expect(
-      new CheckoutPage({
-        info: { page: 'payment' },
-        ...pageDependenciesProps,
-      }).render()
-    ).toMatchSnapshot();
+    const page = new CheckoutPage({
+      info: { page: 'payment' },
+      ...pageDependenciesProps,
+    });
+
+    page.state = {
+      order: new Order(),
+    };
+
+    expect(page.render()).toMatchSnapshot();
   });
 
   it('renders review', () => {
-    expect(
-      new CheckoutPage({
-        info: { page: 'review' },
-        ...pageDependenciesProps,
-      }).render()
-    ).toMatchSnapshot();
+    const page = new CheckoutPage({
+      info: { page: 'review' },
+      ...pageDependenciesProps,
+    });
+
+    page.state = {
+      order: new Order(),
+    };
+
+    expect(page.render()).toMatchSnapshot();
   });
 
   it('renders confirmation', () => {
-    expect(
-      new CheckoutPage({
-        info: {
-          page: 'confirmation',
-          orderId: '123-456-7',
-          contactEmail: 'ttoe@squirrelzone.net',
-        },
-        ...pageDependenciesProps,
-      }).render()
-    ).toMatchSnapshot();
+    const page = new CheckoutPage({
+      info: {
+        page: 'confirmation',
+        orderId: '123-456-7',
+        contactEmail: 'ttoe@squirrelzone.net',
+      },
+      ...pageDependenciesProps,
+    });
+
+    page.state = {
+      order: new Order(),
+    };
+
+    expect(page.render()).toMatchSnapshot();
   });
 });
 
@@ -157,10 +142,11 @@ describe('operations', () => {
   let component: CheckoutPage;
   let scrollSpy;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     scrollSpy = jest.spyOn(window, 'scroll').mockImplementation(() => {});
 
     orderProvider = new OrderProvider();
+    orderProvider.attach(null, null);
     checkoutDao = new CheckoutDao(null as any, null);
 
     // page doesn't really matter for this
@@ -175,7 +161,13 @@ describe('operations', () => {
       checkoutDao,
     });
 
-    component.componentWillMount();
+    component.state = {
+      order: await orderProvider.get(),
+    };
+
+    // Keeps us from setting state in the order succes case, since it will fail
+    // (the component isn’t actually mounted)
+    component.setState = jest.fn();
   });
 
   afterEach(() => {

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
@@ -1,9 +1,9 @@
 // Wrapper controller for the separate pages along the checkout flow
 
 import React from 'react';
-import { runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import Router from 'next/router';
+import Head from 'next/head';
 
 import { PageDependencies, GetInitialProps } from '../../../pages/_app';
 import Order, { OrderInfo } from '../../models/Order';
@@ -13,6 +13,8 @@ import PaymentContent from './PaymentContent';
 import ReviewContent from './ReviewContent';
 import ConfirmationContent from './ConfirmationContent';
 import { DEATH_CERTIFICATE_COST } from '../../../lib/costs';
+import PageLayout from '../../PageLayout';
+import { BreadcrumbNavLinks } from '../breadcrumbs';
 
 type PageInfo =
   | {
@@ -46,14 +48,26 @@ export type PageDependenciesProps = Pick<
 
 interface Props extends InitialProps, PageDependenciesProps {}
 
+type State = {
+  /**
+   * This will be null on the server and during the first client render.
+   */
+  order: Order | null;
+};
+
 @observer
-export default class CheckoutPageController extends React.Component<Props> {
-  static getInitialProps: GetInitialProps<InitialProps, 'query' | 'res'> = ({
+export default class CheckoutPageController extends React.Component<
+  Props,
+  State
+> {
+  state: State = {
+    order: null,
+  };
+
+  static getInitialProps: GetInitialProps<InitialProps, 'query'> = ({
     query,
-    res,
   }) => {
     let info: PageInfo;
-    let redirectToShippingIfServer = false;
 
     const page = query.page || '';
 
@@ -64,19 +78,9 @@ export default class CheckoutPageController extends React.Component<Props> {
         break;
       case 'payment':
         info = { page: 'payment' };
-
-        // We know that we won't have shipping information if someone visits
-        // the payment page directly from the server (since this component's
-        // internal state will be blank), so redirect.
-        redirectToShippingIfServer = true;
         break;
       case 'review':
         info = { page: 'review' };
-
-        // We know that we won't have shipping information if someone visits
-        // the payment page directly from the server (since this component's
-        // internal state will be blank), so redirect.
-        redirectToShippingIfServer = true;
         break;
       case 'confirmation':
         info = {
@@ -87,46 +91,24 @@ export default class CheckoutPageController extends React.Component<Props> {
         break;
       default:
         info = { page: 'shipping' };
-        redirectToShippingIfServer = true;
-    }
-
-    if (redirectToShippingIfServer && res) {
-      res.writeHead(301, {
-        Location: '/death/checkout',
-      });
-      res.end();
+        break;
     }
 
     return { info };
   };
 
-  // This wil persist across different sub-pages since React will preserve the
-  // component instance. This will keep the form fields filled out as the user
-  // goes forward and back in the interface, and it will get automatically
-  // disposed of if the user leaves the flow, which is the behavior that we
-  // want.
-  //
-  // Set in componentWillMount, so it always is non-null;
-  private order: Order = null as any;
-
-  componentWillMount() {
-    const { orderProvider } = this.props;
-
+  async componentDidMount() {
     this.reportCheckoutStep(this.props);
 
-    // This will be populated from localStorage, and changes to it will get
-    // written back there.
-    const order = orderProvider.get();
-    this.order = order;
-  }
+    const { orderProvider } = this.props;
 
-  componentDidMount() {
-    this.redirectIfMissingOrderInfo(this.props);
+    // We won’t have an Order until we’re mounted in the browser because it’s
+    // dependent on sessionStorage / localStorage data.
+    const order = await orderProvider.get();
+    await new Promise(resolve => this.setState({ order }, resolve));
   }
 
   componentWillReceiveProps(newProps: Props) {
-    this.redirectIfMissingOrderInfo(newProps);
-
     if (newProps.info.page !== this.props.info.page) {
       this.reportCheckoutStep(newProps);
     }
@@ -152,22 +134,14 @@ export default class CheckoutPageController extends React.Component<Props> {
     }
   }
 
-  // In the case of reloading from the browser, for example, or clicking
-  // "back" from the confirmation page.
-  async redirectIfMissingOrderInfo(props: Props) {
-    if (
-      (props.info.page === 'payment' && !this.order.shippingIsComplete) ||
-      (props.info.page === 'review' &&
-        (!this.order.shippingIsComplete || !this.order.paymentIsComplete))
-    ) {
-      await Router.push('/death/checkout?page=shipping', '/death/checkout');
-
-      window.scroll(0, 0);
-    }
-  }
-
   advanceToPayment = async (shippingInfo: Partial<OrderInfo>) => {
-    this.order.updateInfo(shippingInfo);
+    const { order } = this.state;
+
+    if (!order) {
+      return;
+    }
+
+    order.updateInfo(shippingInfo);
 
     await Router.push('/death/checkout?page=payment');
 
@@ -178,10 +152,14 @@ export default class CheckoutPageController extends React.Component<Props> {
     cardElement: stripe.elements.Element | null,
     billingInfo: Partial<OrderInfo>
   ) => {
-    const { order } = this;
     const { checkoutDao } = this.props;
+    const { order } = this.state;
 
-    this.order.updateInfo(billingInfo);
+    if (!order) {
+      return;
+    }
+
+    order.updateInfo(billingInfo);
 
     // This may throw, in which case the payment page will catch it and display
     // the error.
@@ -198,7 +176,6 @@ export default class CheckoutPageController extends React.Component<Props> {
    * Will throw exceptions if things didn’t go well.
    */
   submitOrder = async () => {
-    const { order } = this;
     const {
       deathCertificateCart,
       checkoutDao,
@@ -206,26 +183,34 @@ export default class CheckoutPageController extends React.Component<Props> {
       orderProvider,
     } = this.props;
 
+    const { order } = this.state;
+
+    if (!order) {
+      return;
+    }
+
     const orderId = await checkoutDao.submitDeathCertificateCart(
       deathCertificateCart,
       order
     );
 
     deathCertificateCart.trackCartItems();
+
     siteAnalytics.setProductAction('purchase', {
       id: orderId,
       revenue: deathCertificateCart.size * DEATH_CERTIFICATE_COST / 100,
     });
+
     siteAnalytics.sendEvent('click', {
       category: 'UX',
       label: 'submit order',
     });
 
-    runInAction(() => {
-      deathCertificateCart.clear();
-      orderProvider.clear();
+    deathCertificateCart.clear();
+    orderProvider.clear();
 
-      this.order = orderProvider.get();
+    this.setState({
+      order: await orderProvider.get(),
     });
 
     await Router.push(
@@ -239,8 +224,21 @@ export default class CheckoutPageController extends React.Component<Props> {
   };
 
   render() {
-    const { order } = this;
     const { info, deathCertificateCart, stripe } = this.props;
+    const { order } = this.state;
+
+    // This happens during server side rendering
+    if (!order) {
+      return (
+        <PageLayout breadcrumbNav={BreadcrumbNavLinks}>
+          <div className="b-c b-c--hsm">
+            <Head>
+              <title>Boston.gov — Death Certificates — Checkout</title>
+            </Head>
+          </div>
+        </PageLayout>
+      );
+    }
 
     switch (info.page) {
       case 'shipping':

--- a/services-js/registry-certs/client/death/checkout/PaymentContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/PaymentContent.stories.tsx
@@ -94,7 +94,6 @@ storiesOf('Checkout/PaymentContent', module)
       stripe={makeStripe()}
       order={makeBillingCompleteOrder()}
       submit={action('submit')}
-      showErrorsForTest
       cardElementErrorForTest="Your card number is incomplete."
     />
   ))
@@ -104,9 +103,9 @@ storiesOf('Checkout/PaymentContent', module)
       stripe={makeStripe()}
       order={makeBillingCompleteOrder({
         billingZip: 'abc123',
+        billingAddressSameAsShippingAddress: false,
       })}
       submit={action('submit')}
-      showErrorsForTest
     />
   ))
   .add('Stripe error', () => (
@@ -115,7 +114,6 @@ storiesOf('Checkout/PaymentContent', module)
       stripe={makeStripe()}
       order={makeBillingCompleteOrder()}
       submit={action('submit')}
-      showErrorsForTest
       tokenizationErrorForTest="The card could not be tokenized"
     />
   ))

--- a/services-js/registry-certs/client/death/checkout/ShippingContent.stories.tsx
+++ b/services-js/registry-certs/client/death/checkout/ShippingContent.stories.tsx
@@ -70,7 +70,6 @@ storiesOf('Checkout/ShippingContent', module)
       cart={makeCart()}
       order={makeOrder({ contactEmail: 'notacompleteaddress@' })}
       submit={action('submit')}
-      showErrorsForTest
     />
   ))
   .add('existing address', () => (

--- a/services-js/registry-certs/client/death/checkout/__snapshots__/CheckoutPage.test.tsx.snap
+++ b/services-js/registry-certs/client/death/checkout/__snapshots__/CheckoutPage.test.tsx.snap
@@ -21,7 +21,38 @@ exports[`rendering renders payment 1`] = `
       "siteAnalytics": null,
     }
   }
-  order={null}
+  order={
+    Order {
+      "idempotencyKey": null,
+      "info": Object {
+        "billingAddress1": "",
+        "billingAddress2": "",
+        "billingAddressSameAsShippingAddress": true,
+        "billingCity": "",
+        "billingState": "MA",
+        "billingZip": "",
+        "cardFunding": "unknown",
+        "cardLast4": "",
+        "cardToken": null,
+        "cardholderName": "",
+        "contactEmail": "",
+        "contactName": "",
+        "contactPhone": "",
+        "shippingAddress1": "",
+        "shippingAddress2": "",
+        "shippingCity": "",
+        "shippingCompanyName": "",
+        "shippingName": "",
+        "shippingState": "MA",
+        "shippingZip": "",
+        "storeBilling": false,
+        "storeContactAndShipping": false,
+      },
+      "localStorageAvailable": true,
+      "processing": false,
+      "updateStorageDisposer": null,
+    }
+  }
   stripe={null}
   submit={[Function]}
 />
@@ -35,7 +66,38 @@ exports[`rendering renders review 1`] = `
       "siteAnalytics": null,
     }
   }
-  order={null}
+  order={
+    Order {
+      "idempotencyKey": null,
+      "info": Object {
+        "billingAddress1": "",
+        "billingAddress2": "",
+        "billingAddressSameAsShippingAddress": true,
+        "billingCity": "",
+        "billingState": "MA",
+        "billingZip": "",
+        "cardFunding": "unknown",
+        "cardLast4": "",
+        "cardToken": null,
+        "cardholderName": "",
+        "contactEmail": "",
+        "contactName": "",
+        "contactPhone": "",
+        "shippingAddress1": "",
+        "shippingAddress2": "",
+        "shippingCity": "",
+        "shippingCompanyName": "",
+        "shippingName": "",
+        "shippingState": "MA",
+        "shippingZip": "",
+        "storeBilling": false,
+        "storeContactAndShipping": false,
+      },
+      "localStorageAvailable": true,
+      "processing": false,
+      "updateStorageDisposer": null,
+    }
+  }
   submit={[Function]}
 />
 `;
@@ -48,7 +110,38 @@ exports[`rendering renders shipping 1`] = `
       "siteAnalytics": null,
     }
   }
-  order={null}
+  order={
+    Order {
+      "idempotencyKey": null,
+      "info": Object {
+        "billingAddress1": "",
+        "billingAddress2": "",
+        "billingAddressSameAsShippingAddress": true,
+        "billingCity": "",
+        "billingState": "MA",
+        "billingZip": "",
+        "cardFunding": "unknown",
+        "cardLast4": "",
+        "cardToken": null,
+        "cardholderName": "",
+        "contactEmail": "",
+        "contactName": "",
+        "contactPhone": "",
+        "shippingAddress1": "",
+        "shippingAddress2": "",
+        "shippingCity": "",
+        "shippingCompanyName": "",
+        "shippingName": "",
+        "shippingState": "MA",
+        "shippingZip": "",
+        "storeBilling": false,
+        "storeContactAndShipping": false,
+      },
+      "localStorageAvailable": true,
+      "processing": false,
+      "updateStorageDisposer": null,
+    }
+  }
   submit={[Function]}
 />
 `;

--- a/services-js/registry-certs/client/death/checkout/formik-util.ts
+++ b/services-js/registry-certs/client/death/checkout/formik-util.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+/**
+ * Given a ref to a Formik component, runs its validator and automatically
+ * touches any fields that have both errors and values.
+ *
+ * Useful to run Formik when it’s initialized with values that might not be
+ * valid.
+ *
+ * Hopefully Formik 2.0 will have something like this built-in:
+ * https://github.com/jaredpalmer/formik/issues/288#issuecomment-431670630
+ */
+export async function runInitialValidation<T>(ref: React.RefObject<Formik<T>>) {
+  const errors = ref.current
+    ? await ref.current.getFormikBag().validateForm()
+    : [];
+
+  // We might have unmounted while awaiting the errors, so we have to check
+  // again.
+  if (ref.current) {
+    const { setFieldTouched, values } = ref.current.getFormikBag();
+    Object.keys(errors).forEach(k => values[k] && setFieldTouched(k));
+  }
+}

--- a/services-js/registry-certs/client/store/DeathCertificateCart.ts
+++ b/services-js/registry-certs/client/store/DeathCertificateCart.ts
@@ -25,6 +25,7 @@ export default class DeathCertificateCart {
   localStorageDisposer: Function | null = null;
   siteAnalytics: GaSiteAnalytics | null = null;
 
+  @action
   attach(
     localStorage: Storage | null,
     deathCertificatesDao: DeathCertificatesDao,
@@ -90,6 +91,7 @@ export default class DeathCertificateCart {
     }
   }
 
+  @action
   detach() {
     if (this.localStorageDisposer) {
       this.localStorageDisposer();
@@ -101,6 +103,7 @@ export default class DeathCertificateCart {
 
   trackCartItems() {
     const { siteAnalytics } = this;
+
     if (!siteAnalytics) {
       return;
     }
@@ -197,6 +200,7 @@ export default class DeathCertificateCart {
     this.entries = this.entries.filter(({ quantity }) => quantity > 0);
   }
 
+  @action
   clear() {
     this.entries = [];
   }

--- a/services-js/registry-certs/client/store/OrderProvider.test.ts
+++ b/services-js/registry-certs/client/store/OrderProvider.test.ts
@@ -2,7 +2,7 @@ import OrderProvider, {
   LOCAL_STORAGE_KEY,
   SESSION_STORAGE_KEY,
 } from './OrderProvider';
-import { OrderInfo } from '../models/Order';
+import Order, { OrderInfo } from '../models/Order';
 
 class FakeStorage implements Storage {
   store = {};
@@ -43,7 +43,7 @@ describe('storage', () => {
     orderProvider.attach(localStorage, sessionStorage);
   });
 
-  it('initializes order from session storage', () => {
+  it('initializes order from session storage', async () => {
     const orderInfo: OrderInfo = {
       storeContactAndShipping: true,
       storeBilling: false,
@@ -76,12 +76,12 @@ describe('storage', () => {
 
     sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(orderInfo));
 
-    const order = orderProvider.get();
+    const order = await orderProvider.get();
 
     expect(order.info.contactName).toEqual('Squirrel Girl');
   });
 
-  it('initializes order from local storage', () => {
+  it('initializes order from local storage', async () => {
     const orderInfo: OrderInfo = {
       storeContactAndShipping: true,
       storeBilling: false,
@@ -113,13 +113,13 @@ describe('storage', () => {
     };
     localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(orderInfo));
 
-    const order = orderProvider.get();
+    const order = await orderProvider.get();
 
     expect(order.info.contactName).toEqual('Squirrel Girl');
   });
 
-  it('saves shipping after checking the box, deletes it later', () => {
-    const order = orderProvider.get();
+  it('saves shipping after checking the box, deletes it later', async () => {
+    const order = await orderProvider.get();
 
     order.info.contactName = 'Tippy Toe';
 
@@ -140,8 +140,8 @@ describe('storage', () => {
     ).toBeUndefined();
   });
 
-  it('saves billing after checking the box, deletes it later', () => {
-    const order = orderProvider.get();
+  it('saves billing after checking the box, deletes it later', async () => {
+    const order = await orderProvider.get();
 
     order.info.billingAddress1 = '10 College Avenue';
 
@@ -166,5 +166,27 @@ describe('storage', () => {
         'billingAddress1'
       ]
     ).toBeUndefined();
+  });
+});
+
+describe('promises', () => {
+  it('resolves a promise once attachment happens', async () => {
+    const orderProvider = new OrderProvider();
+    const orderPromise = orderProvider.get();
+
+    orderProvider.attach(null, null);
+
+    // Failure here is a timeout from this never resolving
+    await expect(orderPromise).resolves.toBeInstanceOf(Order);
+  });
+
+  it('resolves promises once it’s been attached', async () => {
+    const orderProvider = new OrderProvider();
+    orderProvider.attach(null, null);
+
+    const orderPromise = orderProvider.get();
+
+    // Failure here is a timeout from this never resolving
+    await expect(orderPromise).resolves.toBeInstanceOf(Order);
   });
 });

--- a/services-js/registry-certs/pages/_app.tsx
+++ b/services-js/registry-certs/pages/_app.tsx
@@ -183,32 +183,6 @@ export default class RegistryCertsApp extends App {
     const orderProvider = new OrderProvider();
     const siteAnalytics = new GaSiteAnalytics();
 
-    if ((process as any).browser) {
-      // We attach to localStorage in the constructor, rather than
-      // componentDidMount, so that the information is available on first
-      // render.
-
-      // We need to ensure localStorage is available in the browser,
-      // otherwise an error could be thrown:
-      // https://github.com/CityOfBoston/digital/issues/199
-      let localStorage: Storage | null = null;
-      let sessionStorage: Storage | null = null;
-
-      try {
-        localStorage = window.localStorage;
-        sessionStorage = window.sessionStorage;
-      } catch {
-        //  possible security error; ignore.
-      }
-
-      deathCertificateCart.attach(
-        localStorage,
-        initialPageDependencies.deathCertificatesDao,
-        siteAnalytics
-      );
-      orderProvider.attach(localStorage, sessionStorage);
-    }
-
     const config = getConfig();
 
     const stripe =
@@ -236,6 +210,9 @@ export default class RegistryCertsApp extends App {
       routerListener,
       screenReaderSupport,
       siteAnalytics,
+      deathCertificateCart,
+      orderProvider,
+      deathCertificatesDao,
     } = this.pageDependencies;
 
     screenReaderSupport.attach();
@@ -244,13 +221,43 @@ export default class RegistryCertsApp extends App {
       siteAnalytics,
       screenReaderSupport,
     });
+
+    // We attach to localStorage in the constructor, rather than
+    // componentDidMount, so that the information is available on first
+    // render.
+
+    // We need to ensure localStorage is available in the browser,
+    // otherwise an error could be thrown:
+    // https://github.com/CityOfBoston/digital/issues/199
+    let localStorage: Storage | null = null;
+    let sessionStorage: Storage | null = null;
+
+    try {
+      localStorage = window.localStorage;
+      sessionStorage = window.sessionStorage;
+    } catch {
+      //  possible security error; ignore.
+    }
+
+    deathCertificateCart.attach(
+      localStorage,
+      deathCertificatesDao,
+      siteAnalytics
+    );
+
+    orderProvider.attach(localStorage, sessionStorage);
   }
 
   componentWillUnmount() {
-    const { routerListener, screenReaderSupport } = this.pageDependencies;
+    const {
+      routerListener,
+      screenReaderSupport,
+      orderProvider,
+    } = this.pageDependencies;
 
     routerListener.detach();
     screenReaderSupport.detach();
+    orderProvider.detach();
   }
 
   render() {


### PR DESCRIPTION
 - Uses query parameters to move between pages, so back / forward /
   reload works
 - Changes all localStorage and sessionStorage attaching to happen in
   componentDidMount to remove that as a difference between SSR and
   initial client rendering (React does not guarantee that hydrating
   will succeed if the HTML is different) – this fixes reloading the
   shipping page and the button always being disabled even if the form
   is filled out
 - Updates uses of OrderProvider to work with Promises
 - Fixes PaymentContent to allow initialization with "differentAddress"
 - Runs validations and shows errors in Formik forms for initialValues,
   in the case of Order not being valid (also helps for Storybook)