### PR TITLE
Adds jest project support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+const { workspaces = [] } = require('./package.json');
+
+// This is necessary for the Jest babel transformer — when it’s run from the
+// repo’s root – to find each package’s .babelrc files.
+//
+// See: https://github.com/facebook/jest/issues/6053#issuecomment-383632515 And:
+// https://github.com/vikr01/toms-shuttles/blob/dev/babel.config.js
+module.exports = {
+  babelrcRoots: workspaces.packages || workspaces,
+};

--- a/modules-js/react-fleet/src/Storyshots.test.ts
+++ b/modules-js/react-fleet/src/Storyshots.test.ts
@@ -1,5 +1,8 @@
+import path from 'path';
 import initStoryshots from '@storybook/addon-storyshots';
 
 require('babel-plugin-require-context-hook/register')();
 
-initStoryshots({});
+initStoryshots({
+  configPath: path.resolve(__dirname, '../.storybook'),
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "engines": {
     "yarn": "^1.6.0"
   },
+  "jest": {
+    "projects": [
+      "<rootDir>/modules-js/*",
+      "<rootDir>/services-js/*"
+    ]
+  },
   "workspaces": {
     "packages": [
       "services-js/*",
@@ -41,6 +47,8 @@
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
     "jest": "23.6.0",
+    "jest-environment-jsdom": "23.4.0",
+    "jest-environment-node": "23.4.0",
     "khaos": "^0.9.3",
     "lerna": "3.4.0",
     "lint-staged": "^7.0.4",

--- a/services-js/311/.storybook/Storyshots.test.ts
+++ b/services-js/311/.storybook/Storyshots.test.ts
@@ -9,6 +9,7 @@ function createNodeMock(element) {
 }
 
 initStoryshots({
+  configPath: __dirname,
   test: snapshotWithOptions({
     createNodeMock,
   }),

--- a/services-js/access-boston/src/stories/Storyshots.test.ts
+++ b/services-js/access-boston/src/stories/Storyshots.test.ts
@@ -1,5 +1,6 @@
+import path from 'path';
 import initStoryshots from '@storybook/addon-storyshots';
 
 require('babel-plugin-require-context-hook/register')();
 
-initStoryshots({});
+initStoryshots({ configPath: path.resolve(__dirname, '../../.storybook') });

--- a/services-js/commissions-app/src/server/email/EmailContent.ts
+++ b/services-js/commissions-app/src/server/email/EmailContent.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import Handlebars from 'handlebars';
 import mjml2html from 'mjml';
 
@@ -77,11 +78,11 @@ export default class EmailContent {
   }
 
   private readTemplateFiles(recipient: string): Templates {
-    const path = 'src/server/email';
+    const p = path.resolve(__dirname, '../../../src/server/email');
 
     return {
-      MJML: fs.readFileSync(`${path}/${recipient}.mjml.hbs`, 'utf-8'),
-      TEXT: fs.readFileSync(`${path}/${recipient}.text.hbs`, 'utf-8'),
+      MJML: fs.readFileSync(`${p}/${recipient}.mjml.hbs`, 'utf-8'),
+      TEXT: fs.readFileSync(`${p}/${recipient}.text.hbs`, 'utf-8'),
     };
   }
 }

--- a/services-js/commissions-app/src/stories/Storyshots.test.ts
+++ b/services-js/commissions-app/src/stories/Storyshots.test.ts
@@ -1,5 +1,6 @@
+import path from 'path';
 import initStoryshots from '@storybook/addon-storyshots';
 
 require('babel-plugin-require-context-hook/register')();
 
-initStoryshots({});
+initStoryshots({ configPath: path.resolve(__dirname, '../../.storybook') });

--- a/services-js/public-notices/src/Storyshots.test.ts
+++ b/services-js/public-notices/src/Storyshots.test.ts
@@ -1,5 +1,6 @@
+import path from 'path';
 import initStoryshots from '@storybook/addon-storyshots';
 
 require('babel-plugin-require-context-hook/register')();
 
-initStoryshots({});
+initStoryshots({ configPath: path.resolve(__dirname, '../.storybook') });

--- a/services-js/registry-certs/client/Storyshots.test.ts
+++ b/services-js/registry-certs/client/Storyshots.test.ts
@@ -1,5 +1,6 @@
+import path from 'path';
 import initStoryshots from '@storybook/addon-storyshots';
 
 require('babel-plugin-require-context-hook/register')();
 
-initStoryshots({});
+initStoryshots({ configPath: path.resolve(__dirname, '../.storybook') });

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -17,7 +17,6 @@ exports[`Storyshots Birth/QuestionsFlow QuestionsFlow page 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -456,7 +455,6 @@ exports[`Storyshots Birth/QuestionsFlow date of birth? 1`] = `
         </legend>
         <div
           className="css-1u6hmg8"
-          style={undefined}
         >
           <label
             className="txt-l "
@@ -476,19 +474,10 @@ exports[`Storyshots Birth/QuestionsFlow date of birth? 1`] = `
           <input
             aria-label=""
             className="txt-f  "
-            defaultValue={undefined}
-            disabled={undefined}
             id="input-4004051805"
-            inputMode={undefined}
-            maxLength={undefined}
-            minLength={undefined}
             name="dateOfBirth"
-            onBlur={undefined}
             onChange={[Function]}
-            onFocus={undefined}
             onKeyDown={[Function]}
-            placeholder={undefined}
-            required={undefined}
             type="text"
             value=""
           />
@@ -550,10 +539,7 @@ exports[`Storyshots Birth/QuestionsFlow enter name 1`] = `
         <div
           className="css-cbwvwu"
         >
-          <div
-            className={undefined}
-            style={undefined}
-          >
+          <div>
             <label
               className="txt-l "
               htmlFor="input-2048906072"
@@ -573,20 +559,10 @@ exports[`Storyshots Birth/QuestionsFlow enter name 1`] = `
               aria-label=""
               className="txt-f  "
               defaultValue=""
-              disabled={undefined}
               id="input-2048906072"
-              inputMode={undefined}
-              maxLength={undefined}
-              minLength={undefined}
               name="firstName"
-              onBlur={undefined}
               onChange={[Function]}
-              onFocus={undefined}
-              onKeyDown={undefined}
-              placeholder={undefined}
-              required={undefined}
               type="text"
-              value={undefined}
             />
             <div
               className="t--subinfo t--err m-b100"
@@ -594,10 +570,7 @@ exports[`Storyshots Birth/QuestionsFlow enter name 1`] = `
                
             </div>
           </div>
-          <div
-            className={undefined}
-            style={undefined}
-          >
+          <div>
             <label
               className="txt-l "
               htmlFor="input-1103291528"
@@ -617,20 +590,11 @@ exports[`Storyshots Birth/QuestionsFlow enter name 1`] = `
               aria-label=""
               className="txt-f  "
               defaultValue=""
-              disabled={undefined}
               id="input-1103291528"
-              inputMode={undefined}
-              maxLength={undefined}
-              minLength={undefined}
               name="lastName"
-              onBlur={undefined}
               onChange={[Function]}
-              onFocus={undefined}
               onKeyDown={[Function]}
-              placeholder={undefined}
-              required={undefined}
               type="text"
-              value={undefined}
             />
             <div
               className="t--subinfo t--err m-b100"
@@ -649,7 +613,6 @@ exports[`Storyshots Birth/QuestionsFlow enter name 1`] = `
             name?
           </h3>
           <div
-            className={undefined}
             style={
               Object {
                 "textAlign": "left",
@@ -675,20 +638,11 @@ exports[`Storyshots Birth/QuestionsFlow enter name 1`] = `
               aria-label=""
               className="txt-f  "
               defaultValue=""
-              disabled={undefined}
               id="input-1349562878"
-              inputMode={undefined}
-              maxLength={undefined}
-              minLength={undefined}
               name="altSpelling"
-              onBlur={undefined}
               onChange={[Function]}
-              onFocus={undefined}
               onKeyDown={[Function]}
-              placeholder={undefined}
-              required={undefined}
               type="text"
-              value={undefined}
             />
             <div
               className="t--subinfo t--err m-b100"
@@ -771,10 +725,7 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
           <div
             className="css-cbwvwu"
           >
-            <div
-              className={undefined}
-              style={undefined}
-            >
+            <div>
               <label
                 className="txt-l "
                 htmlFor="input-2048906072"
@@ -794,20 +745,10 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
                 aria-label=""
                 className="txt-f  "
                 defaultValue=""
-                disabled={undefined}
                 id="input-2048906072"
-                inputMode={undefined}
-                maxLength={undefined}
-                minLength={undefined}
                 name="parent1FirstName"
-                onBlur={undefined}
                 onChange={[Function]}
-                onFocus={undefined}
-                onKeyDown={undefined}
-                placeholder={undefined}
-                required={undefined}
                 type="text"
-                value={undefined}
               />
               <div
                 className="t--subinfo t--err m-b100"
@@ -815,10 +756,7 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
                  
               </div>
             </div>
-            <div
-              className={undefined}
-              style={undefined}
-            >
+            <div>
               <label
                 className="txt-l "
                 htmlFor="input-1103291528"
@@ -838,20 +776,10 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
                 aria-label=""
                 className="txt-f  "
                 defaultValue=""
-                disabled={undefined}
                 id="input-1103291528"
-                inputMode={undefined}
-                maxLength={undefined}
-                minLength={undefined}
                 name="parent1LastName"
-                onBlur={undefined}
                 onChange={[Function]}
-                onFocus={undefined}
-                onKeyDown={undefined}
-                placeholder={undefined}
-                required={undefined}
                 type="text"
-                value={undefined}
               />
               <div
                 className="t--subinfo t--err m-b100"
@@ -873,10 +801,7 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
           <div
             className="css-cbwvwu"
           >
-            <div
-              className={undefined}
-              style={undefined}
-            >
+            <div>
               <label
                 className="txt-l "
                 htmlFor="input-2048906072"
@@ -896,20 +821,10 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
                 aria-label=""
                 className="txt-f  "
                 defaultValue=""
-                disabled={undefined}
                 id="input-2048906072"
-                inputMode={undefined}
-                maxLength={undefined}
-                minLength={undefined}
                 name="parent2FirstName"
-                onBlur={undefined}
                 onChange={[Function]}
-                onFocus={undefined}
-                onKeyDown={undefined}
-                placeholder={undefined}
-                required={undefined}
                 type="text"
-                value={undefined}
               />
               <div
                 className="t--subinfo t--err m-b100"
@@ -917,10 +832,7 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
                  
               </div>
             </div>
-            <div
-              className={undefined}
-              style={undefined}
-            >
+            <div>
               <label
                 className="txt-l "
                 htmlFor="input-1103291528"
@@ -940,20 +852,10 @@ exports[`Storyshots Birth/QuestionsFlow parents’ names? 1`] = `
                 aria-label=""
                 className="txt-f  "
                 defaultValue=""
-                disabled={undefined}
                 id="input-1103291528"
-                inputMode={undefined}
-                maxLength={undefined}
-                minLength={undefined}
                 name="parent2LastName"
-                onBlur={undefined}
                 onChange={[Function]}
-                onFocus={undefined}
-                onKeyDown={undefined}
-                placeholder={undefined}
-                required={undefined}
                 type="text"
-                value={undefined}
               />
               <div
                 className="t--subinfo t--err m-b100"
@@ -1180,7 +1082,6 @@ exports[`Storyshots Birth/ReviewRequest default page 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -1663,7 +1564,6 @@ exports[`Storyshots Checkout/CheckoutPage server-side render 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -1932,7 +1832,6 @@ exports[`Storyshots Checkout/ConfirmationContent default 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -2302,7 +2201,6 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -3323,7 +3221,6 @@ exports[`Storyshots Checkout/PaymentContent ZIP code error 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -4303,7 +4200,6 @@ exports[`Storyshots Checkout/PaymentContent credit card error 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -5287,7 +5183,6 @@ exports[`Storyshots Checkout/PaymentContent default 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -5805,7 +5700,6 @@ exports[`Storyshots Checkout/PaymentContent existing billing 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -6785,7 +6679,6 @@ exports[`Storyshots Checkout/ReviewContent cart has pending certs 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -7560,7 +7453,6 @@ exports[`Storyshots Checkout/ReviewContent default 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -8251,7 +8143,6 @@ exports[`Storyshots Checkout/ReviewContent payment error 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -8975,7 +8866,6 @@ exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -9707,7 +9597,6 @@ exports[`Storyshots Checkout/ReviewContent submitting 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -10420,7 +10309,6 @@ exports[`Storyshots Checkout/ShippingContent default 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -11407,7 +11295,6 @@ exports[`Storyshots Checkout/ShippingContent email error 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -12394,7 +12281,6 @@ exports[`Storyshots Checkout/ShippingContent existing address 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -14370,10 +14256,7 @@ exports[`Storyshots Common Components/Order Details OrderDetailsDropdown: open 1
       role="region"
     >
       <div
-        appear={undefined}
         className="dr-c css-1mti76v"
-        enter={undefined}
-        exit={undefined}
         in={true}
         onExited={[Function]}
       >
@@ -14914,7 +14797,6 @@ exports[`Storyshots Death/CartPage empty cart 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -15253,7 +15135,6 @@ exports[`Storyshots Death/CartPage loading 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -15763,7 +15644,6 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -16408,7 +16288,6 @@ exports[`Storyshots Death/CertificatePage certificate in cart 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -16948,7 +16827,6 @@ exports[`Storyshots Death/CertificatePage missing certificate 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -17309,7 +17187,6 @@ exports[`Storyshots Death/CertificatePage normal certificate 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -17839,7 +17716,6 @@ exports[`Storyshots Death/CertificatePage normal certificate — not from search
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -18369,7 +18245,6 @@ exports[`Storyshots Death/CertificatePage pending certificate 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -19976,7 +19851,6 @@ exports[`Storyshots Death/SearchPage no results 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -20372,7 +20246,6 @@ exports[`Storyshots Death/SearchPage no search 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}
@@ -20757,7 +20630,6 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
   </a>
   <input
     aria-label="Open Boston.gov menu"
-    checked={undefined}
     className="brg-tr"
     id="brg-tr"
     onKeyDown={[Function]}

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -125,7 +125,7 @@
     "eslint-plugin-graphql": "^2.1.1",
     "faker": "^4.1.0",
     "fetch-mock": "^5.12.2",
-    "jest": "^22.1.4",
+    "jest": "^23.6.0",
     "json-loader": "^0.5.4",
     "lint-staged": "^4.0.0",
     "mockdate": "^2.0.2",

--- a/services-js/registry-certs/server/email/ReceiptEmail.ts
+++ b/services-js/registry-certs/server/email/ReceiptEmail.ts
@@ -1,12 +1,21 @@
+import path from 'path';
 import fs from 'fs';
 
 const RECEIPT_MJML_TEMPLATE = fs.readFileSync(
-  'server/email/receipt.mjml.hbs',
+  path.resolve(
+    // This needs to work for both dev and compiled locations of this file.
+    __dirname.replace('/registry-certs/build/', '/registry-certs/'),
+    '../../server/email/receipt.mjml.hbs'
+  ),
   'utf-8'
 );
 
 const RECEIPT_TEXT_TEMPLATE = fs.readFileSync(
-  'server/email/receipt.txt.hbs',
+  path.resolve(
+    // This needs to work for both dev and compiled locations of this file.
+    __dirname.replace('/registry-certs/build/', '/registry-certs/'),
+    '../../server/email/receipt.txt.hbs'
+  ),
   'utf-8'
 );
 

--- a/services-js/registry-certs/server/graphql/index.ts
+++ b/services-js/registry-certs/server/graphql/index.ts
@@ -14,7 +14,12 @@ import Emails from '../services/Emails';
 // This file is built by the "generate-graphql-schema" script from
 // the above interfaces.
 const schemaGraphql = fs.readFileSync(
-  path.resolve('graphql', 'schema.graphql'),
+  path.resolve(
+    // Normalize between dev and compiled file locations
+    __dirname.replace('/registry-certs/build/', '/registry-certs/'),
+    '../../graphql',
+    'schema.graphql'
+  ),
   'utf-8'
 );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./modules-js/config-typescript/tsconfig.default.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,13 +3832,6 @@ babel-jest@23.6.0, babel-jest@^23.6.0:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.2.0"
 
-babel-jest@^22.4.4:
-  version "22.4.4"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.4.tgz#977259240420e227444ebe49e226a61e49ea659d"
-  dependencies:
-    babel-plugin-istanbul "^4.1.5"
-    babel-preset-jest "^22.4.4"
-
 babel-loader@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.2.tgz#f6cbe122710f1aa2af4d881c6d5b54358ca24126"
@@ -3900,7 +3893,7 @@ babel-plugin-inline-import@^2.0.6:
   dependencies:
     require-resolve "0.0.2"
 
-babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.4, babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.4, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
@@ -4475,7 +4468,7 @@ babel-preset-jest@^20.0.3:
   dependencies:
     babel-plugin-jest-hoist "^20.0.3"
 
-babel-preset-jest@^22.0.1, babel-preset-jest@^22.4.4:
+babel-preset-jest@^22.0.1:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz#ec9fbd8bcd7dfd24b8b5320e0e688013235b7c39"
   dependencies:
@@ -5995,10 +5988,6 @@ compare-func@^1.3.1:
   dependencies:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
-
-compare-versions@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
 
 component-cookie@^1.1.3:
   version "1.1.3"
@@ -11274,36 +11263,13 @@ istanbul-api@^1.1.1, istanbul-api@^1.3.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-api@^1.1.14:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
-  dependencies:
-    async "^2.1.4"
-    compare-versions "^3.1.0"
-    fileset "^2.0.2"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-hook "^1.2.0"
-    istanbul-lib-instrument "^1.10.1"
-    istanbul-lib-report "^1.1.4"
-    istanbul-lib-source-maps "^1.2.4"
-    istanbul-reports "^1.3.0"
-    js-yaml "^3.7.0"
-    mkdirp "^0.5.1"
-    once "^1.4.0"
-
 istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
 
-istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
-
-istanbul-lib-hook@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz#ae556fd5a41a6e8efa0b1002b1e416dfeaf9816c"
-  dependencies:
-    append-transform "^0.4.0"
 
 istanbul-lib-hook@^1.2.2:
   version "1.2.2"
@@ -11311,7 +11277,7 @@ istanbul-lib-hook@^1.2.2:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.8.0:
+istanbul-lib-instrument@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -11335,15 +11301,6 @@ istanbul-lib-instrument@^1.10.2, istanbul-lib-instrument@^1.4.2:
     istanbul-lib-coverage "^1.2.1"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
-  dependencies:
-    istanbul-lib-coverage "^1.2.0"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
-
 istanbul-lib-report@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz#f2a657fc6282f96170aaf281eb30a458f7f4170c"
@@ -11363,16 +11320,6 @@ istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.6:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-lib-source-maps@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
-  dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.2"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
 istanbul-lib-source-maps@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
@@ -11382,12 +11329,6 @@ istanbul-lib-source-maps@^1.2.4:
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
-
-istanbul-reports@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
-  dependencies:
-    handlebars "^4.0.3"
 
 istanbul-reports@^1.5.1:
   version "1.5.1"
@@ -11413,12 +11354,6 @@ java-properties@^0.2.10:
 jest-changed-files@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.0.3.tgz#9394d5cc65c438406149bef1bf4d52b68e03e3f8"
-
-jest-changed-files@^22.2.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
-  dependencies:
-    throat "^4.0.0"
 
 jest-changed-files@^23.4.2:
   version "23.4.2"
@@ -11460,45 +11395,6 @@ jest-cli@^20.0.4:
     which "^1.2.12"
     worker-farm "^1.3.1"
     yargs "^7.0.2"
-
-jest-cli@^22.4.4:
-  version "22.4.4"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.4.tgz#68cd2a2aae983adb1e6638248ca21082fd6d9e90"
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    exit "^0.1.2"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    import-local "^1.0.0"
-    is-ci "^1.0.10"
-    istanbul-api "^1.1.14"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-instrument "^1.8.0"
-    istanbul-lib-source-maps "^1.2.1"
-    jest-changed-files "^22.2.0"
-    jest-config "^22.4.4"
-    jest-environment-jsdom "^22.4.1"
-    jest-get-type "^22.1.0"
-    jest-haste-map "^22.4.2"
-    jest-message-util "^22.4.0"
-    jest-regex-util "^22.1.0"
-    jest-resolve-dependencies "^22.1.0"
-    jest-runner "^22.4.4"
-    jest-runtime "^22.4.4"
-    jest-snapshot "^22.4.0"
-    jest-util "^22.4.1"
-    jest-validate "^22.4.4"
-    jest-worker "^22.2.2"
-    micromatch "^2.3.11"
-    node-notifier "^5.2.1"
-    realpath-native "^1.0.0"
-    rimraf "^2.5.4"
-    slash "^1.0.0"
-    string-length "^2.0.0"
-    strip-ansi "^4.0.0"
-    which "^1.2.12"
-    yargs "^10.0.3"
 
 jest-cli@^23.6.0:
   version "23.6.0"
@@ -11642,12 +11538,6 @@ jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-jest-docblock@^22.4.0, jest-docblock@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
-  dependencies:
-    detect-newline "^2.1.0"
-
 jest-docblock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
@@ -11660,6 +11550,14 @@ jest-each@^23.6.0:
   dependencies:
     chalk "^2.0.1"
     pretty-format "^23.6.0"
+
+jest-environment-jsdom@23.4.0, jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
 
 jest-environment-jsdom@^20.0.3:
   version "20.0.3"
@@ -11677,13 +11575,12 @@ jest-environment-jsdom@^22.4.1, jest-environment-jsdom@^22.4.3:
     jest-util "^22.4.3"
     jsdom "^11.5.1"
 
-jest-environment-jsdom@^23.4.0:
+jest-environment-node@23.4.0, jest-environment-node@^23.4.0:
   version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
   dependencies:
     jest-mock "^23.2.0"
     jest-util "^23.4.0"
-    jsdom "^11.5.1"
 
 jest-environment-node@^20.0.3:
   version "20.0.3"
@@ -11698,13 +11595,6 @@ jest-environment-node@^22.4.1, jest-environment-node@^22.4.3:
   dependencies:
     jest-mock "^22.4.3"
     jest-util "^22.4.3"
-
-jest-environment-node@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
-  dependencies:
-    jest-mock "^23.2.0"
-    jest-util "^23.4.0"
 
 jest-get-type@^21.2.0:
   version "21.2.0"
@@ -11724,18 +11614,6 @@ jest-haste-map@^20.0.4:
     micromatch "^2.3.11"
     sane "~1.6.0"
     worker-farm "^1.3.1"
-
-jest-haste-map@^22.4.2:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-docblock "^22.4.3"
-    jest-serializer "^22.4.3"
-    jest-worker "^22.4.3"
-    micromatch "^2.3.11"
-    sane "^2.0.0"
 
 jest-haste-map@^23.6.0:
   version "23.6.0"
@@ -11812,12 +11690,6 @@ jest-jasmine2@^23.6.0:
     jest-snapshot "^23.6.0"
     jest-util "^23.4.0"
     pretty-format "^23.6.0"
-
-jest-leak-detector@^22.4.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
-  dependencies:
-    pretty-format "^22.4.3"
 
 jest-leak-detector@^23.6.0:
   version "23.6.0"
@@ -11919,12 +11791,6 @@ jest-resolve-dependencies@^20.0.3:
   dependencies:
     jest-regex-util "^20.0.3"
 
-jest-resolve-dependencies@^22.1.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
-  dependencies:
-    jest-regex-util "^22.4.3"
-
 jest-resolve-dependencies@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz#b4526af24c8540d9a3fab102c15081cf509b723d"
@@ -11954,22 +11820,6 @@ jest-resolve@^23.6.0:
     browser-resolve "^1.11.3"
     chalk "^2.0.1"
     realpath-native "^1.0.0"
-
-jest-runner@^22.4.4:
-  version "22.4.4"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.4.tgz#dfca7b7553e0fa617e7b1291aeb7ce83e540a907"
-  dependencies:
-    exit "^0.1.2"
-    jest-config "^22.4.4"
-    jest-docblock "^22.4.0"
-    jest-haste-map "^22.4.2"
-    jest-jasmine2 "^22.4.4"
-    jest-leak-detector "^22.4.0"
-    jest-message-util "^22.4.0"
-    jest-runtime "^22.4.4"
-    jest-util "^22.4.1"
-    jest-worker "^22.2.2"
-    throat "^4.0.0"
 
 jest-runner@^23.6.0:
   version "23.6.0"
@@ -12009,31 +11859,6 @@ jest-runtime@^20.0.4:
     strip-bom "3.0.0"
     yargs "^7.0.2"
 
-jest-runtime@^22.4.4:
-  version "22.4.4"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.4.tgz#9ba7792fc75582a5be0f79af6f8fe8adea314048"
-  dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^22.4.4"
-    babel-plugin-istanbul "^4.1.5"
-    chalk "^2.0.1"
-    convert-source-map "^1.4.0"
-    exit "^0.1.2"
-    graceful-fs "^4.1.11"
-    jest-config "^22.4.4"
-    jest-haste-map "^22.4.2"
-    jest-regex-util "^22.1.0"
-    jest-resolve "^22.4.2"
-    jest-util "^22.4.1"
-    jest-validate "^22.4.4"
-    json-stable-stringify "^1.0.1"
-    micromatch "^2.3.11"
-    realpath-native "^1.0.0"
-    slash "^1.0.0"
-    strip-bom "3.0.0"
-    write-file-atomic "^2.1.0"
-    yargs "^10.0.3"
-
 jest-runtime@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.6.0.tgz#059e58c8ab445917cd0e0d84ac2ba68de8f23082"
@@ -12059,10 +11884,6 @@ jest-runtime@^23.6.0:
     strip-bom "3.0.0"
     write-file-atomic "^2.1.0"
     yargs "^11.0.0"
-
-jest-serializer@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
 
 jest-serializer@^23.0.1:
   version "23.0.1"
@@ -12203,12 +12024,6 @@ jest-watcher@^23.4.0:
     chalk "^2.0.1"
     string-length "^2.0.0"
 
-jest-worker@^22.2.2, jest-worker@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
-  dependencies:
-    merge-stream "^1.0.1"
-
 jest-worker@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
@@ -12227,13 +12042,6 @@ jest@23.6.0, jest@^23.6.0:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
-
-jest@^22.1.4:
-  version "22.4.4"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.4.tgz#ffb36c9654b339a13e10b3d4b338eb3e9d49f6eb"
-  dependencies:
-    import-local "^1.0.0"
-    jest-cli "^22.4.4"
 
 jmespath@0.15.0:
   version "0.15.0"


### PR DESCRIPTION
With projects, we can run Jest from the root of the repo and have it
test all the separate sub-projects. This is useful for overall code
coverage and IDE integration.

 - Adds a babel.config.js that references that .babelrc files exist
 - Adds a no-op root tsconfig.json
 - Converts all readFile calls to be relative to the file, rather than
   the assumed project root
 - Upgrades registry-certs to Jest 23.6
 - Adds explicit dependencies on jest-environment-* packages to avoid
   the "environment.teardown is not a function" errors (probably related
   to create-react-app in commissions-search)