### PR TITLE
Sends birth cert requests to the registry DB

### DIFF
--- a/services-js/payment-webhooks/package.json
+++ b/services-js/payment-webhooks/package.json
@@ -44,6 +44,7 @@
     "@types/boom": "^7.2.0",
     "@types/hapi": "^17.0.19",
     "@types/node": "^8.0.0",
+    "@types/stripe": "^5.x.x",
     "babel-core": "^7.0.0-0",
     "codecov": "^3.0.0",
     "del": "^3.0.0",

--- a/services-js/payment-webhooks/server/server.ts
+++ b/services-js/payment-webhooks/server/server.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import Hapi from 'hapi';
 import cleanup from 'node-cleanup';
-import makeStripe from 'stripe';
+import Stripe from 'stripe';
 
 import {
   loggingPlugin,
@@ -44,7 +44,7 @@ export async function makeServer({ rollbar }: ServerArgs) {
     options: { rollbar },
   });
 
-  const stripe = makeStripe(process.env.STRIPE_SECRET_KEY || 'fake-secret-key');
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || 'fake-secret-key');
 
   const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   if (process.env.NODE_ENV === 'production' && !stripeWebhookSecret) {

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -108,6 +108,7 @@
     "@types/mssql": "^4.0.10",
     "@types/node": "^8.0.0",
     "@types/react": "^16.7.6",
+    "@types/stripe": "^5.x.x",
     "@types/stripe-v3": "^3.0.8",
     "@zeit/next-typescript": "1.1.1",
     "apollo-codegen": "0.20.2",

--- a/services-js/registry-certs/server/graphql/mutation.test.ts
+++ b/services-js/registry-certs/server/graphql/mutation.test.ts
@@ -51,6 +51,12 @@ const DEFAULT_BIRTH_ITEM = {
 };
 
 describe('Mutation resolvers', () => {
+  let registryDb: jest.Mocked<RegistryDb>;
+
+  beforeEach(() => {
+    registryDb = new RegistryDb(null as any) as any;
+  });
+
   describe('submitDeathCertificateOrder', () => {
     it('throws if a validator fails', async () => {
       await expect(
@@ -93,12 +99,6 @@ describe('Mutation resolvers', () => {
         },
       };
 
-      const registryDb = {
-        addOrder: jest.fn(),
-        addItem: jest.fn(),
-        addPayment: jest.fn(),
-      };
-
       const emails = {
         sendReceiptEmail: jest.fn(),
       };
@@ -124,6 +124,7 @@ describe('Mutation resolvers', () => {
         amount: 14326,
         currency: 'usd',
         source: 'tok_test',
+        capture: true,
         description: 'Death certificates (Registry)',
         statement_descriptor: 'CITYBOSTON*REG + FEE',
         metadata: expect.objectContaining({
@@ -140,12 +141,6 @@ describe('Mutation resolvers', () => {
   });
 
   describe('submitBirthCertificateOrder', () => {
-    let registryDb: jest.Mocked<RegistryDb>;
-
-    beforeEach(() => {
-      registryDb = new RegistryDb(null as any) as any;
-    });
-
     it('throws if a validator fails', async () => {
       await expect(
         resolvers.Mutation.submitBirthCertificateOrder(
@@ -173,12 +168,6 @@ describe('Mutation resolvers', () => {
         },
       };
 
-      const registryDb = {
-        addOrder: jest.fn(),
-        addItem: jest.fn(),
-        addPayment: jest.fn(),
-      };
-
       const emails = {
         sendReceiptEmail: jest.fn(),
       };
@@ -190,17 +179,22 @@ describe('Mutation resolvers', () => {
       );
       chargesCreate.mockReturnValue(Promise.resolve({ id: 'ch_12345' }));
 
-      await resolvers.Mutation.submitDeathCertificateOrder(
+      await resolvers.Mutation.submitBirthCertificateOrder(
         {},
         {
           ...DEFAULT_ORDER,
-          items: [
-            {
-              id: '12345',
-              name: '',
-              quantity: 10,
-            },
-          ],
+          item: {
+            firstName: 'Doreen',
+            lastName: 'Green',
+            alternateSpellings: 'Squirrel Girl',
+            birthDate: new Date('1997-07-01T00:00:00Z'),
+            parent1FirstName: 'Maureen',
+            parent1LastName: 'Green',
+            parent2FirstName: 'Dor',
+            parent2LastName: 'Green',
+            quantity: 10,
+            relationship: 'sidekick',
+          },
         },
 
         {
@@ -214,7 +208,8 @@ describe('Mutation resolvers', () => {
         amount: 14326,
         currency: 'usd',
         source: 'tok_test',
-        description: 'Death certificates (Registry)',
+        capture: false,
+        description: 'Birth certificates (Registry)',
         statement_descriptor: 'CITYBOSTON*REG + FEE',
         metadata: expect.objectContaining({
           'webapp.name': 'registry-certs',
@@ -222,6 +217,8 @@ describe('Mutation resolvers', () => {
           'order.orderId': expect.any(String),
           'order.orderKey': '25',
           'order.quantity': '10',
+          'order.source': 'registry',
+          'order.orderType': 'BC',
           'order.unitPrice': '1400',
         }),
       });

--- a/services-js/registry-certs/server/server.ts
+++ b/services-js/registry-certs/server/server.ts
@@ -6,7 +6,7 @@ import Inert from 'inert';
 import fs from 'fs';
 import { graphqlHapi, graphiqlHapi } from 'apollo-server-hapi';
 import cleanup from 'node-cleanup';
-import makeStripe from 'stripe';
+import Stripe from 'stripe';
 import { Client as PostmarkClient } from 'postmark';
 import Rollbar from 'rollbar';
 
@@ -96,7 +96,7 @@ export async function makeServer({ rollbar }: ServerArgs) {
     database: process.env.REGISTRY_DATA_DB_DATABASE!,
   };
 
-  const stripe = makeStripe(process.env.STRIPE_SECRET_KEY || 'fake-secret-key');
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || 'fake-secret-key');
   const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   if (process.env.NODE_ENV === 'production' && !stripeWebhookSecret) {
     throw new Error('NEED A WEBHOOK SECRET IN PROD');

--- a/services-js/registry-certs/server/services/RegistryDbFake.ts
+++ b/services-js/registry-certs/server/services/RegistryDbFake.ts
@@ -29,7 +29,10 @@ export default class RegistryDbFake implements Required<RegistryDb> {
     return 50;
   }
 
-  async addItem(): Promise<void> {}
+  async addDeathCertificateItem(): Promise<void> {}
+  async addBirthCertificateRequest(): Promise<number> {
+    return 105;
+  }
   async addPayment(): Promise<void> {}
 
   async findOrder(): Promise<FindOrderResult | null> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,6 +2251,13 @@
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/@types/stripe-v3/-/stripe-v3-3.0.8.tgz#9c2816acf34dcf0948236fc81ce99442344ebfb4"
 
+"@types/stripe@^5.x.x":
+  version "5.0.27"
+  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-5.0.27.tgz#4b89b9b1e149638325aae8312ae8b23f95e23924"
+  integrity sha512-imxRxOU1QdmgTIrP8ZGl++UmM+VSlcuuyAz9HcCL9Ylb65lnzDA2V9iz8YNDKWbtD4A8FFZ4u9N7aazXO4tWvg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/url-join@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-0.8.2.tgz#1181ecbe1d97b7034e0ea1e35e62e86cc26b422d"


### PR DESCRIPTION
Uses the new sp_AddBirthRequest stored procedure for birth certificate
requests. Changes addItem to be specifically about death certificates.

Modifies payment-webhooks to be tolerant of uncaptured charges.

Also:
 - Switches to use @types/stripe in order to correctly type our Stripe
   calls and data
 - Changes some fields from protected to private so we get accurate
   unusedness checks on them
 - Tweaks Jest fakes in mutation.test.ts to use Jest’s auto-mocking
   rather than hand-made fakes