### PR TITLE
Switches all buttons to use the btn--br variant

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -460,7 +460,7 @@ exports[`Storyshots Birth/CheckoutPage payment 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -1038,7 +1038,7 @@ exports[`Storyshots Birth/CheckoutPage review 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -2304,13 +2304,16 @@ exports[`Storyshots Birth/CheckoutPage shipping 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
                   Next: Payment
                 </button>
               </div>
+              <div
+                className="g--7 m-b500"
+              />
             </div>
           </form>
         </div>
@@ -2715,16 +2718,26 @@ exports[`Storyshots Birth/QuestionsFlow QuestionsPage 1`] = `
               </fieldset>
             </div>
             <div
-              className="css-1mgku4q"
+              className="g g--r m-t700"
             >
-              <button
-                className="btn css-achae6"
-                disabled={true}
-                onClick={[Function]}
-                type="button"
+              <div
+                className="g--4 ta-r m-b500"
               >
-                Next question
-              </button>
+                <button
+                  className="btn btn--br btn--b"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Next question
+                </button>
+              </div>
+              <div
+                className="g--5"
+              />
+              <div
+                className="g--3 m-b500"
+              />
             </div>
           </section>
         </div>
@@ -2900,23 +2913,34 @@ exports[`Storyshots Birth/QuestionsFlow born in Boston? 1`] = `
     
   </div>
   <div
-    className="css-1mgku4q"
+    className="g g--r m-t700"
   >
-    <button
-      className="btn css-g6p480"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="g--4 ta-r m-b500"
     >
-      Back
-    </button>
-    <button
-      className="btn css-achae6"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
+      <button
+        className="btn btn--br btn--b"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Next question
+      </button>
+    </div>
+    <div
+      className="g--5"
+    />
+    <div
+      className="g--3 m-b500"
     >
-      Next question
-    </button>
+      <button
+        className="btn btn--b btn--br btn--w"
+        onClick={[Function]}
+        type="button"
+      >
+        Back
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -3244,23 +3268,34 @@ exports[`Storyshots Birth/QuestionsFlow parental information 1`] = `
     </fieldset>
   </div>
   <div
-    className="css-1mgku4q"
+    className="g g--r m-t700"
   >
-    <button
-      className="btn css-g6p480"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="g--4 ta-r m-b500"
     >
-      Back
-    </button>
-    <button
-      className="btn css-achae6"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
+      <button
+        className="btn btn--br btn--b"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Review request
+      </button>
+    </div>
+    <div
+      className="g--5"
+    />
+    <div
+      className="g--3 m-b500"
     >
-      Review request
-    </button>
+      <button
+        className="btn btn--b btn--br btn--w"
+        onClick={[Function]}
+        type="button"
+      >
+        Back
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -3449,23 +3484,34 @@ exports[`Storyshots Birth/QuestionsFlow personal information 1`] = `
     </fieldset>
   </div>
   <div
-    className="css-1mgku4q"
+    className="g g--r m-t700"
   >
-    <button
-      className="btn css-g6p480"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="g--4 ta-r m-b500"
     >
-      Back
-    </button>
-    <button
-      className="btn css-achae6"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
+      <button
+        className="btn btn--br btn--b"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Next question
+      </button>
+    </div>
+    <div
+      className="g--5"
+    />
+    <div
+      className="g--3 m-b500"
     >
-      Next question
-    </button>
+      <button
+        className="btn btn--b btn--br btn--w"
+        onClick={[Function]}
+        type="button"
+      >
+        Back
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -3640,23 +3686,34 @@ exports[`Storyshots Birth/QuestionsFlow verify identification 1`] = `
     </div>
   </div>
   <div
-    className="css-1mgku4q"
+    className="g g--r m-t700"
   >
-    <button
-      className="btn css-g6p480"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="g--4 ta-r m-b500"
     >
-      Back
-    </button>
-    <button
-      className="btn css-achae6"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
+      <button
+        className="btn btn--br btn--b"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Review request
+      </button>
+    </div>
+    <div
+      className="g--5"
+    />
+    <div
+      className="g--3 m-b500"
     >
-      Review request
-    </button>
+      <button
+        className="btn btn--b btn--br btn--w"
+        onClick={[Function]}
+        type="button"
+      >
+        Back
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -3768,16 +3825,26 @@ exports[`Storyshots Birth/QuestionsFlow who is this for? 1`] = `
     </fieldset>
   </div>
   <div
-    className="css-1mgku4q"
+    className="g g--r m-t700"
   >
-    <button
-      className="btn css-achae6"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
+    <div
+      className="g--4 ta-r m-b500"
     >
-      Next question
-    </button>
+      <button
+        className="btn btn--br btn--b"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Next question
+      </button>
+    </div>
+    <div
+      className="g--5"
+    />
+    <div
+      className="g--3 m-b500"
+    />
   </div>
 </div>
 `;
@@ -4474,27 +4541,33 @@ exports[`Storyshots Birth/ReviewRequestPage default page 1`] = `
               </table>
             </div>
             <div
-              className="css-1mgku4q"
-              style={
-                Object {
-                  "marginTop": "3rem",
-                }
-              }
+              className="m-t700 g g--r"
             >
-              <button
-                className="btn css-g6p480"
-                onClick={[Function]}
-                type="button"
+              <div
+                className="g--4 m-b500"
               >
-                Back
-              </button>
-              <button
-                className="btn css-achae6"
-                onClick={[Function]}
-                type="button"
+                <button
+                  className="btn btn--b btn--br"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Continue
+                </button>
+              </div>
+              <div
+                className="g--5"
+              />
+              <div
+                className="g--3 m-b500"
               >
-                Continue
-              </button>
+                <button
+                  className="btn btn--b btn--w btn--br"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Back
+                </button>
+              </div>
             </div>
           </section>
         </div>
@@ -5391,7 +5464,7 @@ exports[`Storyshots Checkout/ConfirmationContent default 1`] = `
             className="ta-c m-v300"
           >
             <a
-              className="btn"
+              className="btn btn--br"
               href="/death/receipt?id=123-4444-5&contactEmail=ttoe%40squirrelzone.net"
               target="_blank"
             >
@@ -6459,7 +6532,7 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -7455,7 +7528,7 @@ exports[`Storyshots Checkout/PaymentContent ZIP code error 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -8451,7 +8524,7 @@ exports[`Storyshots Checkout/PaymentContent birth certificates 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={false}
                   type="submit"
                 >
@@ -8972,7 +9045,7 @@ exports[`Storyshots Checkout/PaymentContent credit card error 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -9489,7 +9562,7 @@ exports[`Storyshots Checkout/PaymentContent default 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -10485,7 +10558,7 @@ exports[`Storyshots Checkout/PaymentContent existing billing 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={false}
                   type="submit"
                 >
@@ -11063,7 +11136,7 @@ exports[`Storyshots Checkout/ReviewContent birth certificate 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -11828,7 +11901,7 @@ exports[`Storyshots Checkout/ReviewContent cart has pending certs 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -12519,7 +12592,7 @@ exports[`Storyshots Checkout/ReviewContent default 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -13139,7 +13212,7 @@ exports[`Storyshots Checkout/ReviewContent empty cart 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -13801,7 +13874,7 @@ exports[`Storyshots Checkout/ReviewContent invalid order 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -14510,7 +14583,7 @@ exports[`Storyshots Checkout/ReviewContent payment error 1`] = `
                     className="m-v500 ta-c"
                   >
                     <a
-                      className="btn"
+                      className="btn btn--br"
                       href="/death/checkout?page=payment"
                       onClick={[Function]}
                     >
@@ -14525,7 +14598,7 @@ exports[`Storyshots Checkout/ReviewContent payment error 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -15257,7 +15330,7 @@ exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -15970,7 +16043,7 @@ exports[`Storyshots Checkout/ReviewContent submitting 1`] = `
             >
               <button
                 aria-describedby="charge-message"
-                className="btn"
+                className="btn btn--br"
                 disabled={true}
                 style={
                   Object {
@@ -16978,13 +17051,16 @@ exports[`Storyshots Checkout/ShippingContent birth certificate 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={false}
                   type="submit"
                 >
                   Next: Payment
                 </button>
               </div>
+              <div
+                className="g--7 m-b500"
+              />
             </div>
           </form>
         </div>
@@ -17949,7 +18025,7 @@ exports[`Storyshots Checkout/ShippingContent default 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -18935,7 +19011,7 @@ exports[`Storyshots Checkout/ShippingContent email error 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={true}
                   type="submit"
                 >
@@ -19921,7 +19997,7 @@ exports[`Storyshots Checkout/ShippingContent existing address 1`] = `
                 className="g--5 m-b500"
               >
                 <button
-                  className="btn btn--b"
+                  className="btn btn--b btn--br"
                   disabled={false}
                   type="submit"
                 >
@@ -22284,7 +22360,7 @@ exports[`Storyshots Death/CartPage loading 1`] = `
                   className="ta-c ta-r--large g--4 m-v500"
                 >
                   <a
-                    className="btn ta-c"
+                    className="btn btn--br ta-c"
                     href="/death/checkout"
                     onClick={[Function]}
                     style={
@@ -22928,7 +23004,7 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
                   className="ta-c ta-r--large g--4 m-v500"
                 >
                   <a
-                    className="btn ta-c"
+                    className="btn btn--br ta-c"
                     href="/death/checkout"
                     onClick={[Function]}
                     style={
@@ -23456,7 +23532,7 @@ exports[`Storyshots Death/CertificatePage certificate in cart 1`] = `
                     </div>
                   </div>
                   <button
-                    className="btn btn--row"
+                    className="btn btn--br btn--row"
                     disabled={true}
                     type="submit"
                   >
@@ -24345,7 +24421,7 @@ exports[`Storyshots Death/CertificatePage normal certificate 1`] = `
                     </div>
                   </div>
                   <button
-                    className="btn btn--row"
+                    className="btn btn--br btn--row"
                     disabled={false}
                     type="submit"
                   >
@@ -24874,7 +24950,7 @@ exports[`Storyshots Death/CertificatePage normal certificate — not from search
                     </div>
                   </div>
                   <button
-                    className="btn btn--row"
+                    className="btn btn--br btn--row"
                     disabled={false}
                     type="submit"
                   >
@@ -25398,7 +25474,7 @@ exports[`Storyshots Death/CertificatePage pending certificate 1`] = `
                     </div>
                   </div>
                   <button
-                    className="btn btn--row"
+                    className="btn btn--br btn--row"
                     disabled={false}
                     type="submit"
                   >

--- a/services-js/registry-certs/client/birth/ReviewRequestPage.tsx
+++ b/services-js/registry-certs/client/birth/ReviewRequestPage.tsx
@@ -19,12 +19,7 @@ import { PageDependencies } from '../../pages/_app';
 import PageWrapper from './PageWrapper';
 import CostSummary from '../common/CostSummary';
 
-import {
-  BUTTONS_CONTAINER_STYLING,
-  NEXT_BUTTON_STYLE,
-  SECTION_HEADING_STYLING,
-  SECONDARY_BUTTON_STYLE,
-} from './styling';
+import { SECTION_HEADING_STYLING } from './styling';
 
 interface Props extends Pick<PageDependencies, 'birthCertificateRequest'> {}
 
@@ -132,25 +127,28 @@ export default class ReviewRequestPage extends React.Component<Props> {
           serviceFeeType="CREDIT"
         />
 
-        <div
-          className={BUTTONS_CONTAINER_STYLING}
-          style={{ marginTop: '3rem' }}
-        >
-          <button
-            className={`btn ${SECONDARY_BUTTON_STYLE}`}
-            type="button"
-            onClick={this.returnToQuestions}
-          >
-            Back
-          </button>
+        <div className="m-t700 g g--r">
+          <div className="g--4 m-b500">
+            <button
+              className="btn btn--b btn--br"
+              type="button"
+              onClick={this.goToCheckout}
+            >
+              Continue
+            </button>
+          </div>
 
-          <button
-            className={`btn ${NEXT_BUTTON_STYLE}`}
-            type="button"
-            onClick={this.goToCheckout}
-          >
-            Continue
-          </button>
+          <div className="g--5" />
+
+          <div className="g--3 m-b500">
+            <button
+              className="btn btn--b btn--w btn--br"
+              type="button"
+              onClick={this.returnToQuestions}
+            >
+              Back
+            </button>
+          </div>
         </div>
       </PageWrapper>
     );

--- a/services-js/registry-certs/client/birth/questions/QuestionComponent.tsx
+++ b/services-js/registry-certs/client/birth/questions/QuestionComponent.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 
-import {
-  BUTTONS_CONTAINER_STYLING,
-  NEXT_BUTTON_STYLE,
-  QUESTION_CONTAINER_STYLING,
-  SECONDARY_BUTTON_STYLE,
-} from '../styling';
+import { QUESTION_CONTAINER_STYLING } from '../styling';
 
 interface Props {
   handleProceed?: () => void;
@@ -28,40 +23,46 @@ export default function QuestionComponent(props: Props): JSX.Element {
     <>
       <div className={QUESTION_CONTAINER_STYLING}>{props.children}</div>
 
-      <div className={BUTTONS_CONTAINER_STYLING}>
-        {props.handleStepBack && (
-          <button
-            type="button"
-            className={`btn ${SECONDARY_BUTTON_STYLE}`}
-            onClick={props.handleStepBack}
-          >
-            Back
-          </button>
-        )}
+      <div className="g g--r m-t700">
+        <div className="g--4 ta-r m-b500">
+          {props.handleProceed &&
+            !props.startOver && (
+              <button
+                type="button"
+                className="btn btn--br btn--b"
+                onClick={props.handleProceed}
+                disabled={!props.allowProceed}
+              >
+                {props.nextButtonText || 'Next question'}
+              </button>
+            )}
+        </div>
 
-        {/* Button only appears if handler was passed in AND props.startOver is true. */}
-        {props.handleReset &&
-          props.startOver && (
+        <div className="g--5" />
+
+        <div className="g--3 m-b500">
+          {props.handleStepBack && (
             <button
               type="button"
-              className={`btn ${SECONDARY_BUTTON_STYLE}`}
-              onClick={props.handleReset}
+              className="btn btn--b btn--br btn--w"
+              onClick={props.handleStepBack}
             >
-              Back to start
+              Back
             </button>
           )}
 
-        {props.handleProceed &&
-          !props.startOver && (
-            <button
-              type="button"
-              className={`btn ${NEXT_BUTTON_STYLE}`}
-              onClick={props.handleProceed}
-              disabled={!props.allowProceed}
-            >
-              {props.nextButtonText || 'Next question'}
-            </button>
-          )}
+          {/* Button only appears if handler was passed in AND props.startOver is true. */}
+          {props.handleReset &&
+            props.startOver && (
+              <button
+                type="button"
+                className="btn btn--b btn--br btn--w"
+                onClick={props.handleReset}
+              >
+                Back to start
+              </button>
+            )}
+        </div>
       </div>
     </>
   );

--- a/services-js/registry-certs/client/birth/styling.tsx
+++ b/services-js/registry-certs/client/birth/styling.tsx
@@ -243,32 +243,6 @@ export const HOW_RELATED_CONTAINER_STYLING = css({
   },
 });
 
-export const BUTTONS_CONTAINER_STYLING = css({
-  display: 'flex',
-  flexDirection: 'column',
-  margin: '3rem 0',
-
-  [MEDIA_SMALL]: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-
-  button: {
-    display: 'block',
-    width: '100%',
-    marginBottom: '2rem',
-
-    [MEDIA_SMALL]: {
-      width: 'auto',
-      marginBottom: 0,
-
-      '&:only-of-type': {
-        marginLeft: 'auto',
-      },
-    },
-  },
-});
-
 export const NAME_FIELDS_CONTAINER_STYLING = css({
   [MEDIA_MEDIUM]: {
     display: 'flex',
@@ -287,40 +261,5 @@ export const NAME_FIELDS_CONTAINER_STYLING = css({
         marginLeft: '2rem',
       },
     },
-  },
-});
-
-// Ensures “next” button comes before “back” on mobile, while maintaining the
-// visually-apparent tab order on larger screens.
-export const NEXT_BUTTON_STYLE = css({
-  border: BORDER_STYLE,
-  borderColor: WHITE,
-
-  order: -1,
-
-  [MEDIA_SMALL]: {
-    order: 0,
-  },
-
-  '&:not(:disabled)': {
-    borderColor: CHARLES_BLUE,
-  },
-
-  '&:focus': {
-    ...FOCUS_STYLE,
-  },
-});
-
-export const SECONDARY_BUTTON_STYLE = css({
-  backgroundColor: WHITE,
-  color: OPTIMISTIC_BLUE,
-  border: BORDER_STYLE,
-
-  '&:hover': {
-    backgroundColor: GRAY_100,
-  },
-
-  '&:focus': {
-    ...FOCUS_STYLE,
   },
 });

--- a/services-js/registry-certs/client/common/checkout/PaymentContent.tsx
+++ b/services-js/registry-certs/client/common/checkout/PaymentContent.tsx
@@ -620,7 +620,7 @@ export default class PaymentContent extends React.Component<Props, State> {
         <div className="g g--r g--vc">
           <div className="g--5 m-b500">
             <button
-              className="btn btn--b"
+              className="btn btn--b btn--br"
               type="submit"
               disabled={
                 !isValid ||

--- a/services-js/registry-certs/client/common/checkout/ReviewContent.tsx
+++ b/services-js/registry-certs/client/common/checkout/ReviewContent.tsx
@@ -323,7 +323,7 @@ export default class ReviewContent extends React.Component<Props, State> {
 
                 <div className="m-v500 ta-c">
                   <Link href={`${checkoutPath}?page=payment`}>
-                    <a className="btn">Update Payment Information</a>
+                    <a className="btn btn--br">Update Payment Information</a>
                   </Link>
                 </div>
               </StatusModal>
@@ -331,7 +331,7 @@ export default class ReviewContent extends React.Component<Props, State> {
 
           <div className="m-v300">
             <button
-              className="btn"
+              className="btn btn--br"
               style={{ display: 'block', width: '100%' }}
               type="submit"
               disabled={

--- a/services-js/registry-certs/client/common/checkout/ShippingContent.tsx
+++ b/services-js/registry-certs/client/common/checkout/ShippingContent.tsx
@@ -453,18 +453,25 @@ export default class ShippingContent extends React.Component<Props> {
 
         <div className="g g--r g--vc">
           <div className="g--5 m-b500">
-            <button className="btn btn--b" type="submit" disabled={!isValid}>
+            <button
+              className="btn btn--b btn--br"
+              type="submit"
+              disabled={!isValid}
+            >
               Next: Payment
             </button>
           </div>
 
-          {this.props.certificateType === 'death' && (
-            <div className="g--7 m-b500">
+          {/* We always want this cell, even if it’s empty,
+              so that the above cell’s margins aren’t weird
+              from being the first and last child at the same time.*/}
+          <div className="g--7 m-b500">
+            {this.props.certificateType === 'death' && (
               <Link href="/death/cart">
                 <a style={{ fontStyle: 'italic' }}>← Back to cart</a>
               </Link>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </form>
     );

--- a/services-js/registry-certs/client/death/cart/CartPage.tsx
+++ b/services-js/registry-certs/client/death/cart/CartPage.tsx
@@ -101,7 +101,10 @@ class CartPage extends React.Component<Props> {
                       href="/death/checkout"
                       prefetch={process.env.NODE_ENV !== 'test'}
                     >
-                      <a className="btn ta-c" style={{ display: 'block' }}>
+                      <a
+                        className="btn btn--br ta-c"
+                        style={{ display: 'block' }}
+                      >
                         Go to checkout
                       </a>
                     </Link>

--- a/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
+++ b/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
@@ -364,7 +364,7 @@ class CertificatePage extends React.Component<Props, State> {
         </div>
         <button
           type="submit"
-          className="btn btn--row"
+          className="btn btn--br btn--row"
           disabled={quantity === cartQuantity || quantity === null}
         >
           {cartQuantity ? 'Update Cart' : 'Add to Cart'}

--- a/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
@@ -37,7 +37,7 @@ export default class ConfirmationContent extends React.Component<Props> {
 
           <div className="ta-c m-v300">
             <a
-              className="btn"
+              className="btn btn--br"
               href={`/death/receipt?id=${orderId}&contactEmail=${encodeURIComponent(
                 contactEmail
               )}`}


### PR DESCRIPTION
Makes all registry-certs buttons consistently have the new bordered
button style from Fleet.

Also removes button row styling in favor of Fleet grids:
 - Uses g--r to put "Next" first in source order but to the right of
   the screen
 - Uses small columns and btn--b to make buttons take up an ok amount of
   space at large breakpoints but the entire column when the grid
   collapses at low breakpoints
 - Throws in some margin classes