### PR TITLE
Persistent query API for registry-certs backend

### DIFF
--- a/modules-js/hapi-common/src/hapi-common.test.ts
+++ b/modules-js/hapi-common/src/hapi-common.test.ts
@@ -10,33 +10,34 @@ const AUTH_HEADER = 'X-API-KEY';
 const ALLOWED_KEYS = ['key-1', 'key-2'];
 
 describe('headerKeys', () => {
-  let server;
-
-  beforeEach(() => {
-    server = new Server();
+  const makeServer = (keys): Server => {
+    const server = new Server();
 
     server.auth.scheme('headerKeys', headerKeys);
     server.auth.strategy('testHeaderKeys', 'headerKeys', {
       header: AUTH_HEADER,
-      keys: ALLOWED_KEYS,
+      keys,
     } as HeaderKeysOptions);
 
     server.route({
       method: 'GET',
       path: '/test',
-      handler: () => 'ok',
+      handler: ({ auth }) => auth.credentials,
       options: {
         auth: 'testHeaderKeys',
       },
     });
-  });
 
+    return server;
+  };
   it('fails authentication if there’s no header', async () => {
+    const server = makeServer(ALLOWED_KEYS);
     const resp = await server.inject({ url: '/test' });
     expect(resp.statusCode).toEqual(401);
   });
 
   it('fails authentication if the key isn’t in the list', async () => {
+    const server = makeServer(ALLOWED_KEYS);
     const resp = await server.inject({
       url: '/test',
       headers: { [AUTH_HEADER]: 'key-3' },
@@ -45,11 +46,30 @@ describe('headerKeys', () => {
   });
 
   it('succeeds when the key is in the list', async () => {
+    const server = makeServer(ALLOWED_KEYS);
     const resp = await server.inject({
       url: '/test',
       headers: { [AUTH_HEADER]: 'key-1' },
     });
     expect(resp.statusCode).toEqual(200);
+    expect(JSON.parse(resp.payload)).toMatchObject({ key: 'key-1' });
+  });
+
+  it('succeeds when the keys are a map of credentials', async () => {
+    const server = makeServer({
+      'key-1': { source: 'fulfillment' },
+    });
+
+    const resp = await server.inject({
+      url: '/test',
+      headers: { [AUTH_HEADER]: 'key-1' },
+    });
+
+    expect(resp.statusCode).toEqual(200);
+    expect(JSON.parse(resp.payload)).toMatchObject({
+      key: 'key-1',
+      source: 'fulfillment',
+    });
   });
 });
 

--- a/services-js/registry-certs/server/email/ReceiptEmail.ts
+++ b/services-js/registry-certs/server/email/ReceiptEmail.ts
@@ -1,28 +1,21 @@
 import path from 'path';
 import fs from 'fs';
 
+import Handlebars from 'handlebars';
+import mjml2html from 'mjml';
+import { PACKAGE_SRC_ROOT } from '../util';
+
+require('./handlebars-helpers');
+
 const RECEIPT_MJML_TEMPLATE = fs.readFileSync(
-  path.resolve(
-    // This needs to work for both dev and compiled locations of this file.
-    __dirname.replace('/registry-certs/build/', '/registry-certs/'),
-    '../../server/email/receipt.mjml.hbs'
-  ),
+  path.resolve(PACKAGE_SRC_ROOT, './server/email/receipt.mjml.hbs'),
   'utf-8'
 );
 
 const RECEIPT_TEXT_TEMPLATE = fs.readFileSync(
-  path.resolve(
-    // This needs to work for both dev and compiled locations of this file.
-    __dirname.replace('/registry-certs/build/', '/registry-certs/'),
-    '../../server/email/receipt.txt.hbs'
-  ),
+  path.resolve(PACKAGE_SRC_ROOT, './server/email/receipt.txt.hbs'),
   'utf-8'
 );
-
-import Handlebars from 'handlebars';
-import mjml2html from 'mjml';
-
-require('./handlebars-helpers');
 
 export interface TemplateData {
   // already-formatted date

--- a/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
+++ b/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
@@ -69,6 +69,9 @@ GraphQLSchema {
     "BirthCertificateOrderItemInput": "BirthCertificateOrderItemInput",
     "Boolean": "Boolean",
     "CertificateOrderItem": "CertificateOrderItem",
+    "ChargeOrderError": "ChargeOrderError",
+    "ChargeOrderErrorCause": "ChargeOrderErrorCause",
+    "ChargeOrderResult": "ChargeOrderResult",
     "Date": "Date",
     "DeathCertificate": "DeathCertificate",
     "DeathCertificateOrder": "DeathCertificateOrder",
@@ -81,6 +84,7 @@ GraphQLSchema {
     "OrderError": "OrderError",
     "OrderErrorCause": "OrderErrorCause",
     "OrderResult": "OrderResult",
+    "OrderType": "OrderType",
     "Query": "Query",
     "String": "String",
     "SubmittedOrder": "SubmittedOrder",
@@ -97,28 +101,28 @@ GraphQLSchema {
     "directives": Array [],
     "kind": "SchemaDefinition",
     "loc": Object {
-      "end": 3132,
-      "start": 3086,
+      "end": 3503,
+      "start": 3457,
     },
     "operationTypes": Array [
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3115,
-          "start": 3097,
+          "end": 3486,
+          "start": 3468,
         },
         "operation": "mutation",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3115,
-            "start": 3107,
+            "end": 3486,
+            "start": 3478,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3115,
-              "start": 3107,
+              "end": 3486,
+              "start": 3478,
             },
             "value": "Mutation",
           },
@@ -127,21 +131,21 @@ GraphQLSchema {
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3130,
-          "start": 3118,
+          "end": 3501,
+          "start": 3489,
         },
         "operation": "query",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3130,
-            "start": 3125,
+            "end": 3501,
+            "start": 3496,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3130,
-              "start": 3125,
+              "end": 3501,
+              "start": 3496,
             },
             "value": "Query",
           },

--- a/services-js/registry-certs/server/graphql/death-certificates.test.ts
+++ b/services-js/registry-certs/server/graphql/death-certificates.test.ts
@@ -33,6 +33,7 @@ describe('DeathCertificates resolvers', () => {
           stripe: {} as any,
           rollbar: {} as any,
           emails: {} as any,
+          source: 'web',
         }
       );
       expect(search.page).toEqual(1);
@@ -50,6 +51,7 @@ describe('DeathCertificates resolvers', () => {
           stripe: {} as any,
           rollbar: {} as any,
           emails: {} as any,
+          source: 'web',
         }
       );
       expect(search.page).toEqual(1);
@@ -69,6 +71,7 @@ describe('DeathCertificates resolvers', () => {
             stripe: {} as any,
             rollbar: {} as any,
             emails: {} as any,
+            source: 'web',
           }
         )
       ).toBeTruthy();
@@ -84,6 +87,7 @@ describe('DeathCertificates resolvers', () => {
             stripe: {} as any,
             rollbar: {} as any,
             emails: {} as any,
+            source: 'web',
           }
         )
       ).not.toBeTruthy();
@@ -106,6 +110,7 @@ describe('DeathCertificates resolvers', () => {
           stripe: {} as any,
           rollbar: {} as any,
           emails: {} as any,
+          source: 'web',
         }
       );
       expect(certificates[0]).toBeTruthy();

--- a/services-js/registry-certs/server/graphql/index.ts
+++ b/services-js/registry-certs/server/graphql/index.ts
@@ -11,24 +11,23 @@ import { resolvers as deathResolvers } from './death-certificates';
 
 import RegistryDb from '../services/RegistryDb';
 import Emails from '../services/Emails';
+import { PACKAGE_SRC_ROOT } from '../util';
 
 // This file is built by the "generate-graphql-schema" script from
 // the above interfaces.
 const schemaGraphql = fs.readFileSync(
-  path.resolve(
-    // Normalize between dev and compiled file locations
-    __dirname.replace('/registry-certs/build/', '/registry-certs/'),
-    '../../graphql',
-    'schema.graphql'
-  ),
+  path.resolve(PACKAGE_SRC_ROOT, 'graphql', 'schema.graphql'),
   'utf-8'
 );
+
+export type Source = 'web' | 'fulfillment' | 'unknown';
 
 export interface Context {
   rollbar: Rollbar;
   registryDb: RegistryDb;
   stripe: Stripe;
   emails: Emails;
+  source: Source;
 }
 
 /** @graphql schema */

--- a/services-js/registry-certs/server/queries/fulfillment/charge-bc-order-v1.graphql
+++ b/services-js/registry-certs/server/queries/fulfillment/charge-bc-order-v1.graphql
@@ -1,0 +1,12 @@
+mutation ChargeBcOrderV1($orderId: String!, $transactionId: String!) {
+  chargeOrder(
+      type: BC,
+      orderId: $orderId,
+      transactionId: $transactionId) {
+    success
+    error {
+      code
+      message
+    }
+  }
+}

--- a/services-js/registry-certs/server/util.ts
+++ b/services-js/registry-certs/server/util.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+
+/**
+ * Absolute path to the root of our subpackage within the monorepo.
+ */
+export const PACKAGE_SRC_ROOT: string = path.resolve(
+  // We normalize between this file being run from the source directory and
+  // being run from the build directory (which is one level deeper).
+  __dirname.replace('/registry-certs/build/', '/registry-certs/'),
+  '../'
+);


### PR DESCRIPTION
 - Adds a new helper to support persistent queries to hapi-common
 - Updates header keys authentication to allow extra data for the
   credentials object
 - Adds chargeOrder mutation and a charge-bc-order-v1 persistent query
   that the fulfillment backend can use, that requires that it’s run
   by the fulfillment API key