### PR TITLE
Upload file / delete file APIs for birth certs

### DIFF
--- a/modules-js/deploy-tools/package.json
+++ b/modules-js/deploy-tools/package.json
@@ -27,6 +27,7 @@
     "date-fns": "^1.29.0",
     "ignore": "^5.0.4",
     "lerna": "3.4.0",
+    "mime-types": "^2.1.20",
     "minimist": "^1.2.0",
     "node-fetch": "^2.0.0",
     "shelljs": "^0.8.2",

--- a/services-js/registry-certs/client/queries/graphql-types.ts
+++ b/services-js/registry-certs/client/queries/graphql-types.ts
@@ -241,6 +241,7 @@ export interface BirthCertificateOrderItemInput {
   parent2LastName: string;
   quantity: number;
   relationship: string;
+  uploadSessionId: string;
 }
 
 // undefined

--- a/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
@@ -144,6 +144,7 @@ export default async function submitBirthCertificateOrder(
       birthDate,
       firstName,
       lastName,
+      uploadSessionId: '',
       alternateSpellings: altSpelling || '',
       parent1FirstName,
       parent1LastName: parent1LastName || '',

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -66,6 +66,7 @@
     "https-proxy-agent": "^2.0.0",
     "inert": "^5.1.0",
     "isomorphic-fetch": "^2.2.1",
+    "mime-types": "^2.1.20",
     "mjml": "^4.0.0",
     "mobx": "^4.3.0",
     "mobx-react": "^5.2.0",

--- a/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
+++ b/services-js/registry-certs/server/graphql/__snapshots__/index.test.js.snap
@@ -78,6 +78,7 @@ GraphQLSchema {
     "DeathCertificateOrderItemInput": "DeathCertificateOrderItemInput",
     "DeathCertificateSearch": "DeathCertificateSearch",
     "DeathCertificates": "DeathCertificates",
+    "DeleteUploadResult": "DeleteUploadResult",
     "Float": "Float",
     "Int": "Int",
     "Mutation": "Mutation",
@@ -104,28 +105,28 @@ GraphQLSchema {
     "directives": Array [],
     "kind": "SchemaDefinition",
     "loc": Object {
-      "end": 3896,
-      "start": 3850,
+      "end": 4094,
+      "start": 4048,
     },
     "operationTypes": Array [
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3879,
-          "start": 3861,
+          "end": 4077,
+          "start": 4059,
         },
         "operation": "mutation",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3879,
-            "start": 3871,
+            "end": 4077,
+            "start": 4069,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3879,
-              "start": 3871,
+              "end": 4077,
+              "start": 4069,
             },
             "value": "Mutation",
           },
@@ -134,21 +135,21 @@ GraphQLSchema {
       Object {
         "kind": "OperationTypeDefinition",
         "loc": Object {
-          "end": 3894,
-          "start": 3882,
+          "end": 4092,
+          "start": 4080,
         },
         "operation": "query",
         "type": Object {
           "kind": "NamedType",
           "loc": Object {
-            "end": 3894,
-            "start": 3889,
+            "end": 4092,
+            "start": 4087,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3894,
-              "start": 3889,
+              "end": 4092,
+              "start": 4087,
             },
             "value": "Query",
           },

--- a/services-js/registry-certs/server/graphql/mutation.test.ts
+++ b/services-js/registry-certs/server/graphql/mutation.test.ts
@@ -1,5 +1,9 @@
 import { resolvers } from './mutation';
 import RegistryDb from '../services/RegistryDb';
+import {
+  BirthCertificateOrderItemInput,
+  DeathCertificateOrderItemInput,
+} from '../../client/queries/graphql-types';
 
 jest.mock('../services/RegistryDb');
 
@@ -29,7 +33,7 @@ const DEFAULT_ORDER = {
   idempotencyKey: '1234abcd',
 };
 
-const DEFAULT_DEATH_ITEMS = [
+const DEFAULT_DEATH_ITEMS: Array<DeathCertificateOrderItemInput> = [
   {
     id: '12345',
     name: '',
@@ -37,7 +41,7 @@ const DEFAULT_DEATH_ITEMS = [
   },
 ];
 
-const DEFAULT_BIRTH_ITEM = {
+const DEFAULT_BIRTH_ITEM: BirthCertificateOrderItemInput = {
   firstName: 'Danielle',
   lastName: 'Cage',
   relationship: 'parent',
@@ -48,6 +52,7 @@ const DEFAULT_BIRTH_ITEM = {
   parent2FirstName: 'Luke',
   parent2LastName: 'Cage',
   quantity: 10,
+  uploadSessionId: '',
 };
 
 describe('Mutation resolvers', () => {
@@ -194,6 +199,7 @@ describe('Mutation resolvers', () => {
             parent2LastName: 'Green',
             quantity: 10,
             relationship: 'sidekick',
+            uploadSessionId: '',
           },
         },
 

--- a/services-js/registry-certs/server/services/RegistryDbFake.ts
+++ b/services-js/registry-certs/server/services/RegistryDbFake.ts
@@ -41,4 +41,13 @@ export default class RegistryDbFake implements Required<RegistryDb> {
   }
 
   async cancelOrder(): Promise<void> {}
+
+  async uploadBirthAttachments(_session, _label, files): Promise<string[]> {
+    let n = 0;
+    return files.map(() => `file-${++n}`);
+  }
+
+  async deleteBirthAttachment() {
+    return null;
+  }
 }

--- a/services-js/registry-certs/server/util.ts
+++ b/services-js/registry-certs/server/util.ts
@@ -9,3 +9,13 @@ export const PACKAGE_SRC_ROOT: string = path.resolve(
   __dirname.replace('/registry-certs/build/', '/registry-certs/'),
   '../'
 );
+
+/**
+ * The representation of a file upload when Hapi’s multipart handling is set to
+ * "annotated"
+ */
+export interface AnnotatedFilePart {
+  filename: string;
+  headers: Object;
+  payload: Buffer;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13845,51 +13845,42 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.x.x, mime-db@~1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+mime-db@1.x.x, "mime-db@>= 1.34.0 < 2":
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
 
-"mime-db@>= 1.34.0 < 2", mime-db@~1.35.0:
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+mime-db@~1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
 
-mime-db@~1.36.0:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
-
-mime-types@^2.1.12, mime-types@^2.1.14, mime-types@~2.1.17, mime-types@~2.1.18:
-  version "2.1.18"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+mime-types@^2.1.12, mime-types@^2.1.14, mime-types@^2.1.20, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19, mime-types@~2.1.7:
+  version "2.1.21"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
+  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
   dependencies:
-    mime-db "~1.33.0"
-
-mime-types@~2.1.19:
-  version "2.1.20"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
-  dependencies:
-    mime-db "~1.36.0"
-
-mime-types@~2.1.7:
-  version "2.1.19"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
-  dependencies:
-    mime-db "~1.35.0"
+    mime-db "~1.37.0"
 
 mime@1.4.1, mime@~1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+  integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
 mime@^1.4.1, mime@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.0.3, mime@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
+  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
 
 mimer@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/mimer/-/mimer-0.3.2.tgz#0b83aabdf48eaacfd2e093ed4c0ed3d38eda8073"
+  integrity sha512-N6NcgDQAevhP/02DQ/epK6daLy4NKrIHyTlJcO6qBiYn98q+Y4a/knNsAATCe1xLS2F0nEmJp+QYli2s8vKwyQ==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Upload API is multipart since that's the most straightforward for
browsers. Delete is GraphQL mutation.

Also adds mime-types to deploy-tools, since it was being imported
without an explicit dependency.