### PR TITLE
Adds core-js to rollup externals

### DIFF
--- a/modules-js/form-common/rollup.config.js
+++ b/modules-js/form-common/rollup.config.js
@@ -12,5 +12,8 @@ export default {
     format: 'cjs',
   },
   // Regexp form so we can wildcard
-  external: id => /^@babel\/runtime\//.test(id) || EXTERNALS.includes(id),
+  external: id =>
+    /^@babel\/runtime\//.test(id) ||
+    /^core-js\//.test(id) ||
+    EXTERNALS.includes(id),
 };

--- a/modules-js/react-fleet/rollup.config.js
+++ b/modules-js/react-fleet/rollup.config.js
@@ -18,5 +18,8 @@ export default {
     format: 'cjs',
   },
   // Regexp form so we can wildcard
-  external: id => /^@babel\/runtime\//.test(id) || EXTERNALS.includes(id),
+  external: id =>
+    /^@babel\/runtime\//.test(id) ||
+    /^core-js\//.test(id) ||
+    EXTERNALS.includes(id),
 };

--- a/templates/js-browser-module/template/rollup.config.js
+++ b/templates/js-browser-module/template/rollup.config.js
@@ -12,5 +12,8 @@ export default {
     format: 'cjs',
   },
   // Regexp form so we can wildcard
-  external: id => /^@babel\/runtime\//.test(id) || EXTERNALS.includes(id),
+  external: id =>
+    /^@babel\/runtime\//.test(id) ||
+    /^core-js\//.test(id) ||
+    EXTERNALS.includes(id),
 };


### PR DESCRIPTION
Surpresses the warning when Babel inserts the core-js polyfills based on
the modules' usage.