### PR TITLE
Updates password / device flags in registration

### DIFF
--- a/services-js/access-boston/src/server/graphql/mfa.ts
+++ b/services-js/access-boston/src/server/graphql/mfa.ts
@@ -135,6 +135,9 @@ export const verifyMfaDeviceMutation: MutationResolvers['verifyMfaDevice'] = asy
     phoneNumber: loginSession.mfaPhoneNumber || undefined,
   });
 
+  loginSession.needsMfaDevice = false;
+  session.save();
+
   return {
     success: true,
     error: null,


### PR DESCRIPTION
Keeps stages of the registration flow from repeating if the user clicks
around during the process.

See CityOfBoston/iam#405