### PR TITLE
Adds an "order shipped" email for birth certs

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -34973,7 +34973,7 @@ exports[`Storyshots Email/Birth Receipt HTML 1`] = `
       <div
          style=\\"font-family:Montserrat, sans-serif;font-size:20px;font-weight:bold;line-height:1.8;text-align:left;text-transform:uppercase;color:#000000;\\"
       >
-        Thank you for your order
+        Thank you for your order!
       </div>
     
               </td>
@@ -35219,9 +35219,7 @@ exports[`Storyshots Email/Birth Receipt HTML 1`] = `
       >
         <tr>
                 <td style=\\"padding: 0 25px\\">
-                  <i>4 ×
-                    Birth 
-                    certificate for Carol Danvers (10/6/1976)</i></td>
+                  <i>4 × Birth certificate for Carol Danvers (10/6/1976)</i></td>
                 <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$56.00</b></td>
               </tr>
 
@@ -35246,8 +35244,7 @@ exports[`Storyshots Email/Birth Receipt HTML 1`] = `
       <div
          style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
       >
-        We have received your order. You will be charged when your
-                certificates ship.
+        We have received your order. You will be charged when your certificates ship.
       </div>
     
               </td>
@@ -35261,9 +35258,7 @@ exports[`Storyshots Email/Birth Receipt HTML 1`] = `
       <div
          style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
       >
-        We will contact you if we need more information to fulfill the
-                order. If we contact you but do not hear back within 2 business
-                days we will cancel the order without charge.
+        We will contact you if we need more information to fulfill the order. If we contact you but do not hear back within 2 business days we will cancel the order without charge.
       </div>
     
               </td>
@@ -35431,7 +35426,7 @@ exports[`Storyshots Email/Birth Receipt HTML 1`] = `
       >
         Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
             href=\\"tel:618-635-4175\\">617-635-4175</a>, or email <b><i><a
-            href=\\"mailto:registry@boston.gov\\">registry@boston.gov</a></i></b>.
+            href=\\"mailto:\\"></a></i></b>.
       </div>
     
               </td>
@@ -35502,13 +35497,847 @@ Your order:
   Card processing fee*  $1.32
   Total  $141.32
 
-
 We have received your order. You will be charged when your 
 certificates ship.
 
 We will contact you if we need more information to fulfill 
 the order. If we contact you but do not hear back within 2 
 business days we will cancel the order without charge.
+
+* You are charged an extra service fee of not more than 
+$0.25 plus 2.15%. This fee goes directly to a third party to 
+pay for the cost of card processing. Learn more about card 
+service fees at the City of Boston. 
+[https://www.cityofboston.gov/payments/faqs.asp]
+
+Have any questions? Contact the Registry on weekdays from 9 
+a.m. – 4 p.m. at 617-635-4175, or email registry@boston.gov.
+  </pre>
+</div>
+`;
+
+exports[`Storyshots Email/Birth Shipped HTML 1`] = `
+<div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+    <!doctype html>
+    <html xmlns=\\"http://www.w3.org/1999/xhtml\\" xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:o=\\"urn:schemas-microsoft-com:office:office\\">
+      <head>
+        <title>
+          
+        </title>
+        <!--[if !mso]><!-- -->
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+        <!--<![endif]-->
+        <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+        <style type=\\"text/css\\">
+          #outlook a { padding:0; }
+          .ReadMsgBody { width:100%; }
+          .ExternalClass { width:100%; }
+          .ExternalClass * { line-height:100%; }
+          body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+          table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+          img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+          p { display:block;margin:13px 0; }
+        </style>
+        <!--[if !mso]><!-->
+        <style type=\\"text/css\\">
+          @media only screen and (max-width:480px) {
+            @-ms-viewport { width:320px; }
+            @viewport { width:320px; }
+          }
+        </style>
+        <!--<![endif]-->
+        <!--[if mso]>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+        <!--[if lte mso 11]>
+        <style type=\\"text/css\\">
+          .outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+        
+      <!--[if !mso]><!-->
+        <link href=\\"https://fonts.googleapis.com/css?family=Lora:400,700,400i\\" rel=\\"stylesheet\\" type=\\"text/css\\">
+<link href=\\"https://fonts.googleapis.com/css?family=Montserrat:400,700\\" rel=\\"stylesheet\\" type=\\"text/css\\">
+        <style type=\\"text/css\\">
+          @import url(https://fonts.googleapis.com/css?family=Lora:400,700,400i);
+@import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
+        </style>
+      <!--<![endif]-->
+
+    
+        
+    <style type=\\"text/css\\">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-50 { width:50% !important; max-width: 50%; }
+.mj-column-per-12 { width:12% !important; max-width: 12%; }
+.mj-column-per-88 { width:88% !important; max-width: 88%; }
+      }
+    </style>
+    
+  
+        <style type=\\"text/css\\">
+        
+        
+
+    @media only screen and (max-width:480px) {
+      table.full-width-mobile { width: 100% !important; }
+      td.full-width-mobile { width: auto !important; }
+    }
+  
+        </style>
+        
+      </head>
+      <body>
+        
+        
+      <div
+         style=\\"\\"
+      >
+        
+      
+      <!--[if mso | IE]>
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:25px 0 10px;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0;word-break:break-word;\\"
+              >
+                
+      <table
+         align=\\"left\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"border-collapse:collapse;border-spacing:0px;\\"
+      >
+        <tbody>
+          <tr>
+            <td  style=\\"width:200px;\\">
+              
+      <img
+         alt=\\"City of Boston\\" height=\\"auto\\" src=\\"https://patterns.boston.gov/images/public/logo.png\\" style=\\"border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;\\" width=\\"200\\"
+      />
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"background:#f2f2f2;background-color:#f2f2f2;Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"background:#f2f2f2;background-color:#f2f2f2;width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"border:2px solid #091f2f;direction:ltr;font-size:0px;padding:10px 0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Montserrat, sans-serif;font-size:20px;font-weight:bold;line-height:1.8;text-align:left;text-transform:uppercase;color:#000000;\\"
+      >
+        Your birth certificate order is on its way!
+      </div>
+    
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 style=\\"font-size:0px;padding:0 25px;word-break:break-word;\\"
+              >
+                
+      <p
+         style=\\"border-top:solid 4px #000000;font-size:1;margin:0px auto;width:100%;\\"
+      >
+      </p>
+      
+      <!--[if mso | IE]>
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-top:solid 4px #000000;font-size:1;margin:0px auto;width:550px;\\" role=\\"presentation\\" width=\\"550px\\"
+        >
+          <tr>
+            <td style=\\"height:0;line-height:0;\\">
+              &nbsp;
+            </td>
+          </tr>
+        </table>
+      <![endif]-->
+    
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:25px 25px 0;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
+      >
+        We’ve processed your order and charged your card. Your order is being shipped via USPS to the shipping address you provided.
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:10px 0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:300px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-50 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:10px 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.8;text-align:left;color:#000000;\\"
+      >
+        <b>Date:</b> <i>1/8/2018 2:05PM</i><br/>
+              <b>Order #:</b> <i>RG-DC201801-100001</i>
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:300px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-50 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:10px 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.8;text-align:left;color:#000000;\\"
+      >
+        <b>Shipping information:</b><br/>
+              <i>Nancy Whitehead<br/>
+              
+              123 Fake St.<br/>
+              
+              Boston, MA 02141</i>
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:10px 0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:18px;line-height:1.8;text-align:left;color:#000000;\\"
+      >
+        <b>Order:</b>
+      </div>
+    
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0;word-break:break-word;\\"
+              >
+                
+      <table
+         cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" border=\\"0\\" style=\\"cellspacing:0;color:#000000;font-family:Lora, serif;font-size:16px;line-height:1.8;table-layout:auto;width:100%;\\"
+      >
+        <tr>
+                <td style=\\"padding: 0 25px\\">
+                  <i>4 × Birth certificate for Carol Danvers (10/6/1976)</i></td>
+                <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$56.00</b></td>
+              </tr>
+
+              <tr>
+                <td style=\\"padding: 0 25px\\"><i>Card service fee*</i></td>
+                <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$1.32</b></td>
+              </tr>
+              <tr>
+                <td style=\\"background-color: #d2d2d2; padding: 5px 25px; font: 700 20px Montserrat, sans-serif; text-transform: uppercase;\\">Total</td>
+                <td style=\\"background-color: #d2d2d2; padding: 5px 25px; font: 700 20px Montserrat, sans-serif; text-transform: uppercase; white-space: nowrap;\\" align=\\"right\\"><b>$141.32</b></td>
+              </tr>
+      </table>
+    
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:25px 25px 0;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:13px;line-height:1.5;text-align:left;color:#000000;\\"
+      >
+        <i>* You are charged an extra service fee of not more than
+              $0.25 plus 2.15%. This fee goes directly to a third party to
+              pay for the cost of card processing. Learn more about <a
+              href=\\"https://www.cityofboston.gov/payments/faqs.asp\\">card service fees</a> at the City
+              of Boston.</i>
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:20px 0 10px;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;\\"
+      >
+        <!--[if mso | IE]>
+        <table  role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+          <tr>
+        
+              <td
+                 style=\\"vertical-align:middle;width:72px;\\"
+              >
+              <![endif]-->
+                
+      <div
+         class=\\"mj-column-per-12 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:12%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:middle;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0;word-break:break-word;\\"
+              >
+                
+      <table
+         align=\\"left\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"border-collapse:collapse;border-spacing:0px;\\"
+      >
+        <tbody>
+          <tr>
+            <td  style=\\"width:72px;\\">
+              
+      <img
+         alt=\\"\\" height=\\"auto\\" src=\\"https://patterns.boston.gov/images/public/seal.png\\" style=\\"border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;\\" width=\\"72\\"
+      />
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]>
+              </td>
+              
+              <td
+                 style=\\"vertical-align:middle;width:528px;\\"
+              >
+              <![endif]-->
+                
+      <div
+         class=\\"mj-column-per-88 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:88%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:middle;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0 0 0 10px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
+      >
+        Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
+            href=\\"tel:618-635-4175\\">617-635-4175</a>, or email <b><i><a
+            href=\\"mailto:\\"></a></i></b>.
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]>
+              </td>
+              
+          </tr>
+          </table>
+        <![endif]-->
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      <![endif]-->
+    
+    
+      </div>
+    
+      </body>
+    </html>
+  ",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Storyshots Email/Birth Shipped text 1`] = `
+<div>
+  <pre>
+    City of Boston
+
+Your birth certificate order is on its way!
+
+Date: 1/8/2018 2:05PM
+Order ID: RG-DC201801-100001
+
+Your shipping information:
+Nancy Whitehead
+123 Fake St.
+Boston, MA 02141
+
+Your order:
+  4 x Birth certificate for Carol Danvers (10/6/1976) $56.00
+  Card processing fee*  $1.32
+  Total  $141.32
 
 * You are charged an extra service fee of not more than 
 $0.25 plus 2.15%. This fee goes directly to a third party to 
@@ -35767,7 +36596,7 @@ exports[`Storyshots Email/Death Receipt HTML 1`] = `
       <div
          style=\\"font-family:Montserrat, sans-serif;font-size:20px;font-weight:bold;line-height:1.8;text-align:left;text-transform:uppercase;color:#000000;\\"
       >
-        Thank you for your order
+        Thank you for your order!
       </div>
     
               </td>
@@ -36013,16 +36842,12 @@ exports[`Storyshots Email/Death Receipt HTML 1`] = `
       >
         <tr>
                 <td style=\\"padding: 0 25px\\">
-                  <i>4 ×
-                    Death 
-                    certificate for Monkey Joe</i></td>
+                  <i>4 × Death certificate for Monkey Joe</i></td>
                 <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$56.00</b></td>
               </tr>
               <tr>
                 <td style=\\"padding: 0 25px\\">
-                  <i>6 ×
-                    Death 
-                    certificate for Bruce Banner</i></td>
+                  <i>6 × Death certificate for Bruce Banner</i></td>
                 <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$84.00</b></td>
               </tr>
 
@@ -36051,8 +36876,7 @@ exports[`Storyshots Email/Death Receipt HTML 1`] = `
       <div
          style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
       >
-        Your order will be shipped within 1–2 business days via the U.S.
-                Postal Service.
+        Your order will be shipped within 1–2 business days via the U.S. Postal Service.
       </div>
     
               </td>
@@ -36220,7 +37044,7 @@ exports[`Storyshots Email/Death Receipt HTML 1`] = `
       >
         Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
             href=\\"tel:618-635-4175\\">617-635-4175</a>, or email <b><i><a
-            href=\\"mailto:registry@boston.gov\\">registry@boston.gov</a></i></b>.
+            href=\\"mailto:\\"></a></i></b>.
       </div>
     
               </td>
@@ -36293,8 +37117,8 @@ Your order:
   Card processing fee*  $1.32
   Total  $141.32
 
-Your order will be shipped within 1–2 business days via the U.S. Postal Service.
-
+Your order will be shipped within 1–2 business days via the 
+U.S. Postal Service.
 
 * You are charged an extra service fee of not more than 
 $0.25 plus 2.15%. This fee goes directly to a third party to 

--- a/services-js/registry-certs/server/__snapshots__/stripe-events.test.ts.snap
+++ b/services-js/registry-certs/server/__snapshots__/stripe-events.test.ts.snap
@@ -19,7 +19,7 @@ exports[`charge.captured marks the order as paid 1`] = `
 }
 `;
 
-exports[`charge.created sends birth email 1`] = `
+exports[`charge.captured sends a shipped email 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -27,8 +27,6 @@ exports[`charge.created sends birth email 1`] = `
       "nancy@mew.org",
       Object {
         "fixedFee": 25,
-        "isBirth": true,
-        "isDeath": false,
         "items": Array [
           Object {
             "cost": 8400,
@@ -37,7 +35,49 @@ exports[`charge.created sends birth email 1`] = `
             "quantity": 6,
           },
         ],
-        "orderDate": "1/11/2018 1:40PM",
+        "orderDate": "2018-01-11T18:40:27.707Z",
+        "orderId": "RG-BC201902-150464",
+        "percentageFee": 0.021,
+        "serviceFee": 266,
+        "serviceFeeUri": "https://www.cityofboston.gov/payments/faqs.asp",
+        "shippingAddress1": "Avengers Tower",
+        "shippingAddress2": "",
+        "shippingCity": "New York",
+        "shippingCompanyName": "US Avengers",
+        "shippingName": "Squirrel Girl",
+        "shippingState": "NY",
+        "shippingZip": "10001",
+        "subtotal": 8400,
+        "total": 8666,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`charge.created sends birth email 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "Nancy Whitehead",
+      "nancy@mew.org",
+      Object {
+        "fixedFee": 25,
+        "items": Array [
+          Object {
+            "cost": 8400,
+            "date": "1976-10-06T04:00:00.000Z",
+            "name": "Carol Danvers",
+            "quantity": 6,
+          },
+        ],
+        "orderDate": "2018-01-11T18:40:27.707Z",
         "orderId": "RG-BC201901-414211",
         "percentageFee": 0.021,
         "serviceFee": 266,
@@ -71,8 +111,6 @@ exports[`charge.created sends death email 1`] = `
       "nancy@mew.org",
       Object {
         "fixedFee": 25,
-        "isBirth": false,
-        "isDeath": true,
         "items": Array [
           Object {
             "cost": 9800,
@@ -87,7 +125,7 @@ exports[`charge.created sends death email 1`] = `
             "quantity": 1,
           },
         ],
-        "orderDate": "1/11/2018 1:40PM",
+        "orderDate": "2018-01-11T18:40:27.707Z",
         "orderId": "DC-20171215-yg4lk",
         "percentageFee": 0.021,
         "serviceFee": 266,

--- a/services-js/registry-certs/server/email/EmailTemplates.stories.tsx
+++ b/services-js/registry-certs/server/email/EmailTemplates.stories.tsx
@@ -34,3 +34,15 @@ storiesOf('Email/Birth Receipt', module)
     />
   ))
   .add('text', () => <pre>{snapToString('receipt Birth certificate 3')}</pre>);
+
+storiesOf('Email/Birth Shipped', module)
+  .add('HTML', () => (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: snapToString('receipt Birth certificate shipped 2'),
+      }}
+    />
+  ))
+  .add('text', () => (
+    <pre>{snapToString('receipt Birth certificate shipped 3')}</pre>
+  ));

--- a/services-js/registry-certs/server/email/EmailTemplates.test.ts
+++ b/services-js/registry-certs/server/email/EmailTemplates.test.ts
@@ -2,7 +2,8 @@ import { EmailTemplates, makeEmailTemplates } from './EmailTemplates';
 import { SERVICE_FEE_URI } from '../../lib/costs';
 
 const TEST_ORDER = {
-  orderDate: '1/8/2018 2:05PM',
+  // 1/8/2018 2:05PM
+  orderDate: new Date(1515438300000),
   orderId: 'RG-DC201801-100001',
   shippingName: 'Nancy Whitehead',
   shippingCompanyName: '',
@@ -41,11 +42,7 @@ beforeAll(async () => {
 
 describe('receipt', () => {
   test('Death certificates', () => {
-    const { html, subject, text } = templates.receipt({
-      isDeath: true,
-      isBirth: false,
-      ...TEST_ORDER,
-    });
+    const { html, subject, text } = templates.deathReceipt(TEST_ORDER);
     expect(subject).toMatchInlineSnapshot(
       `"City of Boston Death Certificates Order #RG-DC201801-100001"`
     );
@@ -54,9 +51,27 @@ describe('receipt', () => {
   });
 
   test('Birth certificate', () => {
-    const { html, subject, text } = templates.receipt({
-      isDeath: false,
-      isBirth: true,
+    const { html, subject, text } = templates.birthReceipt({
+      ...TEST_ORDER,
+      items: [
+        {
+          cost: TEST_ORDER.items[0].cost,
+          quantity: TEST_ORDER.items[0].quantity,
+          name: 'Carol Danvers',
+          date: new Date('10/06/1976'),
+        },
+      ],
+    });
+
+    expect(subject).toMatchInlineSnapshot(
+      `"City of Boston Birth Certificate Order #RG-DC201801-100001"`
+    );
+    expect(html).toMatchSnapshot();
+    expect(text).toMatchSnapshot();
+  });
+
+  test('Birth certificate shipped', () => {
+    const { html, subject, text } = templates.birthShipped({
       ...TEST_ORDER,
       items: [
         {

--- a/services-js/registry-certs/server/email/EmailTemplates.ts
+++ b/services-js/registry-certs/server/email/EmailTemplates.ts
@@ -4,6 +4,8 @@ import { promisify } from 'util';
 
 import Handlebars from 'handlebars';
 import mjml2html from 'mjml';
+import moment from 'moment-timezone';
+
 import { PACKAGE_SRC_ROOT } from '../util';
 
 require('./handlebars-helpers');
@@ -13,11 +15,39 @@ const readFile = promisify(fs.readFile);
 const TEMPLATES_DIR = path.resolve(PACKAGE_SRC_ROOT, `./server/email`);
 
 export type ReceiptData = {
-  // Booleans in order to support how Handlebars {#if}s work. Only one of these
-  // should be true.
-  isDeath: boolean;
-  isBirth: boolean;
-  // already-formatted date
+  orderDate: Date;
+  orderId: string;
+  shippingName: string;
+  shippingCompanyName: string;
+  shippingAddress1: string;
+  shippingAddress2: string;
+  shippingCity: string;
+  shippingState: string;
+  shippingZip: string;
+  /** Cost in cents */
+  subtotal: number;
+  /** Cost in cents */
+  serviceFee: number;
+  /** Cost in cents */
+  total: number;
+  items: Array<{
+    name: string;
+    quantity: number;
+    cost: number;
+    date: Date | null;
+  }>;
+  /** Cost in cents */
+  fixedFee: number;
+  /** Percentage between 0–1 */
+  percentageFee: number;
+  serviceFeeUri: string;
+};
+
+/**
+ * The data required by the receipt templates
+ */
+type ReceiptTemplateData = {
+  heading: string;
   orderDate: string;
   orderId: string;
   shippingName: string;
@@ -27,19 +57,24 @@ export type ReceiptData = {
   shippingCity: string;
   shippingState: string;
   shippingZip: string;
-  // all these costs are in cents, matching Stripe
-  subtotal: number;
+  /**
+   * Can be null to not display a subtotal
+   */
+  subtotal: number | null;
   serviceFee: number;
   total: number;
   items: Array<{
-    name: string;
+    description: string;
     quantity: number;
     cost: number;
-    date: Date | null;
   }>;
   fixedFee: number;
   percentageFee: number;
   serviceFeeUri: string;
+  registryEmail: string;
+
+  aboveOrderText?: string[];
+  belowOrderText?: string[];
 };
 
 export type RenderedEmail = {
@@ -48,20 +83,105 @@ export type RenderedEmail = {
   subject: string;
 };
 
-export interface EmailTemplates {
-  receipt(d: ReceiptData): RenderedEmail;
+type EmailRenderer<D> = (d: D, subject: string) => RenderedEmail;
+type ReceiptEmailRenderer = EmailRenderer<ReceiptTemplateData>;
+
+const formatOrderDate = (d: Date) =>
+  moment(d)
+    .tz('America/New_York')
+    .format('l h:mmA');
+
+export class EmailTemplates {
+  private readonly receiptEmailRenderer: ReceiptEmailRenderer;
+  constructor(receiptEmailRenderer: ReceiptEmailRenderer) {
+    this.receiptEmailRenderer = receiptEmailRenderer;
+  }
+
+  deathReceipt(receipt: ReceiptData): RenderedEmail {
+    return this.receiptEmailRenderer(
+      {
+        ...receipt,
+
+        heading: 'Thank you for your order!',
+        orderDate: formatOrderDate(receipt.orderDate),
+        registryEmail: 'registry@boston.gov',
+
+        items: receipt.items.map(({ cost, quantity, name }) => ({
+          quantity,
+          cost,
+          description: `Death certificate for ${name}`,
+        })),
+
+        belowOrderText: [
+          'Your order will be shipped within 1–2 business days via the U.S. Postal Service.',
+        ],
+      },
+      `City of Boston Death Certificates Order #${receipt.orderId}`
+    );
+  }
+
+  birthReceipt(receipt: ReceiptData): RenderedEmail {
+    return this.receiptEmailRenderer(
+      {
+        ...receipt,
+
+        heading: 'Thank you for your order!',
+        orderDate: formatOrderDate(receipt.orderDate),
+        registryEmail: 'birth@boston.gov',
+        subtotal: null,
+
+        items: receipt.items.map(({ cost, quantity, name, date }) => ({
+          quantity,
+          cost,
+          description: `Birth certificate for ${name} (${moment(date)
+            .tz('America/New_York')
+            .format('l')})`,
+        })),
+
+        belowOrderText: [
+          'We have received your order. You will be charged when your certificates ship.',
+          'We will contact you if we need more information to fulfill the order. If we contact you but do not hear back within 2 business days we will cancel the order without charge.',
+        ],
+      },
+      `City of Boston Birth Certificate Order #${receipt.orderId}`
+    );
+  }
+
+  birthShipped(receipt: ReceiptData): RenderedEmail {
+    return this.receiptEmailRenderer(
+      {
+        ...receipt,
+
+        heading: 'Your birth certificate order is on its way!',
+        orderDate: formatOrderDate(receipt.orderDate),
+        registryEmail: 'birth@boston.gov',
+        subtotal: null,
+
+        items: receipt.items.map(({ cost, quantity, name, date }) => ({
+          quantity,
+          cost,
+          description: `Birth certificate for ${name} (${moment(date)
+            .tz('America/New_York')
+            .format('l')})`,
+        })),
+
+        aboveOrderText: [
+          'We’ve processed your order and charged your card. Your order is being shipped via USPS to the shipping address you provided.',
+        ],
+      },
+      `City of Boston Birth Certificate Order #${receipt.orderId}`
+    );
+  }
 }
 
 export async function makeEmailTemplates(): Promise<EmailTemplates> {
-  return {
-    receipt: await makeEmailRenderer('receipt', 'order'),
-  };
+  return new EmailTemplates(await makeEmailRenderer('receipt', 'order'));
 }
 
 async function makeEmailRenderer<D>(
   templatePrefix: string,
   dataKey: string
-): Promise<(d: D) => RenderedEmail> {
+): Promise<EmailRenderer<D>> {
   type TemplateFunc = (d: { [k: string]: D }) => string;
 
   const mjmlTemplateP = readFile(
@@ -74,18 +194,12 @@ async function makeEmailRenderer<D>(
     'utf-8'
   );
 
-  const subjectTemplateP = readFile(
-    path.resolve(TEMPLATES_DIR, `${templatePrefix}.subject.hbs`),
-    'utf-8'
-  );
-
   const mjmlFunc: TemplateFunc = Handlebars.compile(await mjmlTemplateP);
   const textFunc: TemplateFunc = Handlebars.compile(await textTemplateP);
-  const subjectFunc: TemplateFunc = Handlebars.compile(await subjectTemplateP);
 
-  return (d: D) => ({
+  return (d: D, subject: string) => ({
     html: mjml2html(mjmlFunc({ [dataKey]: d })).html,
     text: textFunc({ [dataKey]: d }).trim(),
-    subject: subjectFunc({ [dataKey]: d }).trim(),
+    subject,
   });
 }

--- a/services-js/registry-certs/server/email/__snapshots__/EmailTemplates.test.ts.snap
+++ b/services-js/registry-certs/server/email/__snapshots__/EmailTemplates.test.ts.snap
@@ -241,7 +241,7 @@ exports[`receipt Birth certificate 2`] = `
       <div
          style=\\"font-family:Montserrat, sans-serif;font-size:20px;font-weight:bold;line-height:1.8;text-align:left;text-transform:uppercase;color:#000000;\\"
       >
-        Thank you for your order
+        Thank you for your order!
       </div>
     
               </td>
@@ -487,9 +487,7 @@ exports[`receipt Birth certificate 2`] = `
       >
         <tr>
                 <td style=\\"padding: 0 25px\\">
-                  <i>4 ×
-                    Birth 
-                    certificate for Carol Danvers (10/6/1976)</i></td>
+                  <i>4 × Birth certificate for Carol Danvers (10/6/1976)</i></td>
                 <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$56.00</b></td>
               </tr>
 
@@ -514,8 +512,7 @@ exports[`receipt Birth certificate 2`] = `
       <div
          style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
       >
-        We have received your order. You will be charged when your
-                certificates ship.
+        We have received your order. You will be charged when your certificates ship.
       </div>
     
               </td>
@@ -529,9 +526,7 @@ exports[`receipt Birth certificate 2`] = `
       <div
          style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
       >
-        We will contact you if we need more information to fulfill the
-                order. If we contact you but do not hear back within 2 business
-                days we will cancel the order without charge.
+        We will contact you if we need more information to fulfill the order. If we contact you but do not hear back within 2 business days we will cancel the order without charge.
       </div>
     
               </td>
@@ -699,7 +694,7 @@ exports[`receipt Birth certificate 2`] = `
       >
         Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
             href=\\"tel:618-635-4175\\">617-635-4175</a>, or email <b><i><a
-            href=\\"mailto:registry@boston.gov\\">registry@boston.gov</a></i></b>.
+            href=\\"mailto:\\"></a></i></b>.
       </div>
     
               </td>
@@ -764,13 +759,835 @@ Your order:
   Card processing fee*  $1.32
   Total  $141.32
 
-
 We have received your order. You will be charged when your 
 certificates ship.
 
 We will contact you if we need more information to fulfill 
 the order. If we contact you but do not hear back within 2 
 business days we will cancel the order without charge.
+
+* You are charged an extra service fee of not more than 
+$0.25 plus 2.15%. This fee goes directly to a third party to 
+pay for the cost of card processing. Learn more about card 
+service fees at the City of Boston. 
+[https://www.cityofboston.gov/payments/faqs.asp]
+
+Have any questions? Contact the Registry on weekdays from 9 
+a.m. – 4 p.m. at 617-635-4175, or email registry@boston.gov."
+`;
+
+exports[`receipt Birth certificate shipped 2`] = `
+"
+    <!doctype html>
+    <html xmlns=\\"http://www.w3.org/1999/xhtml\\" xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:o=\\"urn:schemas-microsoft-com:office:office\\">
+      <head>
+        <title>
+          
+        </title>
+        <!--[if !mso]><!-- -->
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+        <!--<![endif]-->
+        <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+        <style type=\\"text/css\\">
+          #outlook a { padding:0; }
+          .ReadMsgBody { width:100%; }
+          .ExternalClass { width:100%; }
+          .ExternalClass * { line-height:100%; }
+          body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+          table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+          img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+          p { display:block;margin:13px 0; }
+        </style>
+        <!--[if !mso]><!-->
+        <style type=\\"text/css\\">
+          @media only screen and (max-width:480px) {
+            @-ms-viewport { width:320px; }
+            @viewport { width:320px; }
+          }
+        </style>
+        <!--<![endif]-->
+        <!--[if mso]>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+        <!--[if lte mso 11]>
+        <style type=\\"text/css\\">
+          .outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+        
+      <!--[if !mso]><!-->
+        <link href=\\"https://fonts.googleapis.com/css?family=Lora:400,700,400i\\" rel=\\"stylesheet\\" type=\\"text/css\\">
+<link href=\\"https://fonts.googleapis.com/css?family=Montserrat:400,700\\" rel=\\"stylesheet\\" type=\\"text/css\\">
+        <style type=\\"text/css\\">
+          @import url(https://fonts.googleapis.com/css?family=Lora:400,700,400i);
+@import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
+        </style>
+      <!--<![endif]-->
+
+    
+        
+    <style type=\\"text/css\\">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-50 { width:50% !important; max-width: 50%; }
+.mj-column-per-12 { width:12% !important; max-width: 12%; }
+.mj-column-per-88 { width:88% !important; max-width: 88%; }
+      }
+    </style>
+    
+  
+        <style type=\\"text/css\\">
+        
+        
+
+    @media only screen and (max-width:480px) {
+      table.full-width-mobile { width: 100% !important; }
+      td.full-width-mobile { width: auto !important; }
+    }
+  
+        </style>
+        
+      </head>
+      <body>
+        
+        
+      <div
+         style=\\"\\"
+      >
+        
+      
+      <!--[if mso | IE]>
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:25px 0 10px;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0;word-break:break-word;\\"
+              >
+                
+      <table
+         align=\\"left\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"border-collapse:collapse;border-spacing:0px;\\"
+      >
+        <tbody>
+          <tr>
+            <td  style=\\"width:200px;\\">
+              
+      <img
+         alt=\\"City of Boston\\" height=\\"auto\\" src=\\"https://patterns.boston.gov/images/public/logo.png\\" style=\\"border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;\\" width=\\"200\\"
+      />
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"background:#f2f2f2;background-color:#f2f2f2;Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"background:#f2f2f2;background-color:#f2f2f2;width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"border:2px solid #091f2f;direction:ltr;font-size:0px;padding:10px 0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Montserrat, sans-serif;font-size:20px;font-weight:bold;line-height:1.8;text-align:left;text-transform:uppercase;color:#000000;\\"
+      >
+        Your birth certificate order is on its way!
+      </div>
+    
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 style=\\"font-size:0px;padding:0 25px;word-break:break-word;\\"
+              >
+                
+      <p
+         style=\\"border-top:solid 4px #000000;font-size:1;margin:0px auto;width:100%;\\"
+      >
+      </p>
+      
+      <!--[if mso | IE]>
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-top:solid 4px #000000;font-size:1;margin:0px auto;width:550px;\\" role=\\"presentation\\" width=\\"550px\\"
+        >
+          <tr>
+            <td style=\\"height:0;line-height:0;\\">
+              &nbsp;
+            </td>
+          </tr>
+        </table>
+      <![endif]-->
+    
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:25px 25px 0;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
+      >
+        We’ve processed your order and charged your card. Your order is being shipped via USPS to the shipping address you provided.
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:10px 0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:300px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-50 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:10px 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.8;text-align:left;color:#000000;\\"
+      >
+        <b>Date:</b> <i>1/8/2018 2:05PM</i><br/>
+              <b>Order #:</b> <i>RG-DC201801-100001</i>
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:300px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-50 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:10px 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.8;text-align:left;color:#000000;\\"
+      >
+        <b>Shipping information:</b><br/>
+              <i>Nancy Whitehead<br/>
+              
+              123 Fake St.<br/>
+              
+              Boston, MA 02141</i>
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 class=\\"\\" width=\\"600px\\"
+              >
+          
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:10px 0;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"vertical-align:top;width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:top;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0 25px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:18px;line-height:1.8;text-align:left;color:#000000;\\"
+      >
+        <b>Order:</b>
+      </div>
+    
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0;word-break:break-word;\\"
+              >
+                
+      <table
+         cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" border=\\"0\\" style=\\"cellspacing:0;color:#000000;font-family:Lora, serif;font-size:16px;line-height:1.8;table-layout:auto;width:100%;\\"
+      >
+        <tr>
+                <td style=\\"padding: 0 25px\\">
+                  <i>4 × Birth certificate for Carol Danvers (10/6/1976)</i></td>
+                <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$56.00</b></td>
+              </tr>
+
+              <tr>
+                <td style=\\"padding: 0 25px\\"><i>Card service fee*</i></td>
+                <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$1.32</b></td>
+              </tr>
+              <tr>
+                <td style=\\"background-color: #d2d2d2; padding: 5px 25px; font: 700 20px Montserrat, sans-serif; text-transform: uppercase;\\">Total</td>
+                <td style=\\"background-color: #d2d2d2; padding: 5px 25px; font: 700 20px Montserrat, sans-serif; text-transform: uppercase; white-space: nowrap;\\" align=\\"right\\"><b>$141.32</b></td>
+              </tr>
+      </table>
+    
+              </td>
+            </tr>
+          
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:25px 25px 0;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:13px;line-height:1.5;text-align:left;color:#000000;\\"
+      >
+        <i>* You are charged an extra service fee of not more than
+              $0.25 plus 2.15%. This fee goes directly to a third party to
+              pay for the cost of card processing. Learn more about <a
+              href=\\"https://www.cityofboston.gov/payments/faqs.asp\\">card service fees</a> at the City
+              of Boston.</i>
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+              </td>
+            </tr>
+          
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      
+      <table
+         align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"\\" style=\\"width:600px;\\" width=\\"600\\"
+      >
+        <tr>
+          <td style=\\"line-height:0px;font-size:0px;mso-line-height-rule:exactly;\\">
+      <![endif]-->
+    
+      
+      <div  style=\\"Margin:0px auto;max-width:600px;\\">
+        
+        <table
+           align=\\"center\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"width:100%;\\"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style=\\"direction:ltr;font-size:0px;padding:20px 0 10px;text-align:center;vertical-align:top;\\"
+              >
+                <!--[if mso | IE]>
+                  <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+                
+        <tr>
+      
+            <td
+               class=\\"\\" style=\\"width:600px;\\"
+            >
+          <![endif]-->
+            
+      <div
+         class=\\"mj-column-per-100 outlook-group-fix\\" style=\\"font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;\\"
+      >
+        <!--[if mso | IE]>
+        <table  role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\">
+          <tr>
+        
+              <td
+                 style=\\"vertical-align:middle;width:72px;\\"
+              >
+              <![endif]-->
+                
+      <div
+         class=\\"mj-column-per-12 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:12%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:middle;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0;word-break:break-word;\\"
+              >
+                
+      <table
+         align=\\"left\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"border-collapse:collapse;border-spacing:0px;\\"
+      >
+        <tbody>
+          <tr>
+            <td  style=\\"width:72px;\\">
+              
+      <img
+         alt=\\"\\" height=\\"auto\\" src=\\"https://patterns.boston.gov/images/public/seal.png\\" style=\\"border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;\\" width=\\"72\\"
+      />
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]>
+              </td>
+              
+              <td
+                 style=\\"vertical-align:middle;width:528px;\\"
+              >
+              <![endif]-->
+                
+      <div
+         class=\\"mj-column-per-88 outlook-group-fix\\" style=\\"font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:88%;\\"
+      >
+        
+      <table
+         border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" role=\\"presentation\\" style=\\"vertical-align:middle;\\" width=\\"100%\\"
+      >
+        
+            <tr>
+              <td
+                 align=\\"left\\" style=\\"font-size:0px;padding:0 0 0 10px;word-break:break-word;\\"
+              >
+                
+      <div
+         style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
+      >
+        Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
+            href=\\"tel:618-635-4175\\">617-635-4175</a>, or email <b><i><a
+            href=\\"mailto:\\"></a></i></b>.
+      </div>
+    
+              </td>
+            </tr>
+          
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]>
+              </td>
+              
+          </tr>
+          </table>
+        <![endif]-->
+      </div>
+    
+          <!--[if mso | IE]>
+            </td>
+          
+        </tr>
+      
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      <![endif]-->
+    
+    
+      </div>
+    
+      </body>
+    </html>
+  "
+`;
+
+exports[`receipt Birth certificate shipped 3`] = `
+"City of Boston
+
+Your birth certificate order is on its way!
+
+Date: 1/8/2018 2:05PM
+Order ID: RG-DC201801-100001
+
+Your shipping information:
+Nancy Whitehead
+123 Fake St.
+Boston, MA 02141
+
+Your order:
+  4 x Birth certificate for Carol Danvers (10/6/1976) $56.00
+  Card processing fee*  $1.32
+  Total  $141.32
 
 * You are charged an extra service fee of not more than 
 $0.25 plus 2.15%. This fee goes directly to a third party to 
@@ -1023,7 +1840,7 @@ exports[`receipt Death certificates 2`] = `
       <div
          style=\\"font-family:Montserrat, sans-serif;font-size:20px;font-weight:bold;line-height:1.8;text-align:left;text-transform:uppercase;color:#000000;\\"
       >
-        Thank you for your order
+        Thank you for your order!
       </div>
     
               </td>
@@ -1269,16 +2086,12 @@ exports[`receipt Death certificates 2`] = `
       >
         <tr>
                 <td style=\\"padding: 0 25px\\">
-                  <i>4 ×
-                    Death 
-                    certificate for Monkey Joe</i></td>
+                  <i>4 × Death certificate for Monkey Joe</i></td>
                 <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$56.00</b></td>
               </tr>
               <tr>
                 <td style=\\"padding: 0 25px\\">
-                  <i>6 ×
-                    Death 
-                    certificate for Bruce Banner</i></td>
+                  <i>6 × Death certificate for Bruce Banner</i></td>
                 <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$84.00</b></td>
               </tr>
 
@@ -1307,8 +2120,7 @@ exports[`receipt Death certificates 2`] = `
       <div
          style=\\"font-family:Lora, serif;font-size:16px;line-height:1.5;text-align:left;color:#000000;\\"
       >
-        Your order will be shipped within 1–2 business days via the U.S.
-                Postal Service.
+        Your order will be shipped within 1–2 business days via the U.S. Postal Service.
       </div>
     
               </td>
@@ -1476,7 +2288,7 @@ exports[`receipt Death certificates 2`] = `
       >
         Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
             href=\\"tel:618-635-4175\\">617-635-4175</a>, or email <b><i><a
-            href=\\"mailto:registry@boston.gov\\">registry@boston.gov</a></i></b>.
+            href=\\"mailto:\\"></a></i></b>.
       </div>
     
               </td>
@@ -1543,8 +2355,8 @@ Your order:
   Card processing fee*  $1.32
   Total  $141.32
 
-Your order will be shipped within 1–2 business days via the U.S. Postal Service.
-
+Your order will be shipped within 1–2 business days via the 
+U.S. Postal Service.
 
 * You are charged an extra service fee of not more than 
 $0.25 plus 2.15%. This fee goes directly to a third party to 

--- a/services-js/registry-certs/server/email/receipt.mjml.hbs
+++ b/services-js/registry-certs/server/email/receipt.mjml.hbs
@@ -20,11 +20,21 @@
       <mj-wrapper border="2px solid #091f2f" background-color="#f2f2f2" padding="10px 0">
         <mj-section padding="0">
           <mj-column>
-            <mj-text font-size="20px" font-weight="bold" font-family="Montserrat, sans-serif" text-transform="uppercase" padding="0 25px">Thank you for your order</mj-text>
+            <mj-text font-size="20px" font-weight="bold" font-family="Montserrat, sans-serif" text-transform="uppercase" padding="0 25px">{{heading}}</mj-text>
 
             <mj-divider padding="0 25px"></mj-divider>
           </mj-column>
         </mj-section>
+
+        {{#if aboveOrderText}}
+          <mj-section padding="0">
+            <mj-column>
+              {{#each aboveOrderText}}
+                <mj-text padding="25px 25px 0" line-height="1.5">{{.}}</mj-text>
+              {{/each}}
+            </mj-column>
+          </mj-section>
+        {{/if}}
 
         <mj-section padding="10px 0">
           <mj-column vertical-align="top">
@@ -56,14 +66,12 @@
               {{#each items}}
               <tr>
                 <td style="padding: 0 25px">
-                  <i>{{quantity}} ×
-                    {{#if ../isBirth}}Birth{{/if}}{{#if ../isDeath}}Death{{/if}} 
-                    certificate for {{name}}{{#if date}} ({{formatDate date}}){{/if}}</i></td>
+                  <i>{{quantity}} × {{description}}</i></td>
                 <td style="padding: 0 25px; white-space: nowrap;" align="right"><b>{{formatCents cost}}</b></td>
               </tr>
               {{/each}}
 
-              {{#if isDeath}}
+              {{#if subtotal}}
               <tr>
                 <td style="padding: 0 25px"><i>Subtotal</i></td>
                 <td style="padding: 0 25px; white-space: nowrap;" align="right"><b>{{formatCents subtotal}}</b></td>
@@ -79,25 +87,9 @@
               </tr>
             </mj-table>
 
-            {{#if isDeath}}
-              <mj-text padding="25px 25px 0" line-height="1.5">
-                Your order will be shipped within 1–2 business days via the U.S.
-                Postal Service.
-              </mj-text>
-            {{/if}}
-
-            {{#if isBirth}}
-              <mj-text padding="25px 25px 0" line-height="1.5">
-                We have received your order. You will be charged when your
-                certificates ship.
-              </mj-text>
-
-              <mj-text padding="25px 25px 0" line-height="1.5">
-                We will contact you if we need more information to fulfill the
-                order. If we contact you but do not hear back within 2 business
-                days we will cancel the order without charge.
-              </mj-text>
-            {{/if}}
+            {{#each belowOrderText}}
+              <mj-text padding="25px 25px 0" line-height="1.5">{{.}}</mj-text>
+            {{/each}}
 
             <mj-text padding="25px 25px 0" font-size="13px" line-height="1.5">
               <i>* You are charged an extra service fee of not more than
@@ -122,7 +114,7 @@
           <mj-text padding="0 0 0 10px" line-height="1.5">
             Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at <a
             href="tel:618-635-4175">617-635-4175</a>, or email <b><i><a
-            href="mailto:registry@boston.gov">registry@boston.gov</a></i></b>.
+            href="mailto:{{registryEmail}}">{{registryEmail}}</a></i></b>.
           </mj-text>
         </mj-column>
       </mj-group>

--- a/services-js/registry-certs/server/email/receipt.subject.hbs
+++ b/services-js/registry-certs/server/email/receipt.subject.hbs
@@ -1,3 +1,0 @@
-{{#with order}}
-City of Boston {{#if isDeath}}Death Certificates{{/if}}{{#if isBirth}}Birth Certificate{{/if}} Order #{{orderId}}
-{{/with}}

--- a/services-js/registry-certs/server/email/receipt.txt.hbs
+++ b/services-js/registry-certs/server/email/receipt.txt.hbs
@@ -1,8 +1,8 @@
 City of Boston
 
-Thank you for your order!
-
 {{#with order}}
+{{heading}}
+
 Date: {{orderDate}}
 Order ID: {{orderId}}
 
@@ -15,19 +15,16 @@ Your shipping information:
 
 Your order:
 {{#each items}}
-  {{quantity}} x {{#if ../isBirth}}Birth{{/if}}{{#if ../isDeath}}Death{{/if}} certificate for {{name}}{{#if date}} ({{formatDate date}}){{/if}} {{formatCents cost}}
+  {{quantity}} x {{description}} {{formatCents cost}}
 {{/each}}
-{{#if isDeath}}  Subtotal  {{formatCents subtotal}}
+{{#if subtotal}}  Subtotal  {{formatCents subtotal}}
 {{/if}}  Card processing fee*  {{formatCents serviceFee}}
   Total  {{formatCents total}}
 
-{{#if isDeath}}Your order will be shipped within 1–2 business days via the U.S. Postal Service.{{/if}}
-{{#if isBirth}}{{#wrap}}We have received your order. You will be charged when your certificates ship.{{/wrap}}
+{{#each belowOrderText}}
+{{#wrap}}{{.}}{{/wrap}}
 
-{{#wrap}}We will contact you if we need more information to fulfill 
-the order. If we contact you but do not hear back within 2 
-business days we will cancel the order without charge.{{/wrap}}{{/if}}
-
+{{/each}}
 {{#wrap}}* You are charged an extra service fee of not more than {{formatCents fixedFee}} plus {{formatPercentage percentageFee}}. This fee goes directly to a third party to pay for the cost of card processing. Learn more about card service fees at the City of Boston. [{{serviceFeeUri}}]
 
 Have any questions? Contact the Registry on weekdays from 9 a.m. – 4 p.m. at 617-635-4175, or email registry@boston.gov.{{/wrap}}

--- a/services-js/registry-certs/server/graphql/death-certificates.ts
+++ b/services-js/registry-certs/server/graphql/death-certificates.ts
@@ -157,9 +157,7 @@ function searchResultToDeathCertificate(
 export function orderToReceiptInfo(id: string, order: FindOrderResult) {
   return {
     id,
-    date: moment(order.OrderDate)
-      .tz('America/New_York')
-      .format('l h:mmA'),
+    date: order.OrderDate,
     contactName: order.ContactName,
     contactEmail: order.ContactEmail,
     contactPhone: order.ContactPhone,
@@ -278,8 +276,13 @@ const deathCertificatesResolvers: Resolvers<DeathCertificates, Context> = {
       return null;
     }
 
+    const receiptInfo = orderToReceiptInfo(id, dbOrder);
+
     const order = {
-      ...orderToReceiptInfo(id, dbOrder),
+      ...receiptInfo,
+      date: moment(receiptInfo)
+        .tz('America/New_York')
+        .format('l h:mmA'),
       ...loadDeathCertificateItems(registryDb, dbOrder),
     };
 

--- a/services-js/registry-certs/server/server.ts
+++ b/services-js/registry-certs/server/server.ts
@@ -128,7 +128,6 @@ export async function makeServer({ rollbar }: ServerArgs) {
   );
 
   const emails = new Emails(
-    process.env.POSTMARK_FROM_ADDRESS || 'no-reply@boston.gov',
     postmarkClient,
     rollbar,
     await makeEmailTemplates()

--- a/services-js/registry-certs/server/services/Emails.ts
+++ b/services-js/registry-certs/server/services/Emails.ts
@@ -8,20 +8,20 @@ import {
   RenderedEmail,
 } from '../email/EmailTemplates';
 
+const REGISTRY_EMAIL = 'registry@boston.gov';
+const BIRTH_EMAIL = 'birth@boston.gov';
+
 export default class Emails {
-  private from: string;
   private postmarkClient: PostmarkClient;
   private rollbar: Rollbar;
 
   private templates: EmailTemplates;
 
   constructor(
-    from: string,
     postmarkClient: PostmarkClient,
     rollbar: Rollbar,
     templates: EmailTemplates
   ) {
-    this.from = from;
     this.postmarkClient = postmarkClient;
     this.rollbar = rollbar;
 
@@ -31,6 +31,7 @@ export default class Emails {
   private async sendEmail(
     toName: string,
     toEmail: string,
+    fromEmail: string,
     email: RenderedEmail
   ): Promise<void> {
     try {
@@ -40,7 +41,7 @@ export default class Emails {
         this.postmarkClient.sendEmail(
           {
             To: formatTo(toName, toEmail),
-            From: this.from,
+            From: fromEmail,
             Subject: subject,
             HtmlBody: html,
             TextBody: text,
@@ -54,12 +55,43 @@ export default class Emails {
     }
   }
 
-  async sendReceiptEmail(
+  async sendDeathReceiptEmail(
     toName: string,
     toEmail: string,
     data: ReceiptData
   ): Promise<void> {
-    await this.sendEmail(toName, toEmail, this.templates.receipt(data));
+    await this.sendEmail(
+      toName,
+      toEmail,
+      REGISTRY_EMAIL,
+      this.templates.deathReceipt(data)
+    );
+  }
+
+  async sendBirthReceiptEmail(
+    toName: string,
+    toEmail: string,
+    data: ReceiptData
+  ): Promise<void> {
+    await this.sendEmail(
+      toName,
+      toEmail,
+      BIRTH_EMAIL,
+      this.templates.birthReceipt(data)
+    );
+  }
+
+  async sendBirthShippedEmail(
+    toName: string,
+    toEmail: string,
+    data: ReceiptData
+  ): Promise<void> {
+    await this.sendEmail(
+      toName,
+      toEmail,
+      BIRTH_EMAIL,
+      this.templates.birthShipped(data)
+    );
   }
 }
 

--- a/services-js/registry-certs/server/services/RegistryDb.ts
+++ b/services-js/registry-certs/server/services/RegistryDb.ts
@@ -81,7 +81,7 @@ export interface AddOrderResult {
 export interface FindOrderResult {
   OrderKey: number;
   OrderType: string;
-  OrderDate: string;
+  OrderDate: Date;
   OrderStatus: string;
   ProcessDtTm: string | null;
   ContactName: string;


### PR DESCRIPTION
 - Moves birth / death specific logic out of the handlebars templates
   and instead passes in values set up in EmailTemplates.ts
 - Corrects the database date response type and moves date formatting to
   where it's appearing
 - Makes emails "from" either "registry@boston.gov" or
   "birth@boston.gov"