### PR TITLE
Changes header not to use pilot.boston.gov

### DIFF
--- a/services-ruby/official-header/src/header.html
+++ b/services-ruby/official-header/src/header.html
@@ -23,9 +23,9 @@
   <div id="header">
     <style><!-- inject:css --><!-- endinject --></style>
     <div class="oh oh-flx oh-fac">
-      <a href="https://cityofboston.gov" title="Go to CityOfBoston.gov" class="oh-mbn oh-mls oh-w25 oh-fl oh-hsm"><!-- inject:cob_logo --><!-- endinject --></a>
+      <a href="https://www.boston.gov" class="oh-mbn oh-mls oh-w25 oh-fl oh-hsm"><!-- inject:cob_logo --><!-- endinject --></a>
       <div class="oh-w50 oh-ttu oh-tac">An official City of Boston website</div>
-      <a class="oh-ttu oh-cr oh-fr oh-hsm" href="https://pilot.boston.gov" title="Go to Boston.gov">Boston.gov</a>
+      <a class="oh-ttu oh-cr oh-fr oh-hsm" href="https://www.boston.gov">Boston.gov</a>
       <span class="oh-bcr oh-psm oh-mls"><!-- inject:b_logo --><!-- endinject --></span>
     </div>
   </div>


### PR DESCRIPTION
Also makes main link be to www.boston.gov, removes unnecessary title
attribute.