### PR TITLE
Fixes Access Boston logout

### DIFF
--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -79,7 +79,7 @@ export async function addLoginAuth(
         assertUrl,
       },
       process.env.PING_HOST
-        ? `https://${process.env.PING_HOST}/idp/startSLO.ping`
+        ? `https://${process.env.PING_HOST}/idp/SLO.saml2`
         : ''
     );
   } else {


### PR DESCRIPTION
Changes to use SLO.saml2 for path to the logout response endpoint.
(startSLO.ping is for browsers to visit directly)