### PR TITLE
Birth certs polish items

### DIFF
--- a/modules-js/react-fleet/src/form-elements/UploadPhoto.tsx
+++ b/modules-js/react-fleet/src/form-elements/UploadPhoto.tsx
@@ -23,6 +23,8 @@ interface Props {
 
   uploadProgress?: number | null; // 0 - 100
   errorMessage?: string | null;
+
+  acceptTypes: string;
 }
 
 interface State {
@@ -49,6 +51,7 @@ export default class UploadPhoto extends React.Component<Props, State> {
     buttonTitleUpload: 'Upload photo',
     buttonTitleRemove: 'Remove photo',
     buttonTitleCancel: 'Cancel upload',
+    acceptTypes: 'image/*',
   };
 
   state: State = {
@@ -111,7 +114,7 @@ export default class UploadPhoto extends React.Component<Props, State> {
   }
 
   render() {
-    const { errorMessage, uploadProgress } = this.props;
+    const { errorMessage, uploadProgress, acceptTypes } = this.props;
     const { file, previewUrl } = this.state;
 
     const isUploading = uploadProgress && uploadProgress < 100;
@@ -132,7 +135,7 @@ export default class UploadPhoto extends React.Component<Props, State> {
         <div className="br br-a200">
           <Dropzone
             ref={this.dropzoneRef}
-            accept="image/*"
+            accept={acceptTypes}
             multiple={false}
             onDrop={this.onDrop}
           >

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -238,7 +238,7 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
           className="b-c b-c--hsm b-c--nbp"
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -742,7 +742,7 @@ exports[`Storyshots Birth/CheckoutPage payment 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -1297,7 +1297,7 @@ exports[`Storyshots Birth/CheckoutPage review 1`] = `
           className="b-c b-c--hsm b-c--nbp"
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -1948,7 +1948,7 @@ exports[`Storyshots Birth/CheckoutPage server-side render 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -2226,7 +2226,7 @@ exports[`Storyshots Birth/CheckoutPage shipping 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -3250,7 +3250,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? blank 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -3296,22 +3296,22 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? blank 1`] = `
                   role="radiogroup"
                 >
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
-                      className="heavier"
+                      className="forWhom heavier"
                       focusable="false"
-                      viewBox="-26 -2 100 100"
+                      viewBox="-46 -4 140 100"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M126.367,47.9a13.9,13.9,0,1,1-13.9-13.9,13.9,13.9,0,0,1,13.9,13.9Z"
-                        transform="translate(-88.072 -34)"
+                        d="M60.832,79.224v41.865H12.04V78.748l14.238-12.2H46.684Z"
+                        transform="translate(-11.995 -29.65)"
                       />
                       <path
-                        d="M138.1,79.224v41.865H89.31V78.748l14.238-12.2h20.405Z"
-                        transform="translate(-89.31 -29.65)"
+                        d="M49.1,47.9A13.9,13.9,0,1,1,35.2,34,13.9,13.9,0,0,1,49.1,47.9Z"
+                        transform="translate(-10.757 -34)"
                       />
                     </svg>
                     <input
@@ -3326,11 +3326,11 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? blank 1`] = `
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
-                      className="someoneElse heavier"
+                      className="forWhom heavier"
                       focusable="false"
                       viewBox="-2 -4 140 100"
                       xmlns="http://www.w3.org/2000/svg"
@@ -3684,7 +3684,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -3730,22 +3730,22 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                   role="radiogroup"
                 >
                   <label
-                    className="css-ksygmh css-ykfeq4  inactive"
+                    className="css-ksygmh css-1lvrjdi  inactive"
                   >
                     <svg
                       aria-hidden="true"
-                      className="heavier"
+                      className="forWhom heavier"
                       focusable="false"
-                      viewBox="-26 -2 100 100"
+                      viewBox="-46 -4 140 100"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M126.367,47.9a13.9,13.9,0,1,1-13.9-13.9,13.9,13.9,0,0,1,13.9,13.9Z"
-                        transform="translate(-88.072 -34)"
+                        d="M60.832,79.224v41.865H12.04V78.748l14.238-12.2H46.684Z"
+                        transform="translate(-11.995 -29.65)"
                       />
                       <path
-                        d="M138.1,79.224v41.865H89.31V78.748l14.238-12.2h20.405Z"
-                        transform="translate(-89.31 -29.65)"
+                        d="M49.1,47.9A13.9,13.9,0,1,1,35.2,34,13.9,13.9,0,0,1,49.1,47.9Z"
+                        transform="translate(-10.757 -34)"
                       />
                     </svg>
                     <input
@@ -3760,11 +3760,11 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4 selected "
+                    className="css-ksygmh css-1lvrjdi selected "
                   >
                     <svg
                       aria-hidden="true"
-                      className="someoneElse heavier"
+                      className="forWhom heavier"
                       focusable="false"
                       viewBox="-2 -4 140 100"
                       xmlns="http://www.w3.org/2000/svg"
@@ -3830,7 +3830,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                   role="radiogroup"
                 >
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
@@ -3892,7 +3892,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
@@ -3973,7 +3973,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
@@ -4017,7 +4017,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
@@ -4093,7 +4093,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
@@ -4131,7 +4131,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     </span>
                   </label>
                   <label
-                    className="css-ksygmh css-ykfeq4  "
+                    className="css-ksygmh css-1lvrjdi  "
                   >
                     <svg
                       aria-hidden="true"
@@ -4481,7 +4481,7 @@ exports[`Storyshots Birth/QuestionsFlow/1a. Client instructions default 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -4880,7 +4880,7 @@ exports[`Storyshots Birth/QuestionsFlow/2. Born in Boston? blank 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -5372,7 +5372,7 @@ exports[`Storyshots Birth/QuestionsFlow/2. Born in Boston? hard no 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -6019,7 +6019,7 @@ exports[`Storyshots Birth/QuestionsFlow/2. Born in Boston? maybe no 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -6664,7 +6664,7 @@ exports[`Storyshots Birth/QuestionsFlow/3. Personal information blank 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -6825,97 +6825,101 @@ exports[`Storyshots Birth/QuestionsFlow/3. Personal information blank 1`] = `
                   </div>
                 </div>
               </fieldset>
-              <fieldset
-                className="css-svo1gv"
+              <div
+                className="m-v700"
               >
-                <legend
-                  style={
-                    Object {
-                      "width": "100%",
-                    }
-                  }
+                <fieldset
+                  className="css-svo1gv"
                 >
-                  <h2
-                    className="css-vmrobw"
+                  <legend
                     style={
                       Object {
-                        "marginBottom": "1.5rem",
+                        "width": "100%",
                       }
                     }
                   >
-                    When were 
-                    you
-                     born?
-                  </h2>
-                </legend>
-                <div
-                  className="css-k2dcag"
-                >
-                  <div>
-                    <label
-                      className="txt-l"
-                      htmlFor="dob-month"
+                    <h2
+                      className="css-vmrobw"
+                      style={
+                        Object {
+                          "marginBottom": "1.5rem",
+                        }
+                      }
                     >
-                      Month
-                    </label>
-                    <input
-                      className="txt-f"
-                      id="dob-month"
-                      max="12"
-                      min="1"
-                      name="month"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="MM"
-                      type="number"
-                      value=""
-                    />
+                      When were 
+                      you
+                       born?
+                    </h2>
+                  </legend>
+                  <div
+                    className="css-k2dcag"
+                  >
+                    <div>
+                      <label
+                        className="txt-l"
+                        htmlFor="dob-month"
+                      >
+                        Month
+                      </label>
+                      <input
+                        className="txt-f"
+                        id="dob-month"
+                        max="12"
+                        min="1"
+                        name="month"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="MM"
+                        type="number"
+                        value=""
+                      />
+                    </div>
+                    <div>
+                      <label
+                        className="txt-l"
+                        htmlFor="dob-day"
+                      >
+                        Day
+                      </label>
+                      <input
+                        className="txt-f"
+                        id="dob-day"
+                        max="31"
+                        min="1"
+                        name="day"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="DD"
+                        type="number"
+                        value=""
+                      />
+                    </div>
+                    <div>
+                      <label
+                        className="txt-l"
+                        htmlFor="dob-year"
+                      >
+                        Year
+                      </label>
+                      <input
+                        className="txt-f"
+                        id="dob-year"
+                        max={2019}
+                        min={1870}
+                        name="year"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="YYYY"
+                        type="number"
+                        value=""
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <label
-                      className="txt-l"
-                      htmlFor="dob-day"
-                    >
-                      Day
-                    </label>
-                    <input
-                      className="txt-f"
-                      id="dob-day"
-                      max="31"
-                      min="1"
-                      name="day"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="DD"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                  <div>
-                    <label
-                      className="txt-l"
-                      htmlFor="dob-year"
-                    >
-                      Year
-                    </label>
-                    <input
-                      className="txt-f"
-                      id="dob-year"
-                      max={2019}
-                      min={1870}
-                      name="year"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="YYYY"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
-              </fieldset>
+                </fieldset>
+              </div>
             </div>
             <div
               className="g g--mr css-5a3l2g"
@@ -7246,7 +7250,7 @@ exports[`Storyshots Birth/QuestionsFlow/4. Parental information blank 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -7921,7 +7925,7 @@ exports[`Storyshots Birth/QuestionsFlow/4. Parental information may be restricte
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -8624,7 +8628,7 @@ exports[`Storyshots Birth/QuestionsFlow/4. Parental information may be restricte
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -9325,7 +9329,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification blank 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -9432,7 +9436,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification blank 1`] = `
                       tabIndex={0}
                     >
                       <input
-                        accept="image/*"
+                        accept="image/jpeg,image/png,image/tiff,image/bmp,application/pdf"
                         autoComplete="off"
                         multiple={false}
                         onChange={[Function]}
@@ -9556,7 +9560,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification blank 1`] = `
                       tabIndex={0}
                     >
                       <input
-                        accept="image/*"
+                        accept="image/jpeg,image/png,image/tiff,image/bmp,application/pdf"
                         autoComplete="off"
                         multiple={false}
                         onChange={[Function]}
@@ -9698,7 +9702,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification blank 1`] = `
                   className="m-b300"
                 >
                   <input
-                    accept="application/pdf"
+                    accept="image/jpeg,image/png,image/tiff,image/bmp,application/pdf"
                     className="css-1dv1kvn"
                     id="uploadSupportingDocuments"
                     multiple={true}
@@ -10082,7 +10086,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification existing images
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -10189,7 +10193,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification existing images
                       tabIndex={0}
                     >
                       <input
-                        accept="image/*"
+                        accept="image/jpeg,image/png,image/tiff,image/bmp,application/pdf"
                         autoComplete="off"
                         multiple={false}
                         onChange={[Function]}
@@ -10313,7 +10317,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification existing images
                       tabIndex={0}
                     >
                       <input
-                        accept="image/*"
+                        accept="image/jpeg,image/png,image/tiff,image/bmp,application/pdf"
                         autoComplete="off"
                         multiple={false}
                         onChange={[Function]}
@@ -10455,7 +10459,7 @@ exports[`Storyshots Birth/QuestionsFlow/5. Identity verification existing images
                   className="m-b300"
                 >
                   <input
-                    accept="application/pdf"
+                    accept="image/jpeg,image/png,image/tiff,image/bmp,application/pdf"
                     className="css-1dv1kvn"
                     id="uploadSupportingDocuments"
                     multiple={true}
@@ -11213,7 +11217,7 @@ exports[`Storyshots Birth/ReviewRequestPage default page 1`] = `
           className="b-c b-c--hsm b-c--nbp"
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -15285,7 +15289,7 @@ exports[`Storyshots Checkout/PaymentContent birth certificates 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -18353,7 +18357,7 @@ exports[`Storyshots Checkout/ReviewContent birth certificate 1`] = `
           className="b-c b-c--hsm b-c--nbp"
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>
@@ -23895,7 +23899,7 @@ exports[`Storyshots Checkout/ShippingContent birth certificate 1`] = `
           className="b-c b-c--hsm "
         >
           <h1
-            className="sh-title"
+            className="sh-title css-rgzzj4"
           >
             Request a birth certificate
           </h1>

--- a/services-js/registry-certs/client/birth/PageWrapper.tsx
+++ b/services-js/registry-certs/client/birth/PageWrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { css } from 'emotion';
 
-import { ProgressBar } from '@cityofboston/react-fleet';
+import { ProgressBar, MEDIA_X_LARGE } from '@cityofboston/react-fleet';
 
 import PageLayout from '../PageLayout';
 
@@ -34,7 +35,9 @@ export default class PageWrapper extends React.Component<Props> {
           className={`b-c b-c--hsm ${footer ? 'b-c--nbp' : ''}`}
           aria-live="polite"
         >
-          <h1 className="sh-title">Request a birth certificate</h1>
+          <h1 className={`sh-title ${TITLE_STYLE}`}>
+            Request a birth certificate
+          </h1>
 
           {progress && <ProgressBar {...progress} />}
 
@@ -46,3 +49,12 @@ export default class PageWrapper extends React.Component<Props> {
     );
   }
 }
+
+const TITLE_STYLE = css({
+  [MEDIA_X_LARGE]: {
+    // We put a hard top limit on the size, since with the responsive sizes on
+    // sh-title the phrase "Request a birth certificate" gets too big and wraps
+    // past 1245px wide.
+    fontSize: 38,
+  },
+});

--- a/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.stories.tsx
+++ b/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.stories.tsx
@@ -23,6 +23,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       selectedFiles={[]}
       uploadSessionId="id"
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('documents uploading', () => (
@@ -30,6 +31,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       uploadSessionId="id"
       selectedFiles={[sampleFile('uploading', 23)]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('documents successfully uploaded', () => (
@@ -37,6 +39,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       uploadSessionId="id"
       selectedFiles={[sampleFile('success')]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('error uploading one document', () => (
@@ -44,6 +47,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       uploadSessionId="id"
       selectedFiles={[sampleFile('uploadError')]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('error deleting document', () => (
@@ -51,6 +55,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       uploadSessionId="id"
       selectedFiles={[sampleFile('deletionError')]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('cancel in progress', () => (
@@ -58,6 +63,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       uploadSessionId="id"
       selectedFiles={[sampleFile('canceling')]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('delete in progress', () => (
@@ -65,6 +71,7 @@ storiesOf('Birth/SupportingDocumentsInput', module)
       uploadSessionId="id"
       selectedFiles={[sampleFile('deleting')]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ))
   .add('all three statuses', () => (
@@ -76,5 +83,6 @@ storiesOf('Birth/SupportingDocumentsInput', module)
         sampleFile('uploadError'),
       ]}
       handleInputChange={() => {}}
+      acceptTypes="application/pdf"
     />
   ));

--- a/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.tsx
+++ b/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.tsx
@@ -23,6 +23,7 @@ interface Props {
   uploadSessionId: string;
   selectedFiles: UploadableFile[];
   handleInputChange(files: UploadableFile[]): void;
+  acceptTypes: string;
 }
 
 interface State {
@@ -170,7 +171,7 @@ ${file.name} is ${fileSize.amount.toFixed(2) +
           className={VISUALLYHIDDEN}
           ref={this.inputRef}
           type="file"
-          accept="application/pdf"
+          accept={this.props.acceptTypes}
           multiple
           id="uploadSupportingDocuments"
           onChange={this.handleFileChange}

--- a/services-js/registry-certs/client/birth/components/VerifyIdentificationComponent.tsx
+++ b/services-js/registry-certs/client/birth/components/VerifyIdentificationComponent.tsx
@@ -18,6 +18,10 @@ import UploadableFile from '../../models/UploadableFile';
 
 import { SECTION_HEADING_STYLING, SUPPORTING_TEXT_STYLING } from '../styling';
 
+/** Images that are likely output from scanners or phone cameras */
+const SUPPORTED_MIME_TYPES =
+  'image/jpeg,image/png,image/tiff,image/bmp,application/pdf';
+
 interface Props {
   sectionsToDisplay?: 'all' | 'supportingDocumentsOnly';
   uploadSessionId: string;
@@ -112,6 +116,7 @@ export default class VerifyIdentificationComponent extends React.Component<
               handleRemove={() => this.handleIdImageChange('front', null)}
               backgroundElement={<IdImage name="front" />}
               buttonTitleUpload="Upload front of ID"
+              acceptTypes={SUPPORTED_MIME_TYPES}
             />
           </div>
 
@@ -124,6 +129,7 @@ export default class VerifyIdentificationComponent extends React.Component<
               handleRemove={() => this.handleIdImageChange('back', null)}
               backgroundElement={<IdImage name="back" />}
               buttonTitleUpload="Upload back of ID"
+              acceptTypes={SUPPORTED_MIME_TYPES}
             />
           </div>
         </div>
@@ -184,6 +190,7 @@ export default class VerifyIdentificationComponent extends React.Component<
         uploadSessionId={this.props.uploadSessionId}
         selectedFiles={this.props.supportingDocuments}
         handleInputChange={this.handleSupportingDocumentsChange}
+        acceptTypes={SUPPORTED_MIME_TYPES}
       />
     );
   }

--- a/services-js/registry-certs/client/birth/icons/RelatedIcon.tsx
+++ b/services-js/registry-certs/client/birth/icons/RelatedIcon.tsx
@@ -23,14 +23,18 @@ export default function RelatedIcon(props: Props): JSX.Element {
 
 const icons = {
   myself: (
-    <svg {...commonAttributes} viewBox="-26 -2 100 100" className="heavier">
+    <svg
+      {...commonAttributes}
+      viewBox="-46 -4 140 100"
+      className="forWhom heavier"
+    >
       <path
-        d="M126.367,47.9a13.9,13.9,0,1,1-13.9-13.9,13.9,13.9,0,0,1,13.9,13.9Z"
-        transform="translate(-88.072 -34)"
+        d="M60.832,79.224v41.865H12.04V78.748l14.238-12.2H46.684Z"
+        transform="translate(-11.995 -29.65)"
       />
       <path
-        d="M138.1,79.224v41.865H89.31V78.748l14.238-12.2h20.405Z"
-        transform="translate(-89.31 -29.65)"
+        d="M49.1,47.9A13.9,13.9,0,1,1,35.2,34,13.9,13.9,0,0,1,49.1,47.9Z"
+        transform="translate(-10.757 -34)"
       />
     </svg>
   ),
@@ -38,7 +42,7 @@ const icons = {
     <svg
       {...commonAttributes}
       viewBox="-2 -4 140 100"
-      className="someoneElse heavier"
+      className="forWhom heavier"
     >
       <path
         d="M60.832,79.224v41.865H12.04V78.748l14.238-12.2H46.684Z"

--- a/services-js/registry-certs/client/birth/questions/PersonalInformation.tsx
+++ b/services-js/registry-certs/client/birth/questions/PersonalInformation.tsx
@@ -101,21 +101,23 @@ export default class PersonalInformation extends React.Component<Props> {
           </div>
         </FieldsetComponent>
 
-        <MemorableDateInput
-          legend={
-            <h2
-              className={SECTION_HEADING_STYLING}
-              style={{ marginBottom: '1.5rem' }}
-            >
-              When were {forSelf ? 'you' : 'they'} born?
-            </h2>
-          }
-          initialDate={birthDate || ''}
-          componentId="dob"
-          onlyAllowPast={true}
-          earliestDate={EARLIEST_DATE}
-          handleDate={this.handleDateChange}
-        />
+        <div className="m-v700">
+          <MemorableDateInput
+            legend={
+              <h2
+                className={SECTION_HEADING_STYLING}
+                style={{ marginBottom: '1.5rem' }}
+              >
+                When were {forSelf ? 'you' : 'they'} born?
+              </h2>
+            }
+            initialDate={birthDate || ''}
+            componentId="dob"
+            onlyAllowPast={true}
+            earliestDate={EARLIEST_DATE}
+            handleDate={this.handleDateChange}
+          />
+        </div>
       </QuestionComponent>
     );
   }

--- a/services-js/registry-certs/client/birth/styling.tsx
+++ b/services-js/registry-certs/client/birth/styling.tsx
@@ -68,7 +68,7 @@ export const RADIOITEM_STYLING = css({
     strokeMiterlimit: 10,
     strokeWidth: 3,
 
-    '&.someoneElse': {
+    '&.forWhom': {
       width: 140,
     },
 


### PR DESCRIPTION
 - Limits uploadable file types to images we're likely to get from
   scanners
 - Adds spacing around the date fields on mobile
 - Limits font size of the heading so that we don’t wrap
 - Tweaks the "forSelf" icon so that it’s consistent with "for someone
   else" when they collapse into a column on mobile