### PR TITLE
Edits submission text as per Rich’s request

### DIFF
--- a/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
@@ -125,17 +125,16 @@ export default async function submitBirthCertificateOrder(
     );
   }
 
+  // Birth Certificate Request Questions:
   const notes = `
-Birth Certificate Request Questions:
-
-Relationship: ${forSelf ? 'self' : howRelated || 'unknown'}
-Born in Boston: ${bornInBoston}${
+Relation: ${forSelf ? 'self' : howRelated || 'unknown'}
+| Born in BOS: ${bornInBoston}${
     bornInBoston !== 'yes'
       ? `
-Parents lived in Boston: ${parentsLivedInBoston}`
+| Parents lived in BOS: ${parentsLivedInBoston}`
       : ''
   }
-Parents married: ${parentsMarried}
+| Parents married: ${parentsMarried}
   `.trim();
 
   const queryVariables: SubmitBirthCertificateOrderVariables = {


### PR DESCRIPTION
Rich asked if we could remove “Birth Certificate Request Questions:” from Search Terms to save on space on the page; I also made minor edits to shave off a few more characters overall, and added separators for the key:val pairs as it seems the carriage returns are not preserved on the back office side.