### PR TITLE
Fix for some dropped contact emails

### DIFF
--- a/services-ruby/contactform/Gemfile
+++ b/services-ruby/contactform/Gemfile
@@ -23,7 +23,7 @@ gem 'typhoeus'
 gem 'foreman'
 gem 'rack-cors'
 gem 'postmark-rails'
-gem 'rollbar'
+gem 'rollbar', '~> 2.19.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6.1'

--- a/services-ruby/contactform/Gemfile.lock
+++ b/services-ruby/contactform/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     redis (3.3.2)
-    rollbar (2.16.2)
+    rollbar (2.19.2)
       multi_json
     ruby_dep (1.5.0)
     sass (3.4.24)
@@ -233,7 +233,7 @@ DEPENDENCIES
   puma (~> 3.10)
   rack-cors
   rails (~> 5.1.6.1)
-  rollbar
+  rollbar (~> 2.19.2)
   sass-rails (~> 5.0)
   sidekiq
   spring

--- a/services-ruby/contactform/app/mailers/contact_mailer.rb
+++ b/services-ruby/contactform/app/mailers/contact_mailer.rb
@@ -6,8 +6,7 @@ class ContactMailer < ApplicationMailer
       to: @email.to_address,
       from: get_from(@email),
       reply_to: get_reply_to(@email),
-      subject: @email.subject,
-      message: @email.message
+      subject: @email.subject
     )
   end
 


### PR DESCRIPTION
 - Stops sending the message as an email header, since that’s redundant
   and not all messages can parse as headers
 - Updates rollbar gem to include the fix that catches exceptions in
   ApplicationMailer subclasses