### PR TITLE
Rewrites "unsubscribe" subject lines

### DIFF
--- a/services-ruby/contactform/app/controllers/emails_controller.rb
+++ b/services-ruby/contactform/app/controllers/emails_controller.rb
@@ -5,6 +5,13 @@ class EmailsController < ApplicationController
 
   def create
     @email = Email.new(email_params)
+
+    # We need to prevent Google Groups from thinking that the contact form is trying to
+    # unsubscribe from whatever distribution list is the recipient of the email.
+    if @email.subject =~ /unsubscribe/i || @email.subject =~ /remove me/i
+      @email.subject = "Subscription question"
+    end
+
     @email.ip = request.remote_ip
     @email.sent = DateTime.now.utc
 

--- a/services-ruby/contactform/app/mailers/contact_mailer.rb
+++ b/services-ruby/contactform/app/mailers/contact_mailer.rb
@@ -12,11 +12,17 @@ class ContactMailer < ApplicationMailer
 
   private
 
+  def get_user_email(email)
+    return "#{@email.name} <#{@email.from_address}>"
+  end
+
+  # "From" address needs to be boston.gov because that’s the only way Postmark will
+  # send it.
   def get_from(email)
     return "Boston.gov Contact Form <#{email.token}@#{ENV['EMAIL_HOST']}>"
   end
 
   def get_reply_to(email)
-    return ["#{@email.name} <#{@email.from_address}>", "Boston.gov Contact Form <#{email.token}@#{ENV['EMAIL_HOST']}>"]
+    return [get_user_email(email), get_from(email)]
   end
 end


### PR DESCRIPTION
Prevents Google Groups from eating the message rather than sending it
along to the distribution list.