### PR TITLE
Allows visiting /mfa if account has no MFA

### DIFF
--- a/services-js/access-boston/src/pages/mfa.tsx
+++ b/services-js/access-boston/src/pages/mfa.tsx
@@ -70,7 +70,7 @@ export default class RegisterMfaPage extends React.Component<Props, State> {
     // POST it torches the session.
     const account = await fetchAccount(fetchGraphql);
 
-    if (!account.needsMfaDevice) {
+    if (account.hasMfaDevice) {
       throw new RedirectError('/');
     }
 


### PR DESCRIPTION
Switches logic from "needs" MFA (which is that the requirement is set)
to "not having MFA" so that the "complete it now" banner will work.

See CityOfBoston/iam#498