### PR TITLE
Sets IE Edge mode meta tag

### DIFF
--- a/services-js/access-boston/src/pages/_document.tsx
+++ b/services-js/access-boston/src/pages/_document.tsx
@@ -41,6 +41,8 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
+          <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
           <link
             rel="shortcut icon"
             href="/assets/favicon.ico"


### PR DESCRIPTION
Will hopefully keep internal IE from defaulting to compatibility mode
for our pages.

See CityOfBoston/iam#497