### PR TITLE
Enforces "+1" for MFA phone numbers

### DIFF
--- a/modules-js/form-common/src/form-common.ts
+++ b/modules-js/form-common/src/form-common.ts
@@ -27,5 +27,14 @@ export function makeFormData(values: Object): FormData {
   return data;
 }
 
-// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s02.html
-export const PHONE_REGEXP = /^(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+/**
+ * Matches 10-digit phone numbers with a variety of separators. Allows for a
+ * country code, so long as that code is "1".
+ *
+ * Parens pull out the country code, the area code, the first 3 digits, and the
+ * last 4 digits.
+ *
+ * Source:
+ * https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s02.html
+ */
+export const PHONE_REGEXP = /^(?:\+?(1)[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;

--- a/services-js/access-boston/src/pages/mfa.tsx
+++ b/services-js/access-boston/src/pages/mfa.tsx
@@ -31,6 +31,7 @@ import RedirectForm from '../client/RedirectForm';
 import { registerDeviceSchema } from '../lib/validation';
 import { RedirectError } from '../client/auth-helpers';
 import AccessBostonFooter from '../client/AccessBostonFooter';
+import { PHONE_REGEXP } from '@cityofboston/form-common';
 
 interface InitialProps {
   account: Account;
@@ -95,10 +96,22 @@ export default class RegisterMfaPage extends React.Component<Props, State> {
 
     if (phoneOrEmail === 'email') {
       type = VerificationType.EMAIL;
-    } else if (smsOrVoice === 'sms') {
-      type = VerificationType.SMS;
     } else {
-      type = VerificationType.VOICE;
+      if (smsOrVoice === 'sms') {
+        type = VerificationType.SMS;
+      } else {
+        type = VerificationType.VOICE;
+      }
+
+      // We normalize all phone numbers to include a country code to get around
+      // a problem where Ping thinks that the 857 area code, common to Boston
+      // cell phones, is a country code.
+      const phoneNumberMatches = phoneNumber.match(PHONE_REGEXP);
+      if (phoneNumberMatches) {
+        phoneNumber = `+${phoneNumberMatches[1] || '1'} (${
+          phoneNumberMatches[2]
+        }) ${phoneNumberMatches[3]}-${phoneNumberMatches[4]}})`;
+      }
     }
 
     return { email, phoneNumber, type };


### PR DESCRIPTION
Gets around a bug where Ping can't send to 857 area codes (a common
Boston cell number) without a country code.

See CityOfBoston/iam#504