### PR TITLE
Configure Ruby apps not to send 404s to Rollbar

### DIFF
--- a/services-ruby/codered-proxy/config/initializers/rollbar.rb
+++ b/services-ruby/codered-proxy/config/initializers/rollbar.rb
@@ -30,7 +30,12 @@ Rollbar.configure do |config|
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
   # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
-  #
+
+  config.exception_level_filters.merge!({
+    # We don't care about 404s
+    'ActionController::RoutingError' => 'ignore',
+  })
+
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 

--- a/services-ruby/contactform/config/initializers/rollbar.rb
+++ b/services-ruby/contactform/config/initializers/rollbar.rb
@@ -30,7 +30,12 @@ Rollbar.configure do |config|
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
   # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
-  #
+
+  config.exception_level_filters.merge!({
+    # We don't care about 404s
+    'ActionController::RoutingError' => 'ignore',
+  })
+
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 


### PR DESCRIPTION
They’re junk exceptions that we don’t care about.