### PR TITLE
Removes timezone from birthdate display in email text

### DIFF
--- a/services-js/registry-certs/server/email/EmailTemplates.ts
+++ b/services-js/registry-certs/server/email/EmailTemplates.ts
@@ -146,9 +146,9 @@ export class EmailTemplates {
         items: receipt.items.map(({ cost, quantity, name, date }) => ({
           quantity,
           cost,
-          description: `Birth certificate for ${name} (${moment(date)
-            .tz('America/New_York')
-            .format('l')})`,
+          description: `Birth certificate for ${name} (${moment(date).format(
+            'l'
+          )})`,
         })),
 
         belowOrderText: [
@@ -173,9 +173,9 @@ export class EmailTemplates {
         items: receipt.items.map(({ cost, quantity, name, date }) => ({
           quantity,
           cost,
-          description: `Birth certificate for ${name} (${moment(date)
-            .tz('America/New_York')
-            .format('l')})`,
+          description: `Birth certificate for ${name} (${moment(date).format(
+            'l'
+          )})`,
         })),
 
         aboveOrderText: [


### PR DESCRIPTION
Fixes #368 

Registry confirmed that this bug was only occurring in the email text to the customer; I removed the `.tz()` from the momentjs formatting, since a timezone isn’t relevant in the case of a birth date.