### PR TITLE
Consistently treats dates as midnight UTC

### DIFF
--- a/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
@@ -137,6 +137,14 @@ Relation: ${forSelf ? 'self' : howRelated || 'unknown'}
 | Parents married: ${parentsMarried}
   `.trim();
 
+  const birthDateUtc = new Date(
+    Date.UTC(
+      birthDate!.getFullYear(),
+      birthDate!.getMonth(),
+      birthDate!.getDate()
+    )
+  );
+
   const queryVariables: SubmitBirthCertificateOrderVariables = {
     contactName,
     contactEmail,
@@ -157,7 +165,7 @@ Relation: ${forSelf ? 'self' : howRelated || 'unknown'}
     billingCity,
     billingZip,
     item: {
-      birthDate: birthDate!.toISOString(),
+      birthDate: birthDateUtc.toISOString(),
       firstName,
       lastName,
       uploadSessionId,

--- a/services-js/registry-certs/server/email/EmailTemplates.ts
+++ b/services-js/registry-certs/server/email/EmailTemplates.ts
@@ -147,7 +147,10 @@ export class EmailTemplates {
           quantity,
           cost,
           description: `Birth certificate for ${name} (${moment(date)
-            .tz('America/New_York')
+            // Database times are midnight UTC. We need to specify UTC or else
+            // we'll print the day before, because midnight UTC is the day
+            // before in Boston.
+            .tz('UTC')
             .format('l')})`,
         })),
 
@@ -174,7 +177,10 @@ export class EmailTemplates {
           quantity,
           cost,
           description: `Birth certificate for ${name} (${moment(date)
-            .tz('America/New_York')
+            // Database times are midnight UTC. We need to specify UTC or else
+            // we'll print the day before, because midnight UTC is the day
+            // before in Boston.
+            .tz('UTC')
             .format('l')})`,
         })),
 

--- a/services-js/registry-certs/server/graphql/mutation.ts
+++ b/services-js/registry-certs/server/graphql/mutation.ts
@@ -39,6 +39,7 @@ interface BirthCertificateOrderItemInput {
   firstName: string;
   lastName: string;
   alternateSpellings: string;
+  /** ISO8601 format. Should be midnight UTC on the date. */
   birthDate: string;
   parent1FirstName: string;
   parent1LastName: string;
@@ -801,7 +802,7 @@ async function makeStripeCharge(
     // (because Stripe will retry webhooks if they fail).
 
     // We can only get the Stripe callback when in production, so we fake it for dev.
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
       await processChargeSucceeded({ stripe, emails, registryDb }, charge);
     }
   } catch (e) {


### PR DESCRIPTION
The contract for the API is now to use midnight UTC, and we render the
date in emails in UTC as well.

Prevents problems where birth dates were being given a time early in the
morning in UTC that was the day before when we rendered the time out in
eastern.

Fixes #368