### PR TITLE
Switches to use UTC exclusively for date input

### DIFF
--- a/modules-js/react-fleet/src/form-elements/inputs/MemorableDateInput.stories.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/MemorableDateInput.stories.tsx
@@ -15,7 +15,7 @@ storiesOf('Form Elements/Memorable date input', module)
   .add('earliestDate: 9/7/1630', () => (
     <MemorableDateInput
       componentId="earliest"
-      earliestDate="9/7/1630"
+      earliestDate={new Date('9/7/1630')}
       handleDate={() => {}}
       legend={<h2>Date</h2>}
     />
@@ -23,7 +23,7 @@ storiesOf('Form Elements/Memorable date input', module)
   .add('latestDate: 12/31/2025', () => (
     <MemorableDateInput
       componentId="latest"
-      latestDate="12/31/2025"
+      latestDate={new Date('12/31/2025')}
       handleDate={() => {}}
       legend={<h2>Date</h2>}
     />
@@ -31,7 +31,7 @@ storiesOf('Form Elements/Memorable date input', module)
   .add('with an initialDate', () => (
     <MemorableDateInput
       componentId="initial"
-      initialDate="12/31/1999"
+      initialDate={new Date('12/31/1999')}
       onlyAllowPast={true}
       handleDate={() => {}}
       legend={<h2>Date</h2>}
@@ -40,8 +40,8 @@ storiesOf('Form Elements/Memorable date input', module)
   .add('invalid initialDate', () => (
     <MemorableDateInput
       componentId="initial"
-      initialDate="1/1/2000"
-      latestDate="12/31/1999"
+      initialDate={new Date('1/1/2000')}
+      latestDate={new Date('12/31/1999')}
       handleDate={() => {}}
       legend={<h2>Date</h2>}
     />
@@ -65,7 +65,7 @@ storiesOf('Form Elements/Memorable date input', module)
   .add('onlyAllowFuture and latestDate: 1/1/2040', () => (
     <MemorableDateInput
       componentId="story"
-      latestDate="1/1/2040"
+      latestDate={new Date('1/1/2040')}
       onlyAllowFuture={true}
       handleDate={() => {}}
       legend={<h2>Date</h2>}

--- a/modules-js/react-fleet/src/form-elements/inputs/MemorableDateInput.test.ts
+++ b/modules-js/react-fleet/src/form-elements/inputs/MemorableDateInput.test.ts
@@ -5,8 +5,9 @@ import {
   inputCompleteError,
   returnLimitAsDate,
 } from './MemorableDateInput';
+import { MemorableDateInput } from '../../react-fleet';
 
-const TODAY = new Date(new Date('2/1/2019').setHours(0, 0, 0, 0));
+const TODAY = new Date(new Date('2/1/2019').setUTCHours(0, 0, 0, 0));
 
 beforeEach(() => {
   MockDate.set(TODAY);
@@ -18,18 +19,13 @@ afterEach(() => {
 
 describe('set lower or upper limit', () => {
   const exampleDate = new Date(2020, 0, 1);
-  const exampleString = '1/1/2020';
-
-  it('will accept a string', () => {
-    expect(returnLimitAsDate(exampleString, false)).toBeInstanceOf(Date);
-  });
 
   it('will accept a Date', () => {
     expect(returnLimitAsDate(exampleDate, false)).toBeInstanceOf(Date);
   });
 
   it('returns today’s date if onlyAllowFuture or onlyAllowPast is specified', () => {
-    expect(returnLimitAsDate('', true)).toEqual(TODAY);
+    expect(returnLimitAsDate(null, true)).toEqual(TODAY);
   });
 });
 
@@ -258,5 +254,5 @@ describe('dateValidError', () => {
 });
 
 function formattedDate(date: Date): string {
-  return Intl.DateTimeFormat('en-US').format(date);
+  return MemorableDateInput.formattedDateUtc(date);
 }

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -12314,7 +12314,7 @@ exports[`Storyshots Birth/ReviewRequestPage default page 1`] = `
                   </span>
                   <span>
                     Born: 
-                    4/9/1967
+                    4/10/1967
                   </span>
                 </div>
               </div>

--- a/services-js/registry-certs/client/birth/ReviewRequestPage.stories.tsx
+++ b/services-js/registry-certs/client/birth/ReviewRequestPage.stories.tsx
@@ -15,7 +15,7 @@ const birthCertRequest: BirthCertificateRequestInformation = {
   firstName: 'Martin',
   lastName: 'Walsh',
   altSpelling: '',
-  birthDate: new Date(1967, 3, 10),
+  birthDate: new Date(Date.UTC(1967, 3, 10)),
   parentsMarried: '',
   parent1FirstName: 'Martin',
   parent1LastName: '',

--- a/services-js/registry-certs/client/birth/questions/PersonalInformation.tsx
+++ b/services-js/registry-certs/client/birth/questions/PersonalInformation.tsx
@@ -14,7 +14,7 @@ import {
   SECTION_HEADING_STYLING,
 } from '../styling';
 
-const EARLIEST_DATE = '1/1/1870';
+const EARLIEST_DATE = new Date(Date.UTC(1870, 0, 1));
 
 interface Props {
   birthCertificateRequest: BirthCertificateRequest;
@@ -111,7 +111,7 @@ export default class PersonalInformation extends React.Component<Props> {
                 When were {forSelf ? 'you' : 'they'} born?
               </h2>
             }
-            initialDate={birthDate || ''}
+            initialDate={birthDate || undefined}
             componentId="dob"
             onlyAllowPast={true}
             earliestDate={EARLIEST_DATE}

--- a/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
+++ b/services-js/registry-certs/client/queries/submit-birth-certificate-order.ts
@@ -137,14 +137,6 @@ Relation: ${forSelf ? 'self' : howRelated || 'unknown'}
 | Parents married: ${parentsMarried}
   `.trim();
 
-  const birthDateUtc = new Date(
-    Date.UTC(
-      birthDate!.getFullYear(),
-      birthDate!.getMonth(),
-      birthDate!.getDate()
-    )
-  );
-
   const queryVariables: SubmitBirthCertificateOrderVariables = {
     contactName,
     contactEmail,
@@ -165,7 +157,7 @@ Relation: ${forSelf ? 'self' : howRelated || 'unknown'}
     billingCity,
     billingZip,
     item: {
-      birthDate: birthDateUtc.toISOString(),
+      birthDate: birthDate!.toISOString(),
       firstName,
       lastName,
       uploadSessionId,

--- a/services-js/registry-certs/client/store/BirthCertificateRequest.ts
+++ b/services-js/registry-certs/client/store/BirthCertificateRequest.ts
@@ -2,6 +2,7 @@ import { action, observable, computed } from 'mobx';
 import uuidv4 from 'uuid/v4';
 
 import { GaSiteAnalytics } from '@cityofboston/next-client-common';
+import { MemorableDateInput } from '@cityofboston/react-fleet';
 
 import { BirthCertificateRequestInformation, Step } from '../types';
 import { BIRTH_CERTIFICATE_COST } from '../../lib/costs';
@@ -147,7 +148,7 @@ export default class BirthCertificateRequest {
     const date = this.requestInformation.birthDate || null;
 
     if (date) {
-      return Intl.DateTimeFormat('en-US').format(date);
+      return MemorableDateInput.formattedDateUtc(date);
     } else {
       return '';
     }


### PR DESCRIPTION
We were running into inconsistencies in how Safari created dates in the
past that were a different daylight savings from the current time.

Removes string inputs for MemorableDateInput for now. If we want them in
the future we can put them back and figure more out about how they
should work with timezones.

Also removes uses of Intl, which isn’t present in iOS 9.

Fixes #375
Fixes #374