### PR TITLE
Aggressive no-cache headers for Access Boston

### DIFF
--- a/services-js/access-boston/src/client/AccessBostonHeader.tsx
+++ b/services-js/access-boston/src/client/AccessBostonHeader.tsx
@@ -60,7 +60,9 @@ export default class AccessBostonHeader extends React.Component<Props> {
 
             {!noLinks && (
               <RedirectForm path="/logout">
-                <button className="btn btn--sm btn--100">Logout</button>
+                <button type="submit" className="btn btn--sm btn--100">
+                  Logout
+                </button>
               </RedirectForm>
             )}
           </div>

--- a/services-js/access-boston/src/pages/_document.tsx
+++ b/services-js/access-boston/src/pages/_document.tsx
@@ -41,7 +41,7 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
 
           <link
             rel="shortcut icon"

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -82,6 +82,7 @@ exports[`Storyshots AccessBostonHeader default 1`] = `
       />
       <button
         className="btn btn--sm btn--100"
+        type="submit"
       >
         Logout
       </button>
@@ -133,6 +134,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -510,6 +512,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -891,6 +894,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -1277,6 +1281,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -1709,6 +1714,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -2119,6 +2125,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -3606,6 +3613,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -4425,6 +4433,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -5235,6 +5244,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -6449,6 +6459,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -6725,6 +6736,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -6949,6 +6961,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -8422,6 +8435,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>
@@ -8615,6 +8629,7 @@ Array [
         />
         <button
           className="btn btn--sm btn--100"
+          type="submit"
         >
           Logout
         </button>


### PR DESCRIPTION
Keeps Firefox back/forward cache from letting you "back" from the
logged-out landing page into a still-logged in web portal page.

May also keep other browsers from being so cache-y.

See CityOfBoston/iam#502

Also fixes logout button to be "submit" and fixes JSX httpEquiv
attribute casing in _document.