### PR TITLE
Passes Boom#data along to Rollbar

### DIFF
--- a/modules-js/hapi-common/src/hapi-common.ts
+++ b/modules-js/hapi-common/src/hapi-common.ts
@@ -244,7 +244,16 @@ export const rollbarPlugin = {
       // other 4xx errors, but for now we’ll keep them because they’re more
       // likely our fault than someone messing with requests.
       if (error.output.statusCode !== 404) {
-        rollbar.error(error, request, cb);
+        rollbar.error(
+          error,
+          request,
+          {
+            custom: {
+              data: error.data,
+            },
+          },
+          cb
+        );
       }
 
       return h.continue;


### PR DESCRIPTION
Necessary to help us debug the "Cannot throw non-Error object" exception
we saw coming from payments webhook.

https://rollbar.com/CityofBoston/payment-webhooks-server/items/6/occurrences/71070597761/