### PR TITLE
Adds polyfill bugfix for IE11

### DIFF
--- a/modules-js/next-client-common/polyfills.js
+++ b/modules-js/next-client-common/polyfills.js
@@ -7,18 +7,33 @@
  * "usage" should cause Babel to automatically include necessary polyfills.
  */
 
+// Issues arise in IE11: Stencil’s polyfill and core-js’ polyfill compete with each other in a neverending loop.
+if (
+  typeof window !== 'undefined' &&
+  !('' + window['Map'.toString()]).includes('native code')
+) {
+  delete window['Map'.toString()];
+}
+
+if (
+  typeof window !== 'undefined' &&
+  !('' + window['Set'.toString()]).includes('native code')
+) {
+  delete window['Set'.toString()];
+}
+
 // React needs map and set
-import 'core-js/es6/map';
-import 'core-js/es6/set';
+require('core-js/es6/map');
+require('core-js/es6/set');
 
 // Emotion needs weak-map
-import 'core-js/es6/weak-map';
+require('core-js/es6/weak-map');
 
 // Yup needs map and Array.from
-import 'core-js/es6/map';
-import 'core-js/fn/array/from';
+require('core-js/es6/map');
+require('core-js/fn/array/from');
 
 // fetch isn't in core-js, so the Babel env plugin can’t add it automatically on
 // usage. Since it’s so useful (and easy to forget when it’s not available) we
 // polyfill it by default.
-import 'isomorphic-fetch';
+require('isomorphic-fetch');


### PR DESCRIPTION
Stencil.js’ polyfills and core-js’s polyfills were interfering with each other in IE11; this should resolve it.