### PR TITLE
Redirects user to /birth if page reload occurs

### DIFF
--- a/services-js/registry-certs/client/birth/CheckoutPage.stories.tsx
+++ b/services-js/registry-certs/client/birth/CheckoutPage.stories.tsx
@@ -7,6 +7,7 @@ import CheckoutDao from '../dao/CheckoutDao';
 import OrderProvider from '../store/OrderProvider';
 import Order, { OrderInfo } from '../models/Order';
 import BirthCertificateRequest from '../store/BirthCertificateRequest';
+import { BirthCertificateRequestInformation } from '../types';
 
 const makeStripe = () =>
   typeof Stripe !== 'undefined' ? Stripe('fake-secret-key') : null;
@@ -74,6 +75,31 @@ function makeBillingCompleteOrder(overrides = {}) {
     ...overrides,
   });
 }
+
+const birthCertificateRequestInformation: BirthCertificateRequestInformation = {
+  forSelf: true,
+  howRelated: '',
+  bornInBoston: 'yes',
+  parentsLivedInBoston: '',
+  firstName: 'Martin',
+  lastName: 'Walsh',
+  altSpelling: '',
+  birthDate: new Date(Date.UTC(1967, 3, 10)),
+  parentsMarried: 'yes',
+  parent1FirstName: 'Martin',
+  parent1LastName: '',
+  parent2FirstName: '',
+  parent2LastName: '',
+  idImageBack: null,
+  idImageFront: null,
+  supportingDocuments: [],
+};
+
+const birthCertificateRequest = new BirthCertificateRequest();
+
+birthCertificateRequest.setRequestInformation(
+  birthCertificateRequestInformation
+);
 
 storiesOf('Birth/CheckoutPage', module)
   .add('server-side render', () => (

--- a/services-js/registry-certs/client/birth/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/birth/CheckoutPage.tsx
@@ -106,7 +106,22 @@ export default class BirthCheckoutPage extends React.Component<Props, State> {
   async componentDidMount() {
     this.reportCheckoutStep(this.props);
 
-    const { orderProvider } = this.props;
+    const { orderProvider, siteAnalytics } = this.props;
+
+    // If any of the question steps are not complete (i.e. user backed up,
+    // changed an answer, and used the browser “forward” button), return to the
+    // beginning of the questions flow.
+    if (this.props.birthCertificateRequest.questionStepsComplete === false) {
+      // todo: improve this experience
+      // todo: behavior is duplicated in ReviewRequestPage.tsx
+
+      siteAnalytics.sendEvent('question results lost', {
+        category: 'Birth',
+        label: `checkout: ${this.props.info.page}`,
+      });
+
+      return Router.push('/birth');
+    }
 
     if (this.state.order) {
       return;

--- a/services-js/registry-certs/client/birth/ReviewRequestPage.stories.tsx
+++ b/services-js/registry-certs/client/birth/ReviewRequestPage.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
+import { GaSiteAnalytics } from '@cityofboston/next-client-common';
+
 import BirthCertificateRequest from '../store/BirthCertificateRequest';
 
 import ReviewRequestPage from './ReviewRequestPage';
@@ -16,7 +18,7 @@ const birthCertRequest: BirthCertificateRequestInformation = {
   lastName: 'Walsh',
   altSpelling: '',
   birthDate: new Date(Date.UTC(1967, 3, 10)),
-  parentsMarried: '',
+  parentsMarried: 'yes',
   parent1FirstName: 'Martin',
   parent1LastName: '',
   parent2FirstName: '',
@@ -28,11 +30,11 @@ const birthCertRequest: BirthCertificateRequestInformation = {
 
 const birthCertificateRequest = new BirthCertificateRequest();
 
-birthCertificateRequest.answerQuestion(birthCertRequest);
+birthCertificateRequest.setRequestInformation(birthCertRequest);
 
 storiesOf('Birth/ReviewRequestPage', module).add('default page', () => (
   <ReviewRequestPage
     birthCertificateRequest={birthCertificateRequest}
-    siteAnalytics={{ addProduct: () => {}, setProductAction: () => {} } as any}
+    siteAnalytics={new GaSiteAnalytics()}
   />
 ));

--- a/services-js/registry-certs/client/birth/ReviewRequestPage.tsx
+++ b/services-js/registry-certs/client/birth/ReviewRequestPage.tsx
@@ -37,6 +37,21 @@ export default class ReviewRequestPage extends React.Component<Props> {
 
     window.scroll(0, 0);
 
+    // If any of the question steps are not complete (i.e. user backed up,
+    // changed an answer, and used the browser “forward” button), return to the
+    // beginning of the questions flow.
+    if (this.props.birthCertificateRequest.questionStepsComplete === false) {
+      // todo: improve this experience
+      // todo: behavior is duplicated in CheckoutPage.tsx
+
+      siteAnalytics.sendEvent('question results lost', {
+        category: 'Birth',
+        label: 'review request',
+      });
+
+      return Router.push('/birth');
+    }
+
     // Since user has provided all needed information by this point, we
     // will count this birth certificate as a trackable product.
     siteAnalytics.addProduct(


### PR DESCRIPTION
Quick fix to handle cases where a user is on `/review` or `/checkout`, but the question flow results have been lost to a page reload.