### PR TITLE
Prevents onDrop setState() if user drag-and-drops incorrect filetype

### DIFF
--- a/modules-js/react-fleet/src/form-elements/UploadPhoto.stories.tsx
+++ b/modules-js/react-fleet/src/form-elements/UploadPhoto.stories.tsx
@@ -7,42 +7,37 @@ import UploadPhoto from './UploadPhoto';
 
 import { BLACK, OPTIMISTIC_BLUE_LIGHT, WHITE } from '../react-fleet';
 
+const mockHandlerFunctions = {
+  handleDrop: () => {},
+  handleRemove: () => {},
+  handleButtonClick: () => {},
+  handleCancel: () => {},
+};
+
 storiesOf('Form Elements/Upload photo', module)
   .addDecorator(s => (
     <div className="g">
       <div className="g--4">{s()}</div>
     </div>
   ))
-  .add('default', () => (
-    <UploadPhoto handleDrop={() => {}} handleRemove={() => {}} />
-  ))
+  .add('default', () => <UploadPhoto {...mockHandlerFunctions} />)
   .add('custom background element', () => (
     <UploadPhoto
       backgroundElement={<IdImage />}
       buttonTitleUpload="Upload front of ID"
-      handleDrop={() => {}}
-      handleRemove={() => {}}
+      {...mockHandlerFunctions}
     />
   ))
   .add('uploading: 60% complete', () => (
-    <UploadPhoto
-      uploadProgress={60}
-      handleDrop={() => {}}
-      handleRemove={() => {}}
-    />
+    <UploadPhoto uploadProgress={60} {...mockHandlerFunctions} />
   ))
   .add('upload error', () => (
-    <UploadPhoto
-      errorMessage="server error"
-      handleDrop={() => {}}
-      handleRemove={() => {}}
-    />
+    <UploadPhoto errorMessage="server error" {...mockHandlerFunctions} />
   ))
   .add('existing photo', () => (
     <UploadPhoto
       initialFile={new File(SVG_BITS, 'img.svg', { type: 'image/svg+xml' })}
-      handleDrop={() => {}}
-      handleRemove={() => {}}
+      {...mockHandlerFunctions}
     />
   ));
 

--- a/modules-js/react-fleet/src/form-elements/UploadPhoto.tsx
+++ b/modules-js/react-fleet/src/form-elements/UploadPhoto.tsx
@@ -65,15 +65,17 @@ export default class UploadPhoto extends React.Component<Props, State> {
   };
 
   private onDrop = (files: File[]): void => {
-    this.setState(
-      {
-        file: files[0],
-        previewUrl: URL.createObjectURL(files[0]),
-      },
-      () => {
-        this.state.file && this.props.handleDrop(this.state.file);
-      }
-    );
+    if (files.length) {
+      this.setState(
+        {
+          file: files[0],
+          previewUrl: URL.createObjectURL(files[0]),
+        },
+        () => {
+          this.state.file && this.props.handleDrop(this.state.file);
+        }
+      );
+    }
   };
 
   private onRemove = (): void => {


### PR DESCRIPTION
Resolves https://rollbar.com/CityofBoston/registry-certs/items/140/

The error message `Failed to execute 'createObjectURL' on 'URL'` occurs after the user tries to drag-and-drop a non-image file into the dropzone; preventing `setState()` from being called in those cases prevents the error.

Issue is discussed in this thread: https://github.com/react-dropzone/react-dropzone/issues/255