### PR TITLE
Moves route change into setState callback

### DIFF
--- a/services-js/registry-certs/client/birth/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/birth/CheckoutPage.tsx
@@ -240,20 +240,23 @@ export default class BirthCheckoutPage extends React.Component<Props, State> {
     birthCertificateRequest.clearBirthCertificateRequest();
     orderProvider.clear();
 
-    this.setState({
-      order: await orderProvider.get(),
-    });
+    this.setState(
+      {
+        order: await orderProvider.get(),
+      },
+      async () => {
+        await Router.push(
+          `/birth/checkout?page=confirmation&orderId=${encodeURIComponent(
+            orderId
+          )}&contactEmail=${encodeURIComponent(
+            order.info.contactEmail
+          )}&stepCount=${stepCount}`,
+          '/birth/checkout?page=confirmation'
+        );
 
-    await Router.push(
-      `/birth/checkout?page=confirmation&orderId=${encodeURIComponent(
-        orderId
-      )}&contactEmail=${encodeURIComponent(
-        order.info.contactEmail
-      )}&stepCount=${stepCount}`,
-      '/birth/checkout?page=confirmation'
+        window.scroll(0, 0);
+      }
     );
-
-    window.scroll(0, 0);
   };
 
   birthCertificateProduct() {


### PR DESCRIPTION
Resolves https://rollbar.com/CityofBoston/registry-certs/items/154/

When an order has been submitted, we need to ensure that state updates have been completed before the route changes.