### PR TITLE
Rewords “forWhom” question text

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -3311,7 +3311,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? blank 1`] = `
                     className="css-vmrobw"
                     id="forSelf"
                   >
-                    Who are you ordering a birth certificate for?
+                    Whose birth certificate are you ordering?
                   </h2>
                 </legend>
                 <div
@@ -3346,7 +3346,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? blank 1`] = `
                       value="true"
                     />
                     <span>
-                      Myself
+                      Mine
                     </span>
                   </label>
                   <label
@@ -3398,7 +3398,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? blank 1`] = `
                       value="false"
                     />
                     <span>
-                      Someone else
+                      Someone else’s
                     </span>
                   </label>
                 </div>
@@ -3749,7 +3749,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     className="css-vmrobw"
                     id="forSelf"
                   >
-                    Who are you ordering a birth certificate for?
+                    Whose birth certificate are you ordering?
                   </h2>
                 </legend>
                 <div
@@ -3784,7 +3784,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                       value="true"
                     />
                     <span>
-                      Myself
+                      Mine
                     </span>
                   </label>
                   <label
@@ -3836,7 +3836,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                       value="false"
                     />
                     <span>
-                      Someone else
+                      Someone else’s
                     </span>
                   </label>
                 </div>
@@ -3849,7 +3849,7 @@ exports[`Storyshots Birth/QuestionsFlow/1. Who is this for? for someone else 1`]
                     className="css-vmrobw"
                     id="howRelated"
                   >
-                    Is it for your…
+                    I’m ordering the birth certificate of my…
                   </h3>
                 </legend>
                 <div

--- a/services-js/registry-certs/client/birth/QuestionsPage.tsx
+++ b/services-js/registry-certs/client/birth/QuestionsPage.tsx
@@ -131,11 +131,11 @@ export default class QuestionsPage extends React.Component<Props, State> {
 
     const nextStep = newSteps[currentIndex + 1];
 
+    this.gaEventActionAndLabel();
+
     if (nextStep === 'reviewRequest') {
       Router.push('/birth/review');
     } else {
-      this.gaEventActionAndLabel();
-
       Router.push(`/birth?step=${nextStep}`);
     }
   };

--- a/services-js/registry-certs/client/birth/questions/ForWhom.tsx
+++ b/services-js/registry-certs/client/birth/questions/ForWhom.tsx
@@ -84,7 +84,7 @@ export default class ForWhom extends React.Component<Props> {
         <FieldsetComponent
           legendText={
             <h2 id="forSelf" className={SECTION_HEADING_STYLING}>
-              Who are you ordering a birth certificate for?
+              Whose birth certificate are you ordering?
             </h2>
           }
         >
@@ -97,7 +97,7 @@ export default class ForWhom extends React.Component<Props> {
               questionName="forSelf"
               questionValue={forSelfValue}
               itemValue="true"
-              labelText="Myself"
+              labelText="Mine"
               className={RADIOITEM_STYLING}
               handleChange={this.handleBooleanChange}
             >
@@ -108,7 +108,7 @@ export default class ForWhom extends React.Component<Props> {
               questionName="forSelf"
               questionValue={forSelfValue}
               itemValue="false"
-              labelText="Someone else"
+              labelText="Someone else’s"
               className={RADIOITEM_STYLING}
               handleChange={this.handleBooleanChange}
             >
@@ -121,7 +121,7 @@ export default class ForWhom extends React.Component<Props> {
           <FieldsetComponent
             legendText={
               <h3 id="howRelated" className={SECTION_HEADING_STYLING}>
-                Is it for your…
+                I’m ordering the birth certificate of my…
               </h3>
             }
           >


### PR DESCRIPTION
@rachelbraun noted that some users are selecting “self” instead of the person they’re _actually_ requesting a certificate for. Question has been reworded for (hopefully) improved user comprehension.

Also addresses a GA reporting bug.

Resolves #389 