### PR TITLE
Fixes phone number normalization to remove "})"

### DIFF
--- a/services-js/access-boston/src/integration/register-device.testcafe.ts
+++ b/services-js/access-boston/src/integration/register-device.testcafe.ts
@@ -67,7 +67,9 @@ test.only('Device registration', async t => {
     .click(mfaPage.voiceRadioButton)
     .click(mfaPage.submitButton)
     .expect(mfaPage.modal.innerText)
-    .contains('Please pick up!', 'Can switch to voice code');
+    .contains('Please pick up!', 'Can switch to voice code')
+    .expect(mfaPage.modal.innerText)
+    .contains('(xxx) xxx-xx12');
 
   await mfaPage
     .submitVerificationCode(t, '999999')

--- a/services-js/access-boston/src/pages/mfa.tsx
+++ b/services-js/access-boston/src/pages/mfa.tsx
@@ -107,10 +107,11 @@ export default class RegisterMfaPage extends React.Component<Props, State> {
       // a problem where Ping thinks that the 857 area code, common to Boston
       // cell phones, is a country code.
       const phoneNumberMatches = phoneNumber.match(PHONE_REGEXP);
+
       if (phoneNumberMatches) {
         phoneNumber = `+${phoneNumberMatches[1] || '1'} (${
           phoneNumberMatches[2]
-        }) ${phoneNumberMatches[3]}-${phoneNumberMatches[4]}})`;
+        }) ${phoneNumberMatches[3]}-${phoneNumberMatches[4]}`;
       }
     }
 


### PR DESCRIPTION
Adds test to explicitly check that we’re getting the # right in the
modal.

See CityOfBoston/iam#533