### PR TITLE
Adds protection around malformed MFA dates

### DIFF
--- a/services-js/access-boston/src/server/access-boston.ts
+++ b/services-js/access-boston/src/server/access-boston.ts
@@ -171,7 +171,7 @@ export async function makeServer(port, rollbar: Rollbar) {
 
   await server.register(browserAuthPlugin);
 
-  await addLoginAuth(server, {
+  await addLoginAuth(server, rollbar, {
     loginPath: '/login',
     logoutPath: '/logout',
     afterLoginUrl: '/',

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -130,7 +130,7 @@ const queryRootResolvers: QueryRootResolvers = {
     _args,
     { session: { loginAuth, forgotPasswordAuth, loginSession } }
   ) => {
-    if (loginAuth) {
+    if (loginAuth && loginSession) {
       const { userId } = loginAuth;
       const {
         needsMfaDevice,
@@ -139,7 +139,7 @@ const queryRootResolvers: QueryRootResolvers = {
         firstName,
         lastName,
         mfaRequiredDate,
-      } = loginSession!;
+      } = loginSession;
 
       return {
         employeeId: userId,


### PR DESCRIPTION
Also adds protection for the case where there’s an auth part of the
session but not session data (such as can happen when creating the
LoginSession fails).

Fixes https://rollbar.com/CityofBoston/access-boston/items/29/
Fixes https://rollbar.com/CityofBoston/access-boston/items/30/