### PR TITLE
Removes the crumb protection from /logout

### DIFF
--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -127,6 +127,11 @@ export async function addLoginAuth(
   server.route({
     path: logoutPath,
     method: 'POST',
+    options: {
+      plugins: {
+        crumb: false,
+      },
+    },
     handler: (request, h) => {
       // We clear our cookie and stored session when you hit this button, since
       // it's better for us to be logged out on AccessBoston but logged in on


### PR DESCRIPTION
We’re seeing errors go by and want to figure out what’s up before we
enforce this (slightly unnecessary) protection.

See: https://rollbar.com/CityofBoston/access-boston/items/49/