### PR TITLE
Adds Boom exceptions’ "data" to Rollbar in GraphQL

### DIFF
--- a/modules-js/hapi-common/src/hapi-common.ts
+++ b/modules-js/hapi-common/src/hapi-common.ts
@@ -278,10 +278,6 @@ export const graphqlOptionsWithRollbar = (
     const oldFormatError = opts.formatError;
     opts.formatError = (e: any) => {
       const request = req.raw && req.raw.req;
-      const extra = {
-        graphql: req.payload,
-      };
-
       // GraphQL wraps the original exception, so we pull it back out from
       // originalError since it has the right type and stacktrace and
       // everything.
@@ -291,6 +287,12 @@ export const graphqlOptionsWithRollbar = (
       } else {
         err = e;
       }
+
+      const data = (err as any).data;
+      const extra = {
+        graphql: req.payload,
+        custom: data ? { data } : {},
+      };
 
       if (!err.silent) {
         rollbar.error(err, request, extra);


### PR DESCRIPTION
Previously the Boom data was only sent on 500 errors, not those caught
by GraphQL.