### PR TITLE
Modifications to speed up full Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 - TZ=America/New_York
 git:
   depth: false
-cache: yarn
 branches:
   only:
   - develop
@@ -23,7 +22,8 @@ jobs:
     if: type IN (push)
     install:
     - curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
-    - yarn install --frozen-lockfile
+    - yarn install --frozen-lockfile --ignore-scripts
+    - yarn run prepare
     script:
     - yarn run test
     - yarn run test:templates
@@ -40,7 +40,7 @@ jobs:
     install:
     - curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
     - yarn install --frozen-lockfile --ignore-scripts
-    - lerna run --stream --since $TRAVIS_PULL_REQUEST_SHA^1 --include-filtered-dependencies
+    - lerna run --stream --since $TRAVIS_PULL_REQUEST_SHA^1 --include-filtered-dependencies 
       prepare
     script:
     - yarn run test:since $TRAVIS_PULL_REQUEST_SHA^1

--- a/modules-js/deploy-tools/package.json
+++ b/modules-js/deploy-tools/package.json
@@ -10,7 +10,6 @@
     "prebuild": "rimraf build",
     "build": "tsc",
     "prepare": "yarn run build",
-    "pretest": "tsc --noEmit",
     "test": "jest --passWithNoTests"
   },
   "bin": {

--- a/modules-js/form-common/package.json
+++ b/modules-js/form-common/package.json
@@ -15,7 +15,6 @@
     "build:typescript": "tsc --emitDeclarationOnly",
     "build:babel": "cross-env BABEL_ENV=esm babel src --out-dir build --extensions \".ts,.tsx\"",
     "prepare": "yarn run build",
-    "pretest": "tsc --noEmit",
     "test": "jest"
   },
   "jest": {

--- a/modules-js/graphql-typescript/package.json
+++ b/modules-js/graphql-typescript/package.json
@@ -11,7 +11,6 @@
     "prebuild": "rimraf build",
     "build": "tsc",
     "prepare": "yarn run build",
-    "pretest": "tsc --noEmit",
     "test": "jest"
   },
   "jest": {

--- a/modules-js/next-client-common/package.json
+++ b/modules-js/next-client-common/package.json
@@ -15,7 +15,6 @@
     "build:typescript": "tsc --emitDeclarationOnly",
     "build:babel": "cross-env BABEL_ENV=esm babel src --source-maps inline --ignore '**/*.stories.*','**/*.test.*' --out-dir build --extensions \".ts,.tsx\"",
     "prepare": "yarn run build",
-    "pretest": "tsc --noEmit",
     "test": "jest"
   },
   "jest": {

--- a/modules-js/react-fleet/package.json
+++ b/modules-js/react-fleet/package.json
@@ -16,7 +16,6 @@
     "build:typescript": "tsc --emitDeclarationOnly",
     "build:babel": "cross-env BABEL_ENV=esm babel src --ignore '**/*.stories.*','**/*.test.*' --out-dir build --extensions \".ts,.tsx\"",
     "prepare": "yarn run build",
-    "pretest": "tsc --noEmit",
     "test": "scripts/test.js",
     "fetch-templates": "ts-node ./scripts/fetch-templates.ts"
   },

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "precommit": "lint-staged",
     "prepush": "jest --clearCache && lerna run --no-sort --stream --since origin/develop --ignore js-*-module test",
     "watch": "lerna run --parallel --scope @cityofboston/* watch",
-    "test": "lerna run --no-sort --concurrency 2 --ignore js-*-module test --",
-    "test:since": "lerna run test --no-sort --concurrency 2 --ignore js-*-module --since",
+    "test": "lerna run --no-sort --concurrency 6 --ignore js-*-module test --",
+    "test:since": "lerna run test --no-sort --concurrency 6 --ignore js-*-module --since",
     "test:templates": "lerna run --no-sort --concurrency 1 --stream --scope js-*-module test --",
     "test:templates:since": "lerna run test --no-sort --concurrency 1 --stream --scope js-*-module --since"
   },

--- a/services-js/311/integration/testcafe-helpers.ts
+++ b/services-js/311/integration/testcafe-helpers.ts
@@ -15,7 +15,7 @@ export const isReactRunning = ClientFunction(
 );
 
 export async function waitForReact(t: TestController) {
-  await t.expect(isReactRunning()).ok({ timeout: 15000 });
+  await t.expect(isReactRunning()).ok({ timeout: 30000 });
 }
 
 export async function printConsoleLogs(t: TestController) {

--- a/services-js/access-boston/src/integration/models/LoginFormModel.ts
+++ b/services-js/access-boston/src/integration/models/LoginFormModel.ts
@@ -16,7 +16,7 @@ export default class LoginFormModel extends PageModel {
         .click(this.submitButton)
         // Make sure the app is going after we’ve submitted
         .expect(isReactRunning())
-        .ok()
+        .ok({ timeout: 30000 })
     );
   }
 }

--- a/services-js/access-boston/src/integration/register-device.testcafe.ts
+++ b/services-js/access-boston/src/integration/register-device.testcafe.ts
@@ -26,7 +26,7 @@ fixture('Device Registration')
     await t
       .navigateTo('/mfa')
       .expect(isReactRunning())
-      .ok();
+      .ok({ timeout: 30000 });
   });
 
 test.only('Device registration', async t => {


### PR DESCRIPTION
 - Only pre-builds modules since apps will get built as part of tests
 - Removes `tsc --noEmit` check from module tests since building the
   module (done in `prepare`) runs `tsc` in order to output the types
 - Increases concurrency
 - Fixes app running check timeout for testcafe tests