### PR TITLE
Shows / hides links based on city agency

### DIFF
--- a/services-js/access-boston/fixtures/apps.yaml
+++ b/services-js/access-boston/fixtures/apps.yaml
@@ -64,14 +64,31 @@ categories:
     apps:
       - title: Create Sponsored Account
         url: https://identity.boston.gov/identityiq/createSponsor.jsf
+        agencies:
+          - BPL
+          - BPD
+          - BFD
+          - CH
       - title: FleetHub
         url: http://boston.getlocalmotion.com/
+        agencies:
+          - CH
       - title: International Travel
         url: https://goo.gl/forms/Xobh9aZeGXSnKH2m2
+        agencies:
+          - BPD
+          - BFD
+          - CH
       - title: Unblock Website Request
         url: https://boston.seamlessdocs.com/f/geol18cumhw
+        agencies:
+          - BPD
+          - BFD
+          - CH
       - title: Building Maintenance
         url: https://eamtst.cityhall.boston.cob:5443/WebMaint/
+        agencies:
+          - CH
       - title: Request FN Access
         url: https://identity.boston.gov/identityiq/requestPsfn.jsf
         groups:

--- a/services-js/access-boston/src/lib/AppsRegistry.test.ts
+++ b/services-js/access-boston/src/lib/AppsRegistry.test.ts
@@ -19,18 +19,32 @@ describe('appsForUserTypeAndGroups', () => {
   });
 
   it('returns just the "everyone" category for no groups', () => {
-    expect(appsRegistry.appsForGroups([], false)).toMatchSnapshot();
+    expect(appsRegistry.appsForGroups([], false, 'CH')).toMatchSnapshot();
   });
 
   it('returns apps for a group', () => {
     // This checks that categories with no apps are not returned
     expect(
-      appsRegistry.appsForGroups(['SG_AB_IAM_TEAM'], false)
+      appsRegistry.appsForGroups(['SG_AB_IAM_TEAM'], false, 'CH')
+    ).toMatchSnapshot();
+  });
+
+  it('returns apps for an agency', () => {
+    // This checks that categories with no apps are not returned
+    expect(
+      appsRegistry.appsForGroups(['SG_AB_IAM_TEAM'], false, 'BPS')
+    ).toMatchSnapshot();
+  });
+
+  it('doesn’t return agency apps if none is specified', () => {
+    // This checks that categories with no apps are not returned
+    expect(
+      appsRegistry.appsForGroups(['SG_AB_IAM_TEAM'], false, null)
     ).toMatchSnapshot();
   });
 
   it('returns apps that require an MFA device', () => {
     // This checks that categories with no apps are not returned
-    expect(appsRegistry.appsForGroups([], true)).toMatchSnapshot();
+    expect(appsRegistry.appsForGroups([], true, 'CH')).toMatchSnapshot();
   });
 });

--- a/services-js/access-boston/src/lib/__snapshots__/AppsRegistry.test.ts.snap
+++ b/services-js/access-boston/src/lib/__snapshots__/AppsRegistry.test.ts.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`appsForUserTypeAndGroups returns apps for a group 1`] = `
+exports[`appsForUserTypeAndGroups doesn’t return agency apps if none is specified 1`] = `
 Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": "/assets/apps/boston-maps.svg",
@@ -13,6 +14,7 @@ Array [
         "url": "https://boston.maps.arcgis.com/",
       },
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": "/assets/apps/hub.svg",
@@ -21,6 +23,7 @@ Array [
         "url": "https://edit-dev-hub.boston.gov/user",
       },
       Object {
+        "agencies": null,
         "description": "",
         "groups": Array [
           "SG_AB_IAM_TEAM",
@@ -38,6 +41,69 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
+        "description": "",
+        "groups": null,
+        "iconUrl": null,
+        "mfaDeviceRequired": false,
+        "title": "Change My Password",
+        "url": "/change-password",
+      },
+    ],
+    "icons": false,
+    "showRequestAccessLink": false,
+    "title": "Account Tools",
+  },
+]
+`;
+
+exports[`appsForUserTypeAndGroups returns apps for a group 1`] = `
+Array [
+  Object {
+    "apps": Array [
+      Object {
+        "agencies": null,
+        "description": "",
+        "groups": null,
+        "iconUrl": "/assets/apps/boston-maps.svg",
+        "mfaDeviceRequired": false,
+        "title": "Boston Maps",
+        "url": "https://boston.maps.arcgis.com/",
+      },
+      Object {
+        "agencies": null,
+        "description": "",
+        "groups": null,
+        "iconUrl": "/assets/apps/hub.svg",
+        "mfaDeviceRequired": false,
+        "title": "The Hub",
+        "url": "https://edit-dev-hub.boston.gov/user",
+      },
+      Object {
+        "agencies": null,
+        "description": "",
+        "groups": Array [
+          "SG_AB_IAM_TEAM",
+        ],
+        "iconUrl": "/assets/apps/identityiq.svg",
+        "mfaDeviceRequired": false,
+        "title": "IIQ",
+        "url": "https://identity.boston.gov/identityiq/",
+      },
+    ],
+    "icons": true,
+    "showRequestAccessLink": true,
+    "title": "Applications",
+  },
+  Object {
+    "apps": Array [
+      Object {
+        "agencies": Array [
+          "BPL",
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -46,6 +112,9 @@ Array [
         "url": "https://identity.boston.gov/identityiq/createSponsor.jsf",
       },
       Object {
+        "agencies": Array [
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -54,6 +123,11 @@ Array [
         "url": "http://boston.getlocalmotion.com/",
       },
       Object {
+        "agencies": Array [
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -62,6 +136,11 @@ Array [
         "url": "https://goo.gl/forms/Xobh9aZeGXSnKH2m2",
       },
       Object {
+        "agencies": Array [
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -70,6 +149,9 @@ Array [
         "url": "https://boston.seamlessdocs.com/f/geol18cumhw",
       },
       Object {
+        "agencies": Array [
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -85,6 +167,64 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
+        "description": "",
+        "groups": null,
+        "iconUrl": null,
+        "mfaDeviceRequired": false,
+        "title": "Change My Password",
+        "url": "/change-password",
+      },
+    ],
+    "icons": false,
+    "showRequestAccessLink": false,
+    "title": "Account Tools",
+  },
+]
+`;
+
+exports[`appsForUserTypeAndGroups returns apps for an agency 1`] = `
+Array [
+  Object {
+    "apps": Array [
+      Object {
+        "agencies": null,
+        "description": "",
+        "groups": null,
+        "iconUrl": "/assets/apps/boston-maps.svg",
+        "mfaDeviceRequired": false,
+        "title": "Boston Maps",
+        "url": "https://boston.maps.arcgis.com/",
+      },
+      Object {
+        "agencies": null,
+        "description": "",
+        "groups": null,
+        "iconUrl": "/assets/apps/hub.svg",
+        "mfaDeviceRequired": false,
+        "title": "The Hub",
+        "url": "https://edit-dev-hub.boston.gov/user",
+      },
+      Object {
+        "agencies": null,
+        "description": "",
+        "groups": Array [
+          "SG_AB_IAM_TEAM",
+        ],
+        "iconUrl": "/assets/apps/identityiq.svg",
+        "mfaDeviceRequired": false,
+        "title": "IIQ",
+        "url": "https://identity.boston.gov/identityiq/",
+      },
+    ],
+    "icons": true,
+    "showRequestAccessLink": true,
+    "title": "Applications",
+  },
+  Object {
+    "apps": Array [
+      Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -105,6 +245,7 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": "/assets/apps/boston-maps.svg",
@@ -113,6 +254,7 @@ Array [
         "url": "https://boston.maps.arcgis.com/",
       },
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": "/assets/apps/hub.svg",
@@ -128,6 +270,12 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": Array [
+          "BPL",
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -136,6 +284,9 @@ Array [
         "url": "https://identity.boston.gov/identityiq/createSponsor.jsf",
       },
       Object {
+        "agencies": Array [
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -144,6 +295,11 @@ Array [
         "url": "http://boston.getlocalmotion.com/",
       },
       Object {
+        "agencies": Array [
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -152,6 +308,11 @@ Array [
         "url": "https://goo.gl/forms/Xobh9aZeGXSnKH2m2",
       },
       Object {
+        "agencies": Array [
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -160,6 +321,9 @@ Array [
         "url": "https://boston.seamlessdocs.com/f/geol18cumhw",
       },
       Object {
+        "agencies": Array [
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -175,6 +339,7 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -183,6 +348,7 @@ Array [
         "url": "/change-password",
       },
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -203,6 +369,7 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": "/assets/apps/boston-maps.svg",
@@ -211,6 +378,7 @@ Array [
         "url": "https://boston.maps.arcgis.com/",
       },
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": "/assets/apps/hub.svg",
@@ -226,6 +394,12 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": Array [
+          "BPL",
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -234,6 +408,9 @@ Array [
         "url": "https://identity.boston.gov/identityiq/createSponsor.jsf",
       },
       Object {
+        "agencies": Array [
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -242,6 +419,11 @@ Array [
         "url": "http://boston.getlocalmotion.com/",
       },
       Object {
+        "agencies": Array [
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -250,6 +432,11 @@ Array [
         "url": "https://goo.gl/forms/Xobh9aZeGXSnKH2m2",
       },
       Object {
+        "agencies": Array [
+          "BPD",
+          "BFD",
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -258,6 +445,9 @@ Array [
         "url": "https://boston.seamlessdocs.com/f/geol18cumhw",
       },
       Object {
+        "agencies": Array [
+          "CH",
+        ],
         "description": "",
         "groups": null,
         "iconUrl": null,
@@ -273,6 +463,7 @@ Array [
   Object {
     "apps": Array [
       Object {
+        "agencies": null,
         "description": "",
         "groups": null,
         "iconUrl": null,

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -106,29 +106,30 @@ export default class IndexPage extends React.Component<Props> {
             </div>
           )}
 
-          {daysUntilMfa && (
-            <div className="b--g">
-              <div className="b-c" style={{ padding: 0 }}>
-                <div className="g g--vc p-v500">
-                  <div className="g--9">
-                    <div className="h3 tt-u">Account notice</div>
-                    <div className="t--intro">
-                      You have <strong>{daysUntilMfa} days</strong> to complete
-                      your registration.
+          {daysUntilMfa &&
+            daysUntilMfa > 0 && (
+              <div className="b--g">
+                <div className="b-c" style={{ padding: 0 }}>
+                  <div className="g g--vc p-v500">
+                    <div className="g--9">
+                      <div className="h3 tt-u">Account notice</div>
+                      <div className="t--intro">
+                        You have <strong>{daysUntilMfa} days</strong> to
+                        complete your registration.
+                      </div>
                     </div>
-                  </div>
 
-                  <div className="g--3 ta-r">
-                    <Link href="/mfa">
-                      <a className="btn" style={{ whiteSpace: 'nowrap' }}>
-                        Complete it now
-                      </a>
-                    </Link>
+                    <div className="g--3 ta-r">
+                      <Link href="/mfa">
+                        <a className="btn" style={{ whiteSpace: 'nowrap' }}>
+                          Complete it now
+                        </a>
+                      </Link>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
           <div className="b b-c">
             {iconCategories.map(({ title, apps, requestAccessUrl }) => (

--- a/services-js/access-boston/src/server/forgot-password-auth.ts
+++ b/services-js/access-boston/src/server/forgot-password-auth.ts
@@ -2,7 +2,11 @@ import { Server as HapiServer } from 'hapi';
 import SamlAuth, { makeSamlAuth } from './services/SamlAuth';
 import SamlAuthFake, { makeFakeLoginHandler } from './services/SamlAuthFake';
 import { BrowserAuthOptions } from '@cityofboston/hapi-common';
-import { getSessionAuth, setSessionAuth } from './Session';
+import {
+  getSessionAuth,
+  setSessionAuth,
+  CURRENT_SESSION_VERSION,
+} from './Session';
 
 const FORGOT_METADATA_PATH = '/metadata-forgot.xml';
 const FORGOT_ASSERT_PATH = '/assert-forgot';
@@ -137,6 +141,7 @@ export async function addForgotPasswordAuth(
 
       setSessionAuth(request, {
         type: 'forgotPassword',
+        sessionVersion: CURRENT_SESSION_VERSION,
         userId: assertResult.nameId,
         resetPasswordToken: assertResult.userAccessToken,
         createdTime: Date.now(),

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -180,7 +180,11 @@ const queryRootResolvers: QueryRootResolvers = {
 
     return {
       categories: appsRegistry
-        .appsForGroups(loginSession.groups, loginSession.hasMfaDevice)
+        .appsForGroups(
+          loginSession.groups,
+          loginSession.hasMfaDevice,
+          loginSession.cobAgency || null
+        )
         .map(({ apps, icons, showRequestAccessLink, title }) => ({
           title,
           showIcons: icons,

--- a/services-js/access-boston/src/server/login-auth.ts
+++ b/services-js/access-boston/src/server/login-auth.ts
@@ -21,6 +21,7 @@ import {
   setSessionAuth,
   getSessionAuth,
   LOGIN_SESSION_KEY,
+  CURRENT_SESSION_VERSION,
 } from './Session';
 
 import { BrowserAuthOptions } from '@cityofboston/hapi-common';
@@ -172,11 +173,13 @@ export async function addLoginAuth(
           needsNewPassword,
           hasMfaDevice,
           userMfaRegistrationDate,
+          cobAgency,
         } = assertResult;
 
         // This will be read by the validate method above when doing authentication.
         const loginAuth: LoginAuth = {
           type: 'login',
+          sessionVersion: CURRENT_SESSION_VERSION,
           userId: nameId,
           sessionIndex,
         };
@@ -213,6 +216,7 @@ export async function addLoginAuth(
           // We normalize to an ISO formatted string but need to keep this a
           // string because we’re serializing in Redis.
           mfaRequiredDate,
+          cobAgency,
         };
 
         request.yar.set(LOGIN_SESSION_KEY, session);

--- a/services-js/access-boston/src/server/services/SamlAuth.ts
+++ b/services-js/access-boston/src/server/services/SamlAuth.ts
@@ -32,6 +32,7 @@ interface SamlAuthAssertion {
       userAccessToken?: string[];
       userMFARegistrationDate?: string[];
       isUserRegistered?: string[];
+      cobUserAgency?: string[];
     };
   };
 }
@@ -74,6 +75,7 @@ export interface SamlLoginResult {
   userAccessToken: string;
   /** Format is MM/DD/YYYY */
   userMfaRegistrationDate: string | null;
+  cobAgency: string | null;
 }
 
 export interface SamlLogoutRequestResult {
@@ -303,6 +305,8 @@ export default class SamlAuth {
             (attributes.userMFARegistrationDate &&
               attributes.userMFARegistrationDate[0]) ||
             null,
+          cobAgency:
+            (attributes.cobUserAgency && attributes.cobUserAgency[0]) || null,
         };
       }
       case 'logout_request':

--- a/services-js/access-boston/src/server/services/SamlAuthFake.ts
+++ b/services-js/access-boston/src/server/services/SamlAuthFake.ts
@@ -54,6 +54,7 @@ export default class SamlAuthFake implements Required<SamlAuth> {
       hasMfaDevice: !isNewUser,
       userAccessToken: 'jfqWE7DExC4nUa7pvkABezkM4oNT',
       userMfaRegistrationDate: null,
+      cobAgency: 'CH',
     };
 
     return Promise.resolve(result);

--- a/services-js/access-boston/src/stories/IndexPage.stories.tsx
+++ b/services-js/access-boston/src/stories/IndexPage.stories.tsx
@@ -22,7 +22,7 @@ const ACCOUNT: Account = {
 const appsRegistry = makeAppsRegistry(APPS_YAML, true);
 
 const APPS: Apps = {
-  categories: appsRegistry.appsForGroups([], true).map(cat => ({
+  categories: appsRegistry.appsForGroups([], true, 'CH').map(cat => ({
     title: cat.title,
     showIcons: cat.icons,
     requestAccessUrl: cat.showRequestAccessLink ? '#' : null,


### PR DESCRIPTION
Also includes new way of invalidating login sessions so that when this
deploys we can ensure that people get their sessions populated
correctly.

See CityOfBoston/iam#565