### PR TITLE
Allows Error#fatal to be null

### DIFF
--- a/services-js/311-indexer/server/stages/load-cases.ts
+++ b/services-js/311-indexer/server/stages/load-cases.ts
@@ -19,7 +19,7 @@ interface Deps {
 
 declare global {
   interface Error {
-    fatal?: boolean;
+    fatal?: boolean | null;
     missing?: boolean;
   }
 }


### PR DESCRIPTION
Fixes incompatibility with @types/vfile-message.