### PR TITLE
Makes key generation password longer

### DIFF
--- a/scripts/generate-ssl-key.sh
+++ b/scripts/generate-ssl-key.sh
@@ -6,8 +6,8 @@ FILENAME_BASE=${2:-server}
 
 cd $1
 
-openssl genrsa -des3 -passout pass:x -out "${FILENAME_BASE}.pass.key" 2048
-openssl rsa -passin pass:x -in "${FILENAME_BASE}.pass.key" -out "${FILENAME_BASE}.key"
+openssl genrsa -des3 -passout pass:swordfish -out "${FILENAME_BASE}.pass.key" 2048
+openssl rsa -passin pass:swordfish -in "${FILENAME_BASE}.pass.key" -out "${FILENAME_BASE}.key"
 rm "${FILENAME_BASE}.pass.key"
 openssl req -new -key "${FILENAME_BASE}.key" -out "${FILENAME_BASE}.csr" \
   -subj "/C=US/ST=Massachusetts/L=Boston/O=Department of Innovation and Technology/OU=Digital/CN=${WORKSPACE:-default}"


### PR DESCRIPTION
Fixes "You must type in 4 to 1023 characters" error when generating a
password.