### PR TITLE
Migrates react-fleet to Emotion css prop

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     }
   },
   "plugins": [
+    "emotion",
     "prettier",
     "react-hooks"
   ],
@@ -22,6 +23,7 @@
     "prettier/react"
   ],
   "rules": {
+    "emotion/jsx-import": "error",
     "prettier/prettier": "error",
     "react-hooks/rules-of-hooks": "error"
   },

--- a/modules-js/config-babel/package.json
+++ b/modules-js/config-babel/package.json
@@ -11,7 +11,7 @@
     "@babel/plugin-transform-runtime": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
-    "@babel/preset-typescript": "7.1.0",
+    "@babel/preset-typescript": "^7.3.2",
     "babel-plugin-require-context-hook": "^1.0.0",
     "next": "8.0.3"
   },

--- a/modules-js/form-common/package.json
+++ b/modules-js/form-common/package.json
@@ -28,8 +28,6 @@
   },
   "peerDependencies": {
     "@babel/runtime": "7.1.2",
-    "@emotion/core": "^10.0.10",
-    "emotion": "^10.0.9",
     "react": "16.8.5"
   },
   "devDependencies": {
@@ -38,13 +36,11 @@
     "@babel/runtime": "7.1.2",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
-    "@emotion/core": "^10.0.10",
     "@types/jest": "24.x.x",
     "@types/react": "^16.8.5",
     "babel-core": "^7.0.0-0",
     "concurrently": "^3.5.1",
     "cross-env": "^5.2.0",
-    "emotion": "^10.0.9",
     "jest": "24.1.0",
     "react": "16.8.5",
     "rimraf": "^2.6.2",

--- a/modules-js/react-fleet/.storybook/.babelrc
+++ b/modules-js/react-fleet/.storybook/.babelrc
@@ -1,0 +1,1 @@
+{ "extends": "../.babelrc" }

--- a/modules-js/react-fleet/package.json
+++ b/modules-js/react-fleet/package.json
@@ -21,6 +21,7 @@
     "fetch-templates": "ts-node ./scripts/fetch-templates.ts"
   },
   "jest": {
+    "snapshotSerializers": ["jest-emotion"],
     "testPathIgnorePatterns": [
       "<rootDir>/build/",
       "<rootDir>/node_modules/",
@@ -34,7 +35,6 @@
     "@emotion/core": "^10.0.10",
     "@babel/runtime": "7.1.2",
     "detect-browser": "^3.0.1",
-    "emotion": "^10.0.9",
     "prop-types": "^15.6.0",
     "react": "16.8.5",
     "react-dom": "16.8.5",
@@ -75,9 +75,9 @@
     "concurrently": "^3.5.1",
     "cross-env": "^5.2.0",
     "detect-browser": "^3.0.1",
-    "emotion": "^10.0.9",
     "fs-extra": "^5.0.0",
     "jest": "24.1.0",
+    "jest-emotion": "^10.0.10",
     "node-fetch": "^1.6.9",
     "prop-types": "^15.6.0",
     "raw-loader": "^0.5.1",

--- a/modules-js/react-fleet/rollup.config.js
+++ b/modules-js/react-fleet/rollup.config.js
@@ -7,7 +7,8 @@ const EXTERNALS = [
   'react',
   'react-dom',
   'react-dropzone',
-  'emotion',
+  '@emotion/core',
+  '@emotion/css',
   'string-hash',
   'detect-browser',
 ];

--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -1,6 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Content Sections|CollapsibleSection default (open) 1`] = `
+.emotion-1 {
+  width: 100%;
+  margin-bottom: 0;
+  padding-right: 0;
+}
+
+.emotion-0 {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  text-transform: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0:focus {
+  outline: auto;
+  outline-color: #288be4;
+}
+
+.emotion-0:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.emotion-0 span {
+  margin-right: auto;
+}
+
+.emotion-0 svg {
+  width: 0.9em;
+  height: 0.9em;
+  stroke: #1871bd;
+  -webkit-transition: -webkit-transform 0.4s;
+  -webkit-transition: transform 0.4s;
+  transition: transform 0.4s;
+}
+
+.emotion-0[aria-expanded='true'] > svg {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+  transform: rotate(-180deg);
+  -webkit-transform-origin: center;
+  -ms-transform-origin: center;
+  transform-origin: center;
+}
+
 <section
   aria-labelledby="collapsiblesection-1469836601"
 >
@@ -8,11 +70,11 @@ exports[`Storyshots Content Sections|CollapsibleSection default (open) 1`] = `
     className="sh "
   >
     <h2
-      className="sh-title css-14x07yu"
+      className="sh-title emotion-1"
     >
       <button
         aria-expanded={true}
-        className="css-306jx9"
+        className="emotion-0"
         onClick={[Function]}
         type="button"
       >
@@ -53,14 +115,20 @@ exports[`Storyshots Content Sections|CollapsibleSection default (open) 1`] = `
 
 exports[`Storyshots Content Sections|CollapsibleSection disabled 1`] = `
 Array [
-  <section
+  .emotion-0 {
+  width: 100%;
+  margin-bottom: 0;
+  padding-right: 0;
+}
+
+<section
     aria-labelledby="collapsiblesection-2725997550"
   >
     <div
       className="sh "
     >
       <h2
-        className="sh-title css-14x07yu"
+        className="sh-title emotion-0"
       >
         <span
           id="collapsiblesection-2725997550"
@@ -80,14 +148,20 @@ Array [
       </p>
     </div>
   </section>,
-  <section
+  .emotion-0 {
+  width: 100%;
+  margin-bottom: 0;
+  padding-right: 0;
+}
+
+<section
     aria-labelledby="collapsiblesection-206548808"
   >
     <div
       className="sh "
     >
       <h2
-        className="sh-title css-14x07yu"
+        className="sh-title emotion-0"
       >
         <span
           id="collapsiblesection-206548808"
@@ -111,6 +185,68 @@ Array [
 `;
 
 exports[`Storyshots Content Sections|CollapsibleSection initially collapsed 1`] = `
+.emotion-1 {
+  width: 100%;
+  margin-bottom: 0;
+  padding-right: 0;
+}
+
+.emotion-0 {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  text-transform: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0:focus {
+  outline: auto;
+  outline-color: #288be4;
+}
+
+.emotion-0:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.emotion-0 span {
+  margin-right: auto;
+}
+
+.emotion-0 svg {
+  width: 0.9em;
+  height: 0.9em;
+  stroke: #1871bd;
+  -webkit-transition: -webkit-transform 0.4s;
+  -webkit-transition: transform 0.4s;
+  transition: transform 0.4s;
+}
+
+.emotion-0[aria-expanded='true'] > svg {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+  transform: rotate(-180deg);
+  -webkit-transform-origin: center;
+  -ms-transform-origin: center;
+  transform-origin: center;
+}
+
 <section
   aria-labelledby="collapsiblesection-3435950689"
 >
@@ -118,11 +254,11 @@ exports[`Storyshots Content Sections|CollapsibleSection initially collapsed 1`] 
     className="sh "
   >
     <h2
-      className="sh-title css-14x07yu"
+      className="sh-title emotion-1"
     >
       <button
         aria-expanded={false}
-        className="css-306jx9"
+        className="emotion-0"
         onClick={[Function]}
         type="button"
       >
@@ -162,6 +298,68 @@ exports[`Storyshots Content Sections|CollapsibleSection initially collapsed 1`] 
 `;
 
 exports[`Storyshots Content Sections|CollapsibleSection subheader variant 1`] = `
+.emotion-1 {
+  width: 100%;
+  margin-bottom: 0;
+  padding-right: 0;
+}
+
+.emotion-0 {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  text-transform: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0:focus {
+  outline: auto;
+  outline-color: #288be4;
+}
+
+.emotion-0:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.emotion-0 span {
+  margin-right: auto;
+}
+
+.emotion-0 svg {
+  width: 0.9em;
+  height: 0.9em;
+  stroke: #1871bd;
+  -webkit-transition: -webkit-transform 0.4s;
+  -webkit-transition: transform 0.4s;
+  transition: transform 0.4s;
+}
+
+.emotion-0[aria-expanded='true'] > svg {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+  transform: rotate(-180deg);
+  -webkit-transform-origin: center;
+  -ms-transform-origin: center;
+  transform-origin: center;
+}
+
 <section
   aria-labelledby="collapsiblesection-1469836601"
 >
@@ -169,11 +367,11 @@ exports[`Storyshots Content Sections|CollapsibleSection subheader variant 1`] = 
     className="sh sh--sm"
   >
     <h3
-      className="sh-title css-14x07yu"
+      className="sh-title emotion-1"
     >
       <button
         aria-expanded={true}
-        className="css-306jx9"
+        className="emotion-0"
         onClick={[Function]}
         type="button"
       >
@@ -252,8 +450,22 @@ exports[`Storyshots Content Sections|SectionHeader yellow 1`] = `
 `;
 
 exports[`Storyshots Form Elements|Buttons/CloseButton close 1`] = `
+.emotion-0 {
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.8;
+  -webkit-transition: opacity 0.15s;
+  transition: opacity 0.15s;
+}
+
+.emotion-0:hover {
+  opacity: 1;
+}
+
 <button
-  className="css-14581tj undefined"
+  className="emotion-0"
   onClick={[Function]}
   style={
     Object {
@@ -354,12 +566,79 @@ Array [
 `;
 
 exports[`Storyshots Form Elements|Inputs/FileInput Multiple file types 1`] = `
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 {
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+  }
+}
+
+.emotion-3 label {
+  margin-bottom: 0.5em;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 label {
+    margin-bottom: 0;
+  }
+}
+
+.emotion-3 div {
+  -webkit-flex-basis: 80%;
+  -ms-flex-preferred-size: 80%;
+  flex-basis: 80%;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 div {
+    -webkit-flex-basis: auto;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto;
+    padding-left: 1em;
+  }
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.emotion-2 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+}
+
 <div
-  className="txt m-b300 css-1mxs0p5"
+  className="txt m-b300 emotion-3"
 >
   <input
     accept="image/jpeg, image/png"
-    className="css-1dv1kvn"
+    className="emotion-0"
     id="FileInput-multi"
     name="multi"
     onBlur={[Function]}
@@ -368,7 +647,7 @@ exports[`Storyshots Form Elements|Inputs/FileInput Multiple file types 1`] = `
     type="file"
   />
   <label
-    className="btn btn--sm btn--100 false"
+    className="btn btn--sm btn--100 emotion-1"
     htmlFor="FileInput-multi"
     style={
       Object {
@@ -382,7 +661,7 @@ exports[`Storyshots Form Elements|Inputs/FileInput Multiple file types 1`] = `
      file
   </label>
   <div
-    className="css-y0g14a"
+    className="emotion-2"
   >
     <span>
       No file selected
@@ -392,12 +671,79 @@ exports[`Storyshots Form Elements|Inputs/FileInput Multiple file types 1`] = `
 `;
 
 exports[`Storyshots Form Elements|Inputs/FileInput Small size limit; unspecified file type 1`] = `
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 {
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+  }
+}
+
+.emotion-3 label {
+  margin-bottom: 0.5em;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 label {
+    margin-bottom: 0;
+  }
+}
+
+.emotion-3 div {
+  -webkit-flex-basis: 80%;
+  -ms-flex-preferred-size: 80%;
+  flex-basis: 80%;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 div {
+    -webkit-flex-basis: auto;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto;
+    padding-left: 1em;
+  }
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.emotion-2 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+}
+
 <div
-  className="txt m-b300 css-1mxs0p5"
+  className="txt m-b300 emotion-3"
 >
   <input
     accept="*"
-    className="css-1dv1kvn"
+    className="emotion-0"
     id="FileInput-coverLetter"
     name="coverLetter"
     onBlur={[Function]}
@@ -406,7 +752,7 @@ exports[`Storyshots Form Elements|Inputs/FileInput Small size limit; unspecified
     type="file"
   />
   <label
-    className="btn btn--sm btn--100 false"
+    className="btn btn--sm btn--100 emotion-1"
     htmlFor="FileInput-coverLetter"
     style={
       Object {
@@ -420,7 +766,7 @@ exports[`Storyshots Form Elements|Inputs/FileInput Small size limit; unspecified
      file
   </label>
   <div
-    className="css-y0g14a"
+    className="emotion-2"
   >
     <span>
       No file selected
@@ -430,12 +776,79 @@ exports[`Storyshots Form Elements|Inputs/FileInput Small size limit; unspecified
 `;
 
 exports[`Storyshots Form Elements|Inputs/FileInput default 1`] = `
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 {
+    -webkit-flex-wrap: nowrap;
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+  }
+}
+
+.emotion-3 label {
+  margin-bottom: 0.5em;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 label {
+    margin-bottom: 0;
+  }
+}
+
+.emotion-3 div {
+  -webkit-flex-basis: 80%;
+  -ms-flex-preferred-size: 80%;
+  flex-basis: 80%;
+}
+
+@media screen and (min-width:480px) {
+  .emotion-3 div {
+    -webkit-flex-basis: auto;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto;
+    padding-left: 1em;
+  }
+}
+
+.emotion-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.emotion-2 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+}
+
 <div
-  className="txt m-b300 css-1mxs0p5"
+  className="txt m-b300 emotion-3"
 >
   <input
     accept="application/pdf"
-    className="css-1dv1kvn"
+    className="emotion-0"
     id="FileInput-pdf"
     name="pdf"
     onBlur={[Function]}
@@ -444,7 +857,7 @@ exports[`Storyshots Form Elements|Inputs/FileInput default 1`] = `
     type="file"
   />
   <label
-    className="btn btn--sm btn--100 false"
+    className="btn btn--sm btn--100 emotion-1"
     htmlFor="FileInput-pdf"
     style={
       Object {
@@ -458,7 +871,7 @@ exports[`Storyshots Form Elements|Inputs/FileInput default 1`] = `
      file
   </label>
   <div
-    className="css-y0g14a"
+    className="emotion-2"
   >
     <span>
       No file selected
@@ -468,8 +881,58 @@ exports[`Storyshots Form Elements|Inputs/FileInput default 1`] = `
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput default 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -483,7 +946,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput default 1`] = `
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -553,8 +1016,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput default 1`] = `
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput earliestDate: 9/7/1630 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -568,7 +1081,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput earliestDate: 9/7/16
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -638,8 +1151,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput earliestDate: 9/7/16
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput invalid initialDate 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -653,7 +1216,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput invalid initialDate 
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -728,8 +1291,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput invalid initialDate 
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput latestDate: 12/31/2025 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -743,7 +1356,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput latestDate: 12/31/20
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -813,8 +1426,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput latestDate: 12/31/20
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -828,7 +1491,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture 1`] 
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -898,8 +1561,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture 1`] 
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture and latestDate: 1/1/2040 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -913,7 +1626,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture and 
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -983,8 +1696,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture and 
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowPast 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -998,7 +1761,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowPast 1`] = 
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -1068,8 +1831,58 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowPast 1`] = 
 `;
 
 exports[`Storyshots Form Elements|Inputs/MemorableDateInput with an initialDate 1`] = `
+.emotion-1 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-1 legend {
+  padding-left: 0;
+  font-size: 120%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-0 > div {
+  -webkit-flex: 0 0 24%;
+  -ms-flex: 0 0 24%;
+  flex: 0 0 24%;
+}
+
+.emotion-0 > div:last-of-type {
+  -webkit-flex: 0 0 50%;
+  -ms-flex: 0 0 50%;
+  flex: 0 0 50%;
+}
+
+.emotion-0 input {
+  -moz-appearance: textfield;
+}
+
+.emotion-0 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.emotion-0 input::-ms-clear {
+  display: none;
+}
+
+.emotion-0 label {
+  margin-top: 0.5rem;
+}
+
 <fieldset
-  className="css-svo1gv"
+  className="emotion-1"
 >
   <legend
     style={
@@ -1083,7 +1896,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput with an initialDate 
     </h2>
   </legend>
   <div
-    className="css-k2dcag"
+    className="emotion-0"
   >
     <div>
       <label
@@ -1900,6 +2713,29 @@ Array [
 `;
 
 exports[`Storyshots Form Elements|UploadPhoto custom background element 1`] = `
+.emotion-2:focus > div {
+  outline: 4px solid #000;
+  outline-offset: -5px;
+}
+
+.emotion-1 {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  background-color: currentColor;
+}
+
+.emotion-3:focus {
+  outline: 3px solid #000;
+  outline-offset: -4px;
+}
+
+.emotion-0 {
+  background-color: #288be4;
+  color: #000;
+  padding: 2rem 4rem;
+}
+
 <div
   className="g"
 >
@@ -1910,7 +2746,7 @@ exports[`Storyshots Form Elements|UploadPhoto custom background element 1`] = `
       className="br br-a200"
     >
       <div
-        className="css-b3ja71"
+        className="emotion-2"
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnter={[Function]}
@@ -1937,7 +2773,7 @@ exports[`Storyshots Form Elements|UploadPhoto custom background element 1`] = `
           type="file"
         />
         <div
-          className="css-18dy1p4 "
+          className="emotion-1"
         >
           <div
             style={
@@ -1947,7 +2783,7 @@ exports[`Storyshots Form Elements|UploadPhoto custom background element 1`] = `
             }
           >
             <header
-              className="css-1v08ydl"
+              className="emotion-0"
             >
               <svg
                 aria-hidden="true"
@@ -2014,7 +2850,7 @@ exports[`Storyshots Form Elements|UploadPhoto custom background element 1`] = `
         }
       >
         <button
-          className="btn btn--w btn--b css-cavyyu  "
+          className="btn btn--w btn--b  emotion-3"
           onClick={[Function]}
           style={
             Object {
@@ -2032,6 +2868,35 @@ exports[`Storyshots Form Elements|UploadPhoto custom background element 1`] = `
 `;
 
 exports[`Storyshots Form Elements|UploadPhoto default 1`] = `
+.emotion-2:focus > div {
+  outline: 4px solid #000;
+  outline-offset: -5px;
+}
+
+.emotion-1 {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  background-color: currentColor;
+}
+
+.emotion-0 {
+  background-color: #828282;
+  color: #fff;
+}
+
+.emotion-0 svg {
+  stroke-width: 3;
+  stroke-linecap: round;
+  fill: none;
+  stroke: currentColor;
+}
+
+.emotion-3:focus {
+  outline: 3px solid #000;
+  outline-offset: -4px;
+}
+
 <div
   className="g"
 >
@@ -2042,7 +2907,7 @@ exports[`Storyshots Form Elements|UploadPhoto default 1`] = `
       className="br br-a200"
     >
       <div
-        className="css-b3ja71"
+        className="emotion-2"
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnter={[Function]}
@@ -2069,7 +2934,7 @@ exports[`Storyshots Form Elements|UploadPhoto default 1`] = `
           type="file"
         />
         <div
-          className="css-18dy1p4 "
+          className="emotion-1"
         >
           <div
             style={
@@ -2079,7 +2944,7 @@ exports[`Storyshots Form Elements|UploadPhoto default 1`] = `
             }
           >
             <div
-              className="css-aipimn"
+              className="emotion-0"
             >
               <svg
                 aria-hidden="true"
@@ -2137,7 +3002,7 @@ exports[`Storyshots Form Elements|UploadPhoto default 1`] = `
         }
       >
         <button
-          className="btn btn--w btn--b css-cavyyu  "
+          className="btn btn--w btn--b  emotion-3"
           onClick={[Function]}
           style={
             Object {
@@ -2155,6 +3020,46 @@ exports[`Storyshots Form Elements|UploadPhoto default 1`] = `
 `;
 
 exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
+.emotion-3:focus > div {
+  outline: 4px solid #000;
+  outline-offset: -5px;
+}
+
+.emotion-2 {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  background-color: currentColor;
+}
+
+.emotion-0 {
+  background-color: #828282;
+  color: #fff;
+}
+
+.emotion-0 svg {
+  stroke-width: 3;
+  stroke-linecap: round;
+  fill: none;
+  stroke: currentColor;
+}
+
+.emotion-4:focus {
+  outline: 3px solid #000;
+  outline-offset: -4px;
+}
+
+.emotion-1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
 <div
   className="g"
 >
@@ -2165,7 +3070,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
       className="br br-a200"
     >
       <div
-        className="css-b3ja71"
+        className="emotion-3"
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnter={[Function]}
@@ -2192,7 +3097,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
           type="file"
         />
         <div
-          className="css-18dy1p4 "
+          className="emotion-2"
         >
           <div
             style={
@@ -2202,7 +3107,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
             }
           >
             <div
-              className="css-aipimn"
+              className="emotion-0"
             >
               <svg
                 aria-hidden="true"
@@ -2250,7 +3155,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
             </div>
           </div>
           <div
-            className="css-5xh0sb"
+            className="emotion-1"
             style={
               Object {
                 "backgroundImage": "url(https://patterns.boston.gov/images/global/icons/experiential/pdf-doc.svg)",
@@ -2268,7 +3173,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
         }
       >
         <button
-          className="btn btn--w btn--b css-cavyyu  "
+          className="btn btn--w btn--b  emotion-4"
           onClick={[Function]}
           style={
             Object {
@@ -2286,6 +3191,46 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo (reloaded) 1`] = `
 `;
 
 exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
+.emotion-3:focus > div {
+  outline: 4px solid #000;
+  outline-offset: -5px;
+}
+
+.emotion-2 {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  background-color: currentColor;
+}
+
+.emotion-0 {
+  background-color: #828282;
+  color: #fff;
+}
+
+.emotion-0 svg {
+  stroke-width: 3;
+  stroke-linecap: round;
+  fill: none;
+  stroke: currentColor;
+}
+
+.emotion-4:focus {
+  outline: 3px solid #000;
+  outline-offset: -4px;
+}
+
+.emotion-1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
 <div
   className="g"
 >
@@ -2296,7 +3241,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
       className="br br-a200"
     >
       <div
-        className="css-b3ja71"
+        className="emotion-3"
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnter={[Function]}
@@ -2323,7 +3268,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
           type="file"
         />
         <div
-          className="css-18dy1p4 "
+          className="emotion-2"
         >
           <div
             style={
@@ -2333,7 +3278,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
             }
           >
             <div
-              className="css-aipimn"
+              className="emotion-0"
             >
               <svg
                 aria-hidden="true"
@@ -2381,7 +3326,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
             </div>
           </div>
           <div
-            className="css-5xh0sb"
+            className="emotion-1"
             style={
               Object {
                 "backgroundImage": "url(https://patterns.boston.gov/images/global/icons/experiential/pdf-doc.svg)",
@@ -2399,7 +3344,7 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
         }
       >
         <button
-          className="btn btn--w btn--b css-cavyyu  "
+          className="btn btn--w btn--b  emotion-4"
           onClick={[Function]}
           style={
             Object {
@@ -2417,6 +3362,39 @@ exports[`Storyshots Form Elements|UploadPhoto existing photo 1`] = `
 `;
 
 exports[`Storyshots Form Elements|UploadPhoto upload error 1`] = `
+.emotion-2:focus > div {
+  outline: 4px solid #000;
+  outline-offset: -5px;
+}
+
+.emotion-1 {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  background-color: currentColor;
+}
+
+.emotion-0 {
+  background-color: #828282;
+  color: #fff;
+}
+
+.emotion-0 svg {
+  stroke-width: 3;
+  stroke-linecap: round;
+  fill: none;
+  stroke: currentColor;
+}
+
+.emotion-3 {
+  color: #d22d23;
+}
+
+.emotion-3:focus {
+  outline: 3px solid #000;
+  outline-offset: -4px;
+}
+
 <div
   className="g"
 >
@@ -2427,7 +3405,7 @@ exports[`Storyshots Form Elements|UploadPhoto upload error 1`] = `
       className="br br-a200"
     >
       <div
-        className="css-b3ja71"
+        className="emotion-2"
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnter={[Function]}
@@ -2454,7 +3432,7 @@ exports[`Storyshots Form Elements|UploadPhoto upload error 1`] = `
           type="file"
         />
         <div
-          className="css-18dy1p4 "
+          className="emotion-1"
         >
           <div
             style={
@@ -2464,7 +3442,7 @@ exports[`Storyshots Form Elements|UploadPhoto upload error 1`] = `
             }
           >
             <div
-              className="css-aipimn"
+              className="emotion-0"
             >
               <svg
                 aria-hidden="true"
@@ -2522,7 +3500,7 @@ exports[`Storyshots Form Elements|UploadPhoto upload error 1`] = `
         }
       >
         <button
-          className="btn btn--w btn--b css-cavyyu  css-udegvj"
+          className="btn btn--w btn--b  emotion-3"
           onClick={[Function]}
           style={
             Object {
@@ -2540,6 +3518,43 @@ exports[`Storyshots Form Elements|UploadPhoto upload error 1`] = `
 `;
 
 exports[`Storyshots Form Elements|UploadPhoto uploading: 60% complete 1`] = `
+.emotion-2:focus > div {
+  outline: 4px solid #000;
+  outline-offset: -5px;
+}
+
+.emotion-1 {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  background-color: currentColor;
+}
+
+.emotion-0 {
+  background-color: #828282;
+  color: #fff;
+}
+
+.emotion-0 svg {
+  stroke-width: 3;
+  stroke-linecap: round;
+  fill: none;
+  stroke: currentColor;
+}
+
+.emotion-3:focus {
+  outline: 3px solid #000;
+  outline-offset: -4px;
+}
+
+.emotion-4 {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 6px;
+  background-color: #288be4;
+}
+
 <div
   className="g"
 >
@@ -2550,7 +3565,7 @@ exports[`Storyshots Form Elements|UploadPhoto uploading: 60% complete 1`] = `
       className="br br-a200"
     >
       <div
-        className="css-b3ja71"
+        className="emotion-2"
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnter={[Function]}
@@ -2577,7 +3592,7 @@ exports[`Storyshots Form Elements|UploadPhoto uploading: 60% complete 1`] = `
           type="file"
         />
         <div
-          className="css-18dy1p4 "
+          className="emotion-1"
         >
           <div
             style={
@@ -2587,7 +3602,7 @@ exports[`Storyshots Form Elements|UploadPhoto uploading: 60% complete 1`] = `
             }
           >
             <div
-              className="css-aipimn"
+              className="emotion-0"
             >
               <svg
                 aria-hidden="true"
@@ -2645,7 +3660,7 @@ exports[`Storyshots Form Elements|UploadPhoto uploading: 60% complete 1`] = `
         }
       >
         <button
-          className="btn btn--w btn--b css-cavyyu btn--r-hov "
+          className="btn btn--w btn--b btn--r-hov emotion-3"
           onClick={[Function]}
           style={
             Object {
@@ -2657,7 +3672,7 @@ exports[`Storyshots Form Elements|UploadPhoto uploading: 60% complete 1`] = `
           Cancel upload
         </button>
         <div
-          className="css-1tjt8qb"
+          className="emotion-4"
           style={
             Object {
               "width": "60%",
@@ -2764,11 +3779,19 @@ Array [
 `;
 
 exports[`Storyshots Notifications|Modals/StatusModal default 1`] = `
+.emotion-0 {
+  padding-top: 0;
+  max-width: 500px;
+  top: 15%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
 <div
-  className="md "
+  className="md"
 >
   <div
-    className="md-c br br-t400 css-1y2scv5"
+    className="md-c br br-t400 emotion-0"
   >
     <div
       className="md-b p-a300"
@@ -2789,11 +3812,19 @@ exports[`Storyshots Notifications|Modals/StatusModal default 1`] = `
 `;
 
 exports[`Storyshots Notifications|Modals/StatusModal error with close 1`] = `
+.emotion-0 {
+  padding-top: 0;
+  max-width: 500px;
+  top: 15%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
 <div
-  className="md "
+  className="md"
 >
   <div
-    className="md-c br br-t400 css-1y2scv5"
+    className="md-c br br-t400 emotion-0"
   >
     <div
       className="md-b p-a300"
@@ -2826,6 +3857,36 @@ exports[`Storyshots Notifications|Modals/StatusModal error with close 1`] = `
 `;
 
 exports[`Storyshots ProgressBar default 1`] = `
+.emotion-0 progress {
+  margin: 1rem 0 0.25rem;
+  width: 100%;
+  height: 1rem;
+  border: 2px solid #091f2f;
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-bar {
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-value {
+  -webkit-transition: width 0.5s;
+  transition: width 0.5s;
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-moz-progress-bar {
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-ms-fill {
+  background-color: #288be4;
+}
+
+.emotion-0 span {
+  font-style: italic;
+}
+
 <div
   style={
     Object {
@@ -2835,7 +3896,7 @@ exports[`Storyshots ProgressBar default 1`] = `
   }
 >
   <div
-    className="css-v8ihoq"
+    className="emotion-0"
   >
     <progress
       aria-valuemax={5}
@@ -2857,6 +3918,36 @@ exports[`Storyshots ProgressBar default 1`] = `
 `;
 
 exports[`Storyshots ProgressBar first step (interactive demo) 1`] = `
+.emotion-0 progress {
+  margin: 1rem 0 0.25rem;
+  width: 100%;
+  height: 1rem;
+  border: 2px solid #091f2f;
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-bar {
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-value {
+  -webkit-transition: width 0.5s;
+  transition: width 0.5s;
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-moz-progress-bar {
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-ms-fill {
+  background-color: #288be4;
+}
+
+.emotion-0 span {
+  font-style: italic;
+}
+
 <div
   style={
     Object {
@@ -2866,7 +3957,7 @@ exports[`Storyshots ProgressBar first step (interactive demo) 1`] = `
   }
 >
   <div
-    className="css-v8ihoq"
+    className="emotion-0"
   >
     <progress
       aria-valuemax={5}
@@ -2888,6 +3979,36 @@ exports[`Storyshots ProgressBar first step (interactive demo) 1`] = `
 `;
 
 exports[`Storyshots ProgressBar last step (interactive demo) 1`] = `
+.emotion-0 progress {
+  margin: 1rem 0 0.25rem;
+  width: 100%;
+  height: 1rem;
+  border: 2px solid #091f2f;
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-bar {
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-value {
+  -webkit-transition: width 0.5s;
+  transition: width 0.5s;
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-moz-progress-bar {
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-ms-fill {
+  background-color: #288be4;
+}
+
+.emotion-0 span {
+  font-style: italic;
+}
+
 <div
   style={
     Object {
@@ -2897,7 +4018,7 @@ exports[`Storyshots ProgressBar last step (interactive demo) 1`] = `
   }
 >
   <div
-    className="css-v8ihoq"
+    className="emotion-0"
   >
     <progress
       aria-valuemax={5}
@@ -2919,6 +4040,36 @@ exports[`Storyshots ProgressBar last step (interactive demo) 1`] = `
 `;
 
 exports[`Storyshots ProgressBar with task name 1`] = `
+.emotion-0 progress {
+  margin: 1rem 0 0.25rem;
+  width: 100%;
+  height: 1rem;
+  border: 2px solid #091f2f;
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-bar {
+  background-color: #fff;
+}
+
+.emotion-0 progress::-webkit-progress-value {
+  -webkit-transition: width 0.5s;
+  transition: width 0.5s;
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-moz-progress-bar {
+  background-color: #288be4;
+}
+
+.emotion-0 progress::-ms-fill {
+  background-color: #288be4;
+}
+
+.emotion-0 span {
+  font-style: italic;
+}
+
 <div
   style={
     Object {
@@ -2928,7 +4079,7 @@ exports[`Storyshots ProgressBar with task name 1`] = `
   }
 >
   <div
-    className="css-v8ihoq"
+    className="emotion-0"
   >
     <progress
       aria-valuemax={5}
@@ -3520,7 +4671,16 @@ Array [
       }
     }
   />,
-  <div
+  .emotion-1 {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.emotion-0 {
+  color: #d22d23;
+}
+
+<div
     className="mn--full-ie"
   >
     <div
@@ -3649,7 +4809,7 @@ Array [
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 emotion-1"
       >
         <ul
           className="brc-l"
@@ -3703,7 +4863,7 @@ Array [
           >
             <a
               aria-current="page"
-              className="css-udegvj"
+              className="emotion-0"
               href="#"
             >
               Registry
@@ -3836,7 +4996,16 @@ Array [
       }
     }
   />,
-  <div
+  .emotion-1 {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.emotion-0 {
+  color: #d22d23;
+}
+
+<div
     className="mn--full-ie"
   >
     <div
@@ -3914,7 +5083,7 @@ Array [
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 emotion-1"
         >
           <ul
             className="brc-l"
@@ -3968,7 +5137,7 @@ Array [
             >
               <a
                 aria-current="page"
-                className="css-udegvj"
+                className="emotion-0"
                 href="#"
               >
                 Registry
@@ -4036,9 +5205,18 @@ Array [
 `;
 
 exports[`Storyshots UI|Navigation/BreadcrumbNav several levels deep 1`] = `
+.emotion-1 {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.emotion-0 {
+  color: #d22d23;
+}
+
 <nav
   aria-label="Breadcrumbs"
-  className="brc css-1bakzg2 undefined"
+  className="brc undefined emotion-1"
 >
   <ul
     className="brc-l"
@@ -4114,7 +5292,7 @@ exports[`Storyshots UI|Navigation/BreadcrumbNav several levels deep 1`] = `
     >
       <a
         aria-current="page"
-        className="css-udegvj"
+        className="emotion-0"
         href="/death"
       >
         Death Certificates
@@ -4125,9 +5303,18 @@ exports[`Storyshots UI|Navigation/BreadcrumbNav several levels deep 1`] = `
 `;
 
 exports[`Storyshots UI|Navigation/BreadcrumbNav single level 1`] = `
+.emotion-1 {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.emotion-0 {
+  color: #d22d23;
+}
+
 <nav
   aria-label="Breadcrumbs"
-  className="brc css-1bakzg2 undefined"
+  className="brc undefined emotion-1"
 >
   <ul
     className="brc-l"
@@ -4159,7 +5346,7 @@ exports[`Storyshots UI|Navigation/BreadcrumbNav single level 1`] = `
     >
       <a
         aria-current="page"
-        className="css-udegvj"
+        className="emotion-0"
         href="/death"
       >
         Death Certificates

--- a/modules-js/react-fleet/src/components/ProgressBar.tsx
+++ b/modules-js/react-fleet/src/components/ProgressBar.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-
-import { css } from 'emotion';
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 
 import { CHARLES_BLUE, OPTIMISTIC_BLUE_LIGHT } from '../utilities/constants';
 
@@ -34,7 +33,7 @@ export default function ProgressBar(props: Props): JSX.Element {
   }
 
   return (
-    <div className={PROGRESS_BAR_STYLE}>
+    <div css={PROGRESS_BAR_STYLE}>
       <progress
         max={totalSteps}
         aria-valuemin={1}

--- a/modules-js/react-fleet/src/components/StatusModal.tsx
+++ b/modules-js/react-fleet/src/components/StatusModal.tsx
@@ -1,7 +1,9 @@
+/** @jsx jsx */
+
 import React, { ReactNode, ReactNodeArray, MouseEvent } from 'react';
 import ReactDOM from 'react-dom';
 
-import { css } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 // todo: look at Fin’s latest status modal work in access-boston
 // todo: add an error state (i.e. red text, “error” label)
@@ -61,8 +63,8 @@ export default class StatusModal extends React.Component<Props> {
     const alertHolder = document.getElementById(StatusModal.ALERT_CONTAINER_ID);
 
     const alertContent = (
-      <div className={`md ${waiting ? WAITING_MODAL_STYLE : ''}`}>
-        <div className={`md-c br br-t400 ${MODAL_STYLE}`}>
+      <div className="md" css={waiting && WAITING_MODAL_STYLE}>
+        <div className="md-c br br-t400" css={MODAL_STYLE}>
           <div className="md-b p-a300">
             <div className={`t--intro ${error ? 't--err' : ''}`}>{message}</div>
 

--- a/modules-js/react-fleet/src/form-elements/UploadPhoto.stories.tsx
+++ b/modules-js/react-fleet/src/form-elements/UploadPhoto.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+/** @jsx jsx */
+
 import { storiesOf } from '@storybook/react';
 
-import { css } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import { BLACK, OPTIMISTIC_BLUE_LIGHT, WHITE } from '../utilities/constants';
 
@@ -62,7 +63,7 @@ const SVG_BITS = [
 ];
 
 const ID_IMAGE: JSX.Element = (
-  <header className={ID_IMAGE_STYLING}>
+  <header css={ID_IMAGE_STYLING}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 181 134"

--- a/modules-js/react-fleet/src/form-elements/UploadPhoto.tsx
+++ b/modules-js/react-fleet/src/form-elements/UploadPhoto.tsx
@@ -1,7 +1,8 @@
+/** @jsx jsx */
 import React from 'react';
 import Dropzone from 'react-dropzone';
 
-import { css } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import {
   FREEDOM_RED_DARK,
@@ -162,14 +163,15 @@ export default class UploadPhoto extends React.Component<Props, State> {
           onDrop={this.onDrop}
         >
           {({ getRootProps, getInputProps, isDragActive }) => (
-            <div {...getRootProps()} className={INPUT_CONTAINER_FOCUS_STYLING}>
+            <div {...getRootProps()} css={INPUT_CONTAINER_FOCUS_STYLING}>
               <input {...getInputProps()} />
 
               <div
                 ref={this.previewRef}
-                className={`${PREVIEW_CONTAINER_STYLING} ${
-                  isDragActive ? DRAG_RING_STYLING : ''
-                }`}
+                css={[
+                  PREVIEW_CONTAINER_STYLING,
+                  isDragActive && DRAG_RING_STYLING,
+                ]}
               >
                 {/* We keep the background element in the flow to preserve height / width */}
                 <div style={{ visibility: previewUrl ? 'hidden' : 'visible' }}>
@@ -178,7 +180,7 @@ export default class UploadPhoto extends React.Component<Props, State> {
 
                 {previewUrl && (
                   <div
-                    className={PREVIEW_IMAGE_STYLING}
+                    css={PREVIEW_IMAGE_STYLING}
                     style={{
                       backgroundImage: `url(${previewUrl})`,
                     }}
@@ -191,9 +193,8 @@ export default class UploadPhoto extends React.Component<Props, State> {
 
         <div className="br br-t200" style={{ position: 'relative' }}>
           <button
-            className={`btn btn--w btn--b ${BUTTON_FOCUS_STYLING} ${
-              isUploading ? 'btn--r-hov' : ''
-            } ${hasError ? ERROR_MESSAGE_STYLING : ''}`}
+            className={`btn btn--w btn--b ${isUploading ? 'btn--r-hov' : ''}`}
+            css={[BUTTON_FOCUS_STYLING, hasError && ERROR_MESSAGE_STYLING]}
             style={{ width: '100%' }}
             type="button"
             onClick={this.handleButtonClick}
@@ -203,7 +204,7 @@ export default class UploadPhoto extends React.Component<Props, State> {
 
           {!!isUploading && (
             <div
-              className={PROGRESS_STYLING}
+              css={PROGRESS_STYLING}
               style={{ width: `${uploadProgress}%` }}
             />
           )}
@@ -218,7 +219,7 @@ export default class UploadPhoto extends React.Component<Props, State> {
  */
 function defaultInitialAppearance(): JSX.Element {
   return (
-    <div className={DEFAULT_IMAGE_STYLING}>
+    <div css={DEFAULT_IMAGE_STYLING}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 22 144 100"

--- a/modules-js/react-fleet/src/form-elements/buttons/CloseButton.tsx
+++ b/modules-js/react-fleet/src/form-elements/buttons/CloseButton.tsx
@@ -1,20 +1,21 @@
-import React from 'react';
-import { css } from 'emotion';
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/core';
 
 import { FREEDOM_RED_DARK } from '../../utilities/constants';
 
-const STYLES = css(`
+const STYLES = css`
   border: none;
   background-color: transparent;
   cursor: pointer;
   padding: 0;
   opacity: 0.8;
   transition: opacity 0.15s;
-  
+
   &:hover {
     opacity: 1;
   }
-`);
+`;
 
 const DEFAULT_SIZE = '48px';
 
@@ -33,7 +34,8 @@ export default function CloseButton(props: Props): JSX.Element {
       type="button"
       title={props.title || 'Close'}
       onClick={props.handleClick}
-      className={`${STYLES} ${props.className}`}
+      className={props.className}
+      css={STYLES}
       style={{
         width: size,
         height: size,

--- a/modules-js/react-fleet/src/form-elements/inputs/FileInput.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/FileInput.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
-import { css } from 'emotion';
+/** @jsx jsx */
 
-import { VISUALLYHIDDEN } from '../../utilities/css';
+import React from 'react';
+import { css, jsx, ClassNames } from '@emotion/core';
+
+import { VISUALLY_HIDDEN } from '../../utilities/css';
 
 import { MEDIA_SMALL, FOCUS_INDICATOR_COLOR } from '../../utilities/constants';
 
@@ -25,7 +27,7 @@ interface FileSize {
   unit: 'B' | 'KB' | 'MB' | 'GB';
 }
 
-const INPUT_CONTAINER_STYLE = css(`
+const INPUT_CONTAINER_STYLE = css`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -33,7 +35,7 @@ const INPUT_CONTAINER_STYLE = css(`
   ${MEDIA_SMALL} {
     flex-wrap: nowrap;
   }
-  
+
   label {
     margin-bottom: 0.5em;
 
@@ -41,16 +43,16 @@ const INPUT_CONTAINER_STYLE = css(`
       margin-bottom: 0;
     }
   }
-  
+
   div {
     flex-basis: 80%;
-        
+
     ${MEDIA_SMALL} {
       flex-basis: auto;
       padding-left: 1em;
     }
   }
-`);
+`;
 
 const LABEL_FOCUSED_STYLE = css({
   outline: `3px solid ${FOCUS_INDICATOR_COLOR}`,
@@ -171,10 +173,12 @@ Your file is ${fileSize.amount.toFixed(2) + fileSize.unit}. Please select a diff
   };
 
   render() {
+    const { selectedFile, isFocused } = this.state;
+
     return (
-      <div className={`txt m-b300 ${INPUT_CONTAINER_STYLE}`}>
+      <div className="txt m-b300" css={INPUT_CONTAINER_STYLE}>
         <input
-          className={VISUALLYHIDDEN}
+          css={VISUALLY_HIDDEN}
           ref={this.inputRef}
           type="file"
           accept={this.fileTypesString(this.props.fileTypes)}
@@ -187,28 +191,30 @@ Your file is ${fileSize.amount.toFixed(2) + fileSize.unit}. Please select a diff
 
         <label
           htmlFor={`FileInput-${this.props.name}`}
-          className={`btn btn--sm btn--100 ${this.state.isFocused &&
-            LABEL_FOCUSED_STYLE}`}
+          className="btn btn--sm btn--100"
+          css={isFocused && LABEL_FOCUSED_STYLE}
           style={{ whiteSpace: 'nowrap', fontWeight: 'bold' }}
         >
           Choose {this.props.title} file
         </label>
 
-        <div className={FILE_PREVIEW_STYLE}>
-          <span title={this.state.selectedFile ? 'Selected file: ' : undefined}>
-            {this.state.selectedFile
-              ? this.state.selectedFile.name
-              : DEFAULT_PREVIEW_TEXT}
+        <div css={FILE_PREVIEW_STYLE}>
+          <span title={selectedFile ? 'Selected file: ' : undefined}>
+            {selectedFile ? selectedFile.name : DEFAULT_PREVIEW_TEXT}
           </span>
         </div>
 
-        {this.state.selectedFile && (
-          <CloseButton
-            className={DELETE_BUTTON_STYLE}
-            size="1.8em"
-            title={`Remove file: ${this.state.selectedFile.name}`}
-            handleClick={this.clearFile}
-          />
+        {selectedFile && (
+          <ClassNames>
+            {({ css }) => (
+              <CloseButton
+                className={css(DELETE_BUTTON_STYLE)}
+                size="1.8em"
+                title={`Remove file: ${selectedFile.name}`}
+                handleClick={this.clearFile}
+              />
+            )}
+          </ClassNames>
         )}
       </div>
     );

--- a/modules-js/react-fleet/src/form-elements/inputs/MemorableDateInput.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/MemorableDateInput.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+/** @jsx jsx */
 
-import { css } from 'emotion';
+import React from 'react';
+import { css, jsx } from '@emotion/core';
 
 type Fields = {
   year: string;
@@ -226,10 +227,10 @@ export default class MemorableDateInput extends React.Component<Props, State> {
     const error = this.currentError();
 
     return (
-      <fieldset className={FIELDSET_STYLING}>
+      <fieldset css={FIELDSET_STYLING}>
         <legend style={{ width: '100%' }}>{this.props.legend}</legend>
 
-        <div className={FIELDS_CONTAINER_STYLING}>
+        <div css={FIELDS_CONTAINER_STYLING}>
           <div>
             <label htmlFor={`${this.componentId}-month`} className="txt-l">
               Month

--- a/modules-js/react-fleet/src/navigation/BreadcrumbNav.tsx
+++ b/modules-js/react-fleet/src/navigation/BreadcrumbNav.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { css } from 'emotion';
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 
 import { FREEDOM_RED_DARK } from '../utilities/constants';
 
@@ -42,7 +42,8 @@ export default function BreadcrumbNav(props: Props): JSX.Element {
 
   return (
     <nav
-      className={`brc ${ADJUST_NAV_STYLE} ${props.className}`}
+      className={`brc ${props.className}`}
+      css={ADJUST_NAV_STYLE}
       aria-label="Breadcrumbs"
     >
       <ul className="brc-l">
@@ -63,7 +64,7 @@ export default function BreadcrumbNav(props: Props): JSX.Element {
         <li className="brc-l-i">
           <a
             href={props.currentPage.url}
-            className={LAST_BREADCRUMB_STYLE}
+            css={LAST_BREADCRUMB_STYLE}
             aria-current="page"
           >
             {props.currentPage.text}

--- a/modules-js/react-fleet/src/sectioning-elements/CollapsibleSection.tsx
+++ b/modules-js/react-fleet/src/sectioning-elements/CollapsibleSection.tsx
@@ -1,6 +1,8 @@
+/** @jsx jsx */
+
 import React, { ReactNode, ReactNodeArray } from 'react';
 
-import { css } from 'emotion';
+import { css, jsx } from '@emotion/core';
 import hash from 'string-hash';
 
 import {
@@ -132,7 +134,7 @@ export default class CollapsibleSection extends React.Component<Props, State> {
       return (
         <button
           type="button"
-          className={BUTTON_STYLING}
+          css={BUTTON_STYLING}
           aria-expanded={this.state.expanded}
           onClick={this.toggleExpanded}
         >
@@ -167,7 +169,8 @@ export default class CollapsibleSection extends React.Component<Props, State> {
     const id = `collapsiblesection-${hash(this.props.title)}`;
 
     const headerAttributes = {
-      className: `sh-title ${HEADER_STYLING}`,
+      className: 'sh-title',
+      css: HEADER_STYLING,
     };
 
     // We use aria-label for the region so that we can give the <button> a label

--- a/modules-js/react-fleet/src/utilities/css.ts
+++ b/modules-js/react-fleet/src/utilities/css.ts
@@ -1,7 +1,7 @@
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 // https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements
-export const VISUALLYHIDDEN = css({
+export const VISUALLY_HIDDEN = css({
   border: 0,
   clip: 'rect(0 0 0 0)',
   height: '1px',

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@yarnpkg/lockfile": "^1.0.0",
     "eslint": "^4.19.1",
+    "eslint-plugin-emotion": "^10.0.7",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react-hooks": "^1.5.0",

--- a/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -913,7 +913,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         Files must be PDFs and under 5MB each in size.
       </p>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -926,7 +926,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-coverLetter"
           style={
             Object {
@@ -948,7 +948,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         </div>
       </div>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -961,7 +961,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-resume"
           style={
             Object {
@@ -1916,7 +1916,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         Files must be PDFs and under 5MB each in size.
       </p>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -1929,7 +1929,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-coverLetter"
           style={
             Object {
@@ -1951,7 +1951,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         </div>
       </div>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -1964,7 +1964,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-resume"
           style={
             Object {
@@ -2954,7 +2954,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         Files must be PDFs and under 5MB each in size.
       </p>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -2967,7 +2967,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-coverLetter"
           style={
             Object {
@@ -2989,7 +2989,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </div>
       </div>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -3002,7 +3002,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-resume"
           style={
             Object {
@@ -3957,7 +3957,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         Files must be PDFs and under 5MB each in size.
       </p>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -3970,7 +3970,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-coverLetter"
           style={
             Object {
@@ -3992,7 +3992,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         </div>
       </div>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -4005,7 +4005,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-resume"
           style={
             Object {
@@ -4044,7 +4044,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
       Submit Application
     </button>
     <div
-      className="md "
+      className="md"
     >
       <div
         className="md-c br br-t400 css-1y2scv5"
@@ -5001,7 +5001,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         Files must be PDFs and under 5MB each in size.
       </p>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -5014,7 +5014,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-coverLetter"
           style={
             Object {
@@ -5036,7 +5036,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         </div>
       </div>
       <div
-        className="txt m-b300 css-1mxs0p5"
+        className="txt m-b300 css-60uf05"
       >
         <input
           accept="application/pdf"
@@ -5049,7 +5049,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           type="file"
         />
         <label
-          className="btn btn--sm btn--100 false"
+          className="btn btn--sm btn--100 css-0"
           htmlFor="FileInput-resume"
           style={
             Object {
@@ -6203,7 +6203,7 @@ Array [
                   Files must be PDFs and under 5MB each in size.
                 </p>
                 <div
-                  className="txt m-b300 css-1mxs0p5"
+                  className="txt m-b300 css-60uf05"
                 >
                   <input
                     accept="application/pdf"
@@ -6216,7 +6216,7 @@ Array [
                     type="file"
                   />
                   <label
-                    className="btn btn--sm btn--100 false"
+                    className="btn btn--sm btn--100 css-0"
                     htmlFor="FileInput-coverLetter"
                     style={
                       Object {
@@ -6238,7 +6238,7 @@ Array [
                   </div>
                 </div>
                 <div
-                  className="txt m-b300 css-1mxs0p5"
+                  className="txt m-b300 css-60uf05"
                 >
                   <input
                     accept="application/pdf"
@@ -6251,7 +6251,7 @@ Array [
                     type="file"
                   />
                   <label
-                    className="btn btn--sm btn--100 false"
+                    className="btn btn--sm btn--100 css-0"
                     htmlFor="FileInput-resume"
                     style={
                       Object {

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -145,7 +145,7 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -653,7 +653,7 @@ exports[`Storyshots Birth/CheckoutPage no birth certificate request 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -952,7 +952,7 @@ exports[`Storyshots Birth/CheckoutPage payment 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -1511,7 +1511,7 @@ exports[`Storyshots Birth/CheckoutPage review 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -2168,7 +2168,7 @@ exports[`Storyshots Birth/CheckoutPage server-side render 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -2450,7 +2450,7 @@ exports[`Storyshots Birth/CheckoutPage shipping 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -7105,7 +7105,7 @@ exports[`Storyshots Birth/Question Components/RadioItemComponent multiple answer
       }
     >
       <label
-        className="css-ksygmh undefined  "
+        className="css-ksygmh   "
       >
         <svg
           style={
@@ -7159,7 +7159,7 @@ exports[`Storyshots Birth/Question Components/RadioItemComponent multiple answer
       }
     >
       <label
-        className="css-ksygmh undefined  "
+        className="css-ksygmh   "
       >
         <svg
           style={
@@ -7213,7 +7213,7 @@ exports[`Storyshots Birth/Question Components/RadioItemComponent multiple answer
       }
     >
       <label
-        className="css-ksygmh undefined  "
+        className="css-ksygmh   "
       >
         <svg
           style={
@@ -7273,7 +7273,7 @@ exports[`Storyshots Birth/Question Components/RadioItemComponent single item 1`]
     }
   >
     <label
-      className="css-ksygmh undefined selected "
+      className="css-ksygmh  selected "
     >
       <svg
         style={
@@ -7382,7 +7382,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
             value={70}
           />
           <button
-            className="css-14581tj css-1jem7y3"
+            className="css-1jem7y3 css-itjkxp"
             onClick={[Function]}
             style={
               Object {
@@ -7450,7 +7450,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
           </span>
         </span>
         <button
-          className="css-14581tj css-1jem7y3"
+          className="css-1jem7y3 css-itjkxp"
           onClick={[Function]}
           style={
             Object {
@@ -7722,7 +7722,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput documents
           </span>
         </span>
         <button
-          className="css-14581tj css-1jem7y3"
+          className="css-1jem7y3 css-itjkxp"
           onClick={[Function]}
           style={
             Object {
@@ -7840,7 +7840,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput documents
             value={23}
           />
           <button
-            className="css-14581tj css-1jem7y3"
+            className="css-1jem7y3 css-itjkxp"
             onClick={[Function]}
             style={
               Object {
@@ -8206,7 +8206,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification default 1`] =
                 type="file"
               />
               <div
-                className="css-18dy1p4 "
+                className="css-18dy1p4"
               >
                 <div
                   style={
@@ -8283,7 +8283,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification default 1`] =
               }
             >
               <button
-                className="btn btn--w btn--b css-cavyyu  "
+                className="btn btn--w btn--b  css-cavyyu"
                 onClick={[Function]}
                 style={
                   Object {
@@ -8331,7 +8331,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification default 1`] =
                 type="file"
               />
               <div
-                className="css-18dy1p4 "
+                className="css-18dy1p4"
               >
                 <div
                   style={
@@ -8425,7 +8425,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification default 1`] =
               }
             >
               <button
-                className="btn btn--w btn--b css-cavyyu  "
+                className="btn btn--w btn--b  css-cavyyu"
                 onClick={[Function]}
                 style={
                   Object {
@@ -8668,7 +8668,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification existing imag
                 type="file"
               />
               <div
-                className="css-18dy1p4 "
+                className="css-18dy1p4"
               >
                 <div
                   style={
@@ -8753,7 +8753,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification existing imag
               }
             >
               <button
-                className="btn btn--w btn--b css-cavyyu  "
+                className="btn btn--w btn--b  css-cavyyu"
                 onClick={[Function]}
                 style={
                   Object {
@@ -8801,7 +8801,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification existing imag
                 type="file"
               />
               <div
-                className="css-18dy1p4 "
+                className="css-18dy1p4"
               >
                 <div
                   style={
@@ -8895,7 +8895,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification existing imag
               }
             >
               <button
-                className="btn btn--w btn--b css-cavyyu  "
+                className="btn btn--w btn--b  css-cavyyu"
                 onClick={[Function]}
                 style={
                   Object {
@@ -8976,7 +8976,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification existing imag
                   </span>
                 </span>
                 <button
-                  className="css-14581tj css-1jem7y3"
+                  className="css-1jem7y3 css-itjkxp"
                   onClick={[Function]}
                   style={
                     Object {
@@ -9043,7 +9043,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification existing imag
                   </span>
                 </span>
                 <button
-                  className="css-14581tj css-1jem7y3"
+                  className="css-1jem7y3 css-itjkxp"
                   onClick={[Function]}
                   style={
                     Object {
@@ -9270,7 +9270,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification reloaded imag
               type="file"
             />
             <div
-              className="css-18dy1p4 "
+              className="css-18dy1p4"
             >
               <div
                 style={
@@ -9355,7 +9355,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification reloaded imag
             }
           >
             <button
-              className="btn btn--w btn--b css-cavyyu  "
+              className="btn btn--w btn--b  css-cavyyu"
               onClick={[Function]}
               style={
                 Object {
@@ -9403,7 +9403,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification reloaded imag
               type="file"
             />
             <div
-              className="css-18dy1p4 "
+              className="css-18dy1p4"
             >
               <div
                 style={
@@ -9497,7 +9497,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification reloaded imag
             }
           >
             <button
-              className="btn btn--w btn--b css-cavyyu  "
+              className="btn btn--w btn--b  css-cavyyu"
               onClick={[Function]}
               style={
                 Object {
@@ -9578,7 +9578,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification reloaded imag
                 </span>
               </span>
               <button
-                className="css-14581tj css-1jem7y3"
+                className="css-1jem7y3 css-itjkxp"
                 onClick={[Function]}
                 style={
                   Object {
@@ -9645,7 +9645,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification reloaded imag
                 </span>
               </span>
               <button
-                className="css-14581tj css-1jem7y3"
+                className="css-1jem7y3 css-itjkxp"
                 onClick={[Function]}
                 style={
                   Object {
@@ -9874,7 +9874,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification upload error 
                 type="file"
               />
               <div
-                className="css-18dy1p4 "
+                className="css-18dy1p4"
               >
                 <div
                   style={
@@ -9959,7 +9959,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification upload error 
               }
             >
               <button
-                className="btn btn--w btn--b css-cavyyu  css-udegvj"
+                className="btn btn--w btn--b  css-jqpn3w"
                 onClick={[Function]}
                 style={
                   Object {
@@ -10007,7 +10007,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification upload error 
                 type="file"
               />
               <div
-                className="css-18dy1p4 "
+                className="css-18dy1p4"
               >
                 <div
                   style={
@@ -10101,7 +10101,7 @@ exports[`Storyshots Birth/Question Components/VerifyIdentification upload error 
               }
             >
               <button
-                className="btn btn--w btn--b css-cavyyu  "
+                className="btn btn--w btn--b  css-cavyyu"
                 onClick={[Function]}
                 style={
                   Object {
@@ -10616,7 +10616,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 1. Who is this for? 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -11054,7 +11054,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 1a. Client instructions 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -11457,7 +11457,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 2. Born in Boston? 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -11953,7 +11953,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 3. Personal information 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -12543,7 +12543,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 4. Parental information 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -13242,7 +13242,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 5. Identity verification 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -13461,7 +13461,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 5. Identity verification 1`] = `
                         type="file"
                       />
                       <div
-                        className="css-18dy1p4 "
+                        className="css-18dy1p4"
                       >
                         <div
                           style={
@@ -13538,7 +13538,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 5. Identity verification 1`] = `
                       }
                     >
                       <button
-                        className="btn btn--w btn--b css-cavyyu  "
+                        className="btn btn--w btn--b  css-cavyyu"
                         onClick={[Function]}
                         style={
                           Object {
@@ -13586,7 +13586,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 5. Identity verification 1`] = `
                         type="file"
                       />
                       <div
-                        className="css-18dy1p4 "
+                        className="css-18dy1p4"
                       >
                         <div
                           style={
@@ -13680,7 +13680,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 5. Identity verification 1`] = `
                       }
                     >
                       <button
-                        className="btn btn--w btn--b css-cavyyu  "
+                        className="btn btn--w btn--b  css-cavyyu"
                         onClick={[Function]}
                         style={
                           Object {
@@ -14010,7 +14010,7 @@ exports[`Storyshots Birth/ReviewRequestPage default page 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -14147,7 +14147,7 @@ exports[`Storyshots Birth/ReviewRequestPage default page 1`] = `
               <button
                 aria-controls="detailsContent"
                 aria-expanded={false}
-                className="css-1ujbbbr"
+                className="css-1mv5oyt-ApostilleRequestInstructions"
                 onClick={[Function]}
                 type="button"
               >
@@ -14677,7 +14677,7 @@ exports[`Storyshots Checkout/CheckoutPage server-side render 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -14967,7 +14967,7 @@ exports[`Storyshots Checkout/ConfirmationContent default 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -15318,7 +15318,7 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -16110,7 +16110,7 @@ exports[`Storyshots Checkout/PaymentContent Stripe error 1`] = `
               </div>
             </fieldset>
             <div
-              className="md "
+              className="md"
             >
               <div
                 className="md-c br br-t400 css-1y2scv5"
@@ -16359,7 +16359,7 @@ exports[`Storyshots Checkout/PaymentContent ZIP code error 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -17359,7 +17359,7 @@ exports[`Storyshots Checkout/PaymentContent birth certificates 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -18397,7 +18397,7 @@ exports[`Storyshots Checkout/PaymentContent credit card error 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -18922,7 +18922,7 @@ exports[`Storyshots Checkout/PaymentContent default 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -19443,7 +19443,7 @@ exports[`Storyshots Checkout/PaymentContent existing billing 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -20443,7 +20443,7 @@ exports[`Storyshots Checkout/ReviewContent birth certificate 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -21100,7 +21100,7 @@ exports[`Storyshots Checkout/ReviewContent cart has pending certs 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -21876,7 +21876,7 @@ exports[`Storyshots Checkout/ReviewContent default 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -22569,7 +22569,7 @@ exports[`Storyshots Checkout/ReviewContent empty cart 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -23193,7 +23193,7 @@ exports[`Storyshots Checkout/ReviewContent invalid order 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -23857,7 +23857,7 @@ exports[`Storyshots Checkout/ReviewContent payment error 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -24322,7 +24322,7 @@ exports[`Storyshots Checkout/ReviewContent payment error 1`] = `
               Pressing the “Submit Order” button will charge the total amount to your card and place an order with the Registry.
             </div>
             <div
-              className="md "
+              className="md"
             >
               <div
                 className="md-c br br-t400 css-1y2scv5"
@@ -24584,7 +24584,7 @@ exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -25049,7 +25049,7 @@ exports[`Storyshots Checkout/ReviewContent submission error 1`] = `
               Pressing the “Submit Order” button will charge the total amount to your card and place an order with the Registry.
             </div>
             <div
-              className="md "
+              className="md"
             >
               <div
                 className="md-c br br-t400 css-1y2scv5"
@@ -25318,7 +25318,7 @@ exports[`Storyshots Checkout/ReviewContent submitting 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -25783,7 +25783,7 @@ exports[`Storyshots Checkout/ReviewContent submitting 1`] = `
               Pressing the “Submit Order” button will charge the total amount to your card and place an order with the Registry.
             </div>
             <div
-              className="md "
+              className="md"
             >
               <div
                 className="md-c br br-t400 css-1y2scv5"
@@ -26033,7 +26033,7 @@ exports[`Storyshots Checkout/ShippingContent birth certificate 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -27061,7 +27061,7 @@ exports[`Storyshots Checkout/ShippingContent default 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -28051,7 +28051,7 @@ exports[`Storyshots Checkout/ShippingContent email error 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -29041,7 +29041,7 @@ exports[`Storyshots Checkout/ShippingContent existing address 1`] = `
       >
         <nav
           aria-label="Breadcrumbs"
-          className="brc css-1bakzg2 p-a300"
+          className="brc p-a300 css-1bakzg2"
         >
           <ul
             className="brc-l"
@@ -31738,7 +31738,7 @@ exports[`Storyshots Death/CartPage empty cart 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -32076,7 +32076,7 @@ exports[`Storyshots Death/CartPage loading 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -32580,7 +32580,7 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -33216,7 +33216,7 @@ exports[`Storyshots Death/CertificatePage certificate in cart 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -33755,7 +33755,7 @@ exports[`Storyshots Death/CertificatePage missing certificate 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -34115,7 +34115,7 @@ exports[`Storyshots Death/CertificatePage normal certificate 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -34644,7 +34644,7 @@ exports[`Storyshots Death/CertificatePage normal certificate — not from search
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -35173,7 +35173,7 @@ exports[`Storyshots Death/CertificatePage pending certificate 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -36000,7 +36000,7 @@ exports[`Storyshots Death/SearchPage no results 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -36395,7 +36395,7 @@ exports[`Storyshots Death/SearchPage no search 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"
@@ -36779,7 +36779,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
       </nav>
       <nav
         aria-label="Breadcrumbs"
-        className="brc css-1bakzg2 p-a300"
+        className="brc p-a300 css-1bakzg2"
       >
         <ul
           className="brc-l"

--- a/services-js/registry-certs/client/birth/components/ApostilleRequestInstructions.tsx
+++ b/services-js/registry-certs/client/birth/components/ApostilleRequestInstructions.tsx
@@ -1,6 +1,9 @@
+/** @jsx jsx */
+
 import React, { useEffect, useState } from 'react';
 
 import { css } from 'emotion';
+import { jsx } from '@emotion/core';
 
 import {
   CLEAR_DEFAULT_STYLING,
@@ -43,7 +46,7 @@ export default function ApostilleRequestInstructions(): JSX.Element {
       <aside className={FALLBACK_STYLING}>
         <button
           type="button"
-          className={CLEAR_DEFAULT_STYLING.BUTTON}
+          css={CLEAR_DEFAULT_STYLING.BUTTON}
           aria-expanded={isOpen}
           aria-controls="detailsContent"
           onClick={toggleIsOpen}

--- a/services-js/registry-certs/client/birth/components/RadioItemComponent.tsx
+++ b/services-js/registry-certs/client/birth/components/RadioItemComponent.tsx
@@ -6,7 +6,7 @@ import {
   GRAY_100,
   MEDIA_MEDIUM,
   SANS,
-  VISUALLYHIDDEN,
+  VISUALLY_HIDDEN,
 } from '@cityofboston/react-fleet';
 
 import { BORDER_STYLE, FOCUS_STYLE } from '../styling';
@@ -47,7 +47,7 @@ export default function RadioItemComponent(props: Props): JSX.Element {
 
   return (
     <label
-      className={`${RADIOITEM_STYLING} ${props.className} ${
+      className={`${RADIOITEM_STYLING} ${props.className || ''} ${
         hasAnswered && itemValue === questionValue ? 'selected' : ''
       } ${hasAnswered && itemValue !== questionValue ? 'inactive' : ''}`}
     >
@@ -81,7 +81,7 @@ const RADIOITEM_STYLING = css({
 
   transition: 'opacity 0.2s',
 
-  input: VISUALLYHIDDEN,
+  input: VISUALLY_HIDDEN,
 
   'input:focus + span': {
     ...FOCUS_STYLE,

--- a/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.tsx
+++ b/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.tsx
@@ -1,4 +1,6 @@
+/** @jsx jsx */
 import React from 'react';
+import { jsx } from '@emotion/core';
 import { css } from 'emotion';
 
 // todo: prevent next/back while uploads pending
@@ -9,7 +11,7 @@ import {
   ERROR_TEXT_COLOR,
   FOCUS_INDICATOR_COLOR,
   OPTIMISTIC_BLUE_LIGHT,
-  VISUALLYHIDDEN,
+  VISUALLY_HIDDEN,
   MEDIA_SMALL,
   SERIF,
 } from '@cityofboston/react-fleet';
@@ -162,7 +164,7 @@ ${file.name} is ${fileSize.amount.toFixed(2) +
     return (
       <div className="m-b300">
         <input
-          className={VISUALLYHIDDEN}
+          css={VISUALLY_HIDDEN}
           ref={this.inputRef}
           type="file"
           accept={this.props.acceptTypes}

--- a/services-js/registry-certs/client/common/CostSummary.tsx
+++ b/services-js/registry-certs/client/common/CostSummary.tsx
@@ -1,7 +1,10 @@
+/** @jsx jsx */
+
 import React from 'react';
 import { css } from 'emotion';
+import { jsx } from '@emotion/core';
 
-import { VISUALLYHIDDEN } from '@cityofboston/react-fleet';
+import { VISUALLY_HIDDEN } from '@cityofboston/react-fleet';
 
 import {
   calculateCreditCardCost,
@@ -80,8 +83,8 @@ export default class CostSummary extends React.Component<Props, State> {
     return (
       <div className={CLEARFIX_STYLE}>
         <table className="t--info ta-r" style={{ float: 'right' }}>
-          <caption className={VISUALLYHIDDEN}>Cost Summary</caption>
-          <thead className={VISUALLYHIDDEN}>
+          <caption css={VISUALLY_HIDDEN}>Cost Summary</caption>
+          <thead css={VISUALLY_HIDDEN}>
             <tr>
               <th scope="col">Item</th>
               <th scope="col">Amount</th>

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,11 +120,12 @@
     "@babel/helper-explode-assignable-expression" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-builder-react-jsx@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz#fa154cb53eb918cf2a9a7ce928e29eb649c5acdb"
+"@babel/helper-builder-react-jsx@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz#a1ac95a5d2b3e88ae5e54846bf462eeb81b318a4"
+  integrity sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.3.0"
     esutils "^2.0.0"
 
 "@babel/helper-call-delegate@^7.4.0":
@@ -451,9 +452,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-jsx@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz#034d5e2b4e14ccaea2e4c137af7e4afb39375ffd"
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz#0b85a3b4bc7cdf4cc4b8bf236335b907ca22e7c7"
+  integrity sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -471,9 +473,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-typescript@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.0.0.tgz#90f4fe0a741ae9c0dcdc3017717c05a0cbbd5158"
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz#a7cc3f66119a9f7ebe2de5383cce193473d65991"
+  integrity sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -735,12 +738,13 @@
     "@babel/plugin-syntax-jsx" "^7.0.0"
 
 "@babel/plugin-transform-react-jsx@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz#524379e4eca5363cd10c4446ba163f093da75f3e"
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz#f2cab99026631c767e2745a5368b331cfe8f5290"
+  integrity sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
   dependencies:
-    "@babel/helper-builder-react-jsx" "^7.0.0"
+    "@babel/helper-builder-react-jsx" "^7.3.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-jsx" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.2.0"
 
 "@babel/plugin-transform-regenerator@^7.0.0", "@babel/plugin-transform-regenerator@^7.4.3":
   version "7.4.3"
@@ -820,12 +824,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typescript@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.1.0.tgz#81e7b4be90e7317cbd04bf1163ebf06b2adee60b"
+"@babel/plugin-transform-typescript@^7.1.0", "@babel/plugin-transform-typescript@^7.3.2":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.4.tgz#93e9c3f2a546e6d3da1e9cc990e30791b807aa9f"
+  integrity sha512-rwDvjaMTx09WC0rXGBRlYSSkEHOKRrecY6hEr3SVIPKII8DVWXtapNAfAyMC0dovuO+zYArcAuKeu3q9DNRfzA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-typescript" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
 
 "@babel/plugin-transform-unicode-regex@^7.0.0", "@babel/plugin-transform-unicode-regex@^7.2.0", "@babel/plugin-transform-unicode-regex@^7.4.3":
   version "7.4.3"
@@ -1016,6 +1021,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
+"@babel/preset-typescript@^7.3.2":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz#88669911053fa16b2b276ea2ede2ca603b3f307a"
+  integrity sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.3.2"
+
 "@babel/register@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
@@ -1106,10 +1119,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.2.2", "@babel/types@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.0.tgz#670724f77d24cce6cc7d8cf64599d511d164894c"
-  integrity sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==
+"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.4.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
@@ -2710,6 +2723,11 @@
   integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/jest@^23.0.2":
+  version "23.3.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
+  integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
 "@types/joi@*":
   version "13.0.8"
@@ -6984,7 +7002,7 @@ css-what@2.1, css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css@2.2.3:
+css@2.2.3, css@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
   dependencies:
@@ -8174,6 +8192,11 @@ eslint-module-utils@^2.2.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
+
+eslint-plugin-emotion@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-emotion/-/eslint-plugin-emotion-10.0.7.tgz#e14d54a2f23c9701d66851a87a5eb35adb10c2a7"
+  integrity sha512-4uasPp7SDt/iYnu+icSq1ZTjGSnk4ZTrHSGXCE790gUfGFZ+Br/VpUfklb5oHeSFVUoRjoTulaEbIrp2Mfo3vA==
 
 eslint-plugin-flowtype@2.50.1:
   version "2.50.1"
@@ -11794,6 +11817,16 @@ jest-each@^24.0.0:
     jest-get-type "^24.0.0"
     jest-util "^24.0.0"
     pretty-format "^24.0.0"
+
+jest-emotion@^10.0.10:
+  version "10.0.10"
+  resolved "https://registry.yarnpkg.com/jest-emotion/-/jest-emotion-10.0.10.tgz#94ba32b3982ba790bab82b3475a1e2d1f2a3f5c8"
+  integrity sha512-RHlOHonIEWwPeOuUZoHSnbf+ZDVlvrZoSuUzWHNcQxQIJPo7LWuRzzZhTZeU+QVWWSSNIFvgfJl7muLezJnlgg==
+  dependencies:
+    "@types/jest" "^23.0.2"
+    chalk "^2.4.1"
+    css "^2.2.1"
+    object-assign "^4.1.1"
 
 jest-environment-jsdom@24.0.0, jest-environment-jsdom@^24.0.0:
   version "24.0.0"


### PR DESCRIPTION
Makes react-fleet just use the @emotion/core library and the css prop so
that it’s compatible with other apps switching to the css prop for
automatic SSR behavior.

 - Adds an eslint rule that enforces using the Emotion JSX processor
   when the css prop is used.
 - Installs jest-emotion for nicer CSS in our Storyshot diffs.
 - Updates usages of VISUALLY_HIDDEN and CLEAR_DEFAULT_STYLING since
   they’re now Emotion style objects, not class name strings.

Adds .babelrc to react-fleet’s .storybook so that we get our custom
Babel behavior, not Storybook’s default.

Upgrades @babel/preset-typescript to a version that correctly handles
not eliminating the "dead" import of a JSX factory.

Also removes Emotion from form-common, since it doesn’t have any UI
elements (and probably shouldn’t).