### PR TITLE
Eliminates warnings in Jest runs

### DIFF
--- a/services-js/311/.storybook/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/311/.storybook/__snapshots__/Storyshots.test.ts.snap
@@ -3172,8 +3172,6 @@ exports[`Storyshots ChooseServicePane Loading matches 1`] = `
                     "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                   }
                 }
-                in={true}
-                onExited={[Function]}
                 role="img"
               />
             </div>
@@ -3191,8 +3189,6 @@ exports[`Storyshots ChooseServicePane Loading matches 1`] = `
                     "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                   }
                 }
-                in={true}
-                onExited={[Function]}
                 role="img"
               />
             </div>
@@ -3210,8 +3206,6 @@ exports[`Storyshots ChooseServicePane Loading matches 1`] = `
                     "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                   }
                 }
-                in={true}
-                onExited={[Function]}
                 role="img"
               />
             </div>
@@ -5605,8 +5599,6 @@ exports[`Storyshots LoadingBuildings loading 1`] = `
             "__html": "<use xlink:href=\\"/assets/img/svg/loading-buildings.svg#allston\\" height=\\"100%\\"></use>",
           }
         }
-        in={true}
-        onExited={[Function]}
         role="img"
       />
     </div>
@@ -5636,8 +5628,6 @@ exports[`Storyshots LoadingBuildings reduced motion 1`] = `
             "__html": "<use xlink:href=\\"/assets/img/svg/loading-buildings.svg#allston\\" height=\\"100%\\"></use>",
           }
         }
-        in={true}
-        onExited={[Function]}
         role="img"
       />
     </div>
@@ -5676,8 +5666,6 @@ exports[`Storyshots LoadingIcons 3 up 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -5700,8 +5688,6 @@ exports[`Storyshots LoadingIcons 3 up 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -5724,8 +5710,6 @@ exports[`Storyshots LoadingIcons 3 up 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -5756,8 +5740,6 @@ exports[`Storyshots LoadingIcons loading 1`] = `
             "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
           }
         }
-        in={true}
-        onExited={[Function]}
         role="img"
       />
     </div>
@@ -5787,8 +5769,6 @@ exports[`Storyshots LoadingIcons reduceMotion 1`] = `
             "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
           }
         }
-        in={true}
-        onExited={[Function]}
         role="img"
       />
     </div>
@@ -5827,8 +5807,6 @@ exports[`Storyshots LoadingIcons reduced Motion 3 up 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -5851,8 +5829,6 @@ exports[`Storyshots LoadingIcons reduced Motion 3 up 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -5875,8 +5851,6 @@ exports[`Storyshots LoadingIcons reduced Motion 3 up 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -6444,8 +6418,6 @@ exports[`Storyshots LocationPopUp searching 1`] = `
                     "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                   }
                 }
-                in={true}
-                onExited={[Function]}
                 role="img"
               />
             </div>
@@ -8364,8 +8336,6 @@ exports[`Storyshots RecentRequests loading without results 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -8923,8 +8893,6 @@ exports[`Storyshots RecentRequests results loaded and loading more 1`] = `
               "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
             }
           }
-          in={true}
-          onExited={[Function]}
           role="img"
         />
       </div>
@@ -12262,8 +12230,6 @@ exports[`Storyshots ServicesLayout Expanded 1`] = `
                 >
                   <div
                     className="dr-c"
-                    in={true}
-                    onExited={[Function]}
                     style={
                       Object {
                         "display": "block",
@@ -12774,8 +12740,6 @@ exports[`Storyshots SubmitPane Submitting 1`] = `
                 "__html": "<use xlink:href=\\"/assets/img/svg/loading-buildings.svg#allston\\" height=\\"100%\\"></use>",
               }
             }
-            in={true}
-            onExited={[Function]}
             role="img"
           />
         </div>

--- a/services-js/311/components/request/RequestLayout.test.tsx
+++ b/services-js/311/components/request/RequestLayout.test.tsx
@@ -256,13 +256,20 @@ describe('missing service page', () => {
 });
 
 describe('routeToServiceForm', () => {
-  let requestLayout;
+  let requestLayout: RequestLayout;
+  let scrollToSpy: jest.Mock;
 
   beforeEach(() => {
+    scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
     const props: any = {
       data: {},
     };
     requestLayout = new RequestLayout(props);
+  });
+
+  afterEach(() => {
+    scrollToSpy.mockRestore();
   });
 
   it('defaults to questions', () => {

--- a/services-js/311/components/request/home/__snapshots__/HomeDialog.test.tsx.snap
+++ b/services-js/311/components/request/home/__snapshots__/HomeDialog.test.tsx.snap
@@ -63,8 +63,6 @@ exports[`choose page rendering 1`] = `
                       "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                     }
                   }
-                  in={true}
-                  onExited={[Function]}
                   role="img"
                 />
               </div>
@@ -82,8 +80,6 @@ exports[`choose page rendering 1`] = `
                       "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                     }
                   }
-                  in={true}
-                  onExited={[Function]}
                   role="img"
                 />
               </div>
@@ -101,8 +97,6 @@ exports[`choose page rendering 1`] = `
                       "__html": "<use xlink:href=\\"/assets/img/svg/loading-icons.svg#311_icons_general_lighting_request\\" height=\\"100%\\"></use>",
                     }
                   }
-                  in={true}
-                  onExited={[Function]}
                   role="img"
                 />
               </div>

--- a/services-js/311/components/request/request/__snapshots__/RequestDialog.test.tsx.snap
+++ b/services-js/311/components/request/request/__snapshots__/RequestDialog.test.tsx.snap
@@ -496,18 +496,33 @@ exports[`methods submitRequest success 1`] = `
                     <div
                       className="css-6ezlc4"
                     >
-                      <svg
-                        className="css-1rr4qq7"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "<use xlink:href=\\"/assets/img/svg/loading-buildings.svg#allston\\" height=\\"100%\\"></use>",
-                          }
-                        }
+                      <Transition
+                        appear={false}
+                        enter={true}
+                        exit={true}
                         in={true}
-                        key=".$allston"
+                        key=".$.$allston"
+                        mountOnEnter={false}
+                        onEnter={[Function]}
+                        onEntered={[Function]}
+                        onEntering={[Function]}
+                        onExit={[Function]}
                         onExited={[Function]}
-                        role="img"
-                      />
+                        onExiting={[Function]}
+                        timeout={0}
+                        unmountOnExit={false}
+                      >
+                        <svg
+                          className="css-1rr4qq7"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<use xlink:href=\\"/assets/img/svg/loading-buildings.svg#allston\\" height=\\"100%\\"></use>",
+                            }
+                          }
+                          key="allston"
+                          role="img"
+                        />
+                      </Transition>
                     </div>
                   </TransitionGroup>
                 </VelocityTransitionGroup>

--- a/services-js/payment-webhooks/server/stripe-events.ts
+++ b/services-js/payment-webhooks/server/stripe-events.ts
@@ -88,11 +88,13 @@ async function processChargeSucceeded(
     }
   );
 
-  console.log(`Added charge ${charge.id} to iNovah:`, {
-    transactionId,
-    batchId,
-    amountInDollars,
-  });
+  if (process.env.NODE_ENV !== 'test') {
+    console.log(`Added charge ${charge.id} to iNovah:`, {
+      transactionId,
+      batchId,
+      amountInDollars,
+    });
+  }
 
   try {
     await stripe.charges.update(charge.id, {

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -7368,7 +7368,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
             •
           </span>
           <span>
-            sample.pdf
+            sample-uploading.pdf
           </span>
         </span>
         <div
@@ -7391,7 +7391,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
                 "width": "1.7em",
               }
             }
-            title="Cancel upload: sample.pdf"
+            title="Cancel upload: sample-uploading.pdf"
             type="button"
           >
             <svg
@@ -7446,7 +7446,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
             •
           </span>
           <span>
-            sample.pdf
+            sample-success.pdf
           </span>
         </span>
         <button
@@ -7459,7 +7459,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
               "width": "1.7em",
             }
           }
-          title="Remove file: sample.pdf"
+          title="Remove file: sample-success.pdf"
           type="button"
         >
           <svg
@@ -7513,7 +7513,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput all three
             •
           </span>
           <span>
-            sample.pdf
+            sample-uploadError.pdf
           </span>
         </span>
         <button
@@ -7596,7 +7596,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput cancel in
             •
           </span>
           <span>
-            sample.pdf
+            sample-canceling.pdf
           </span>
         </span>
         <span
@@ -7657,7 +7657,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput delete in
             •
           </span>
           <span>
-            sample.pdf
+            sample-deleting.pdf
           </span>
         </span>
         <span
@@ -7718,7 +7718,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput documents
             •
           </span>
           <span>
-            sample.pdf
+            sample-success.pdf
           </span>
         </span>
         <button
@@ -7731,7 +7731,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput documents
               "width": "1.7em",
             }
           }
-          title="Remove file: sample.pdf"
+          title="Remove file: sample-success.pdf"
           type="button"
         >
           <svg
@@ -7826,7 +7826,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput documents
             •
           </span>
           <span>
-            sample.pdf
+            sample-uploading.pdf
           </span>
         </span>
         <div
@@ -7849,7 +7849,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput documents
                 "width": "1.7em",
               }
             }
-            title="Cancel upload: sample.pdf"
+            title="Cancel upload: sample-uploading.pdf"
             type="button"
           >
             <svg
@@ -7985,7 +7985,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput error del
             •
           </span>
           <span>
-            sample.pdf
+            sample-deletionError.pdf
           </span>
         </span>
         <button
@@ -8068,7 +8068,7 @@ exports[`Storyshots Birth/Question Components/SupportingDocumentsInput error upl
             •
           </span>
           <span>
-            sample.pdf
+            sample-uploadError.pdf
           </span>
         </span>
         <button
@@ -30820,8 +30820,6 @@ exports[`Storyshots Common Components/Order Details OrderDetailsDropdown: birth 
     >
       <div
         className="dr-c css-1mti76v"
-        in={true}
-        onExited={[Function]}
       >
         <div>
           <div
@@ -31058,8 +31056,6 @@ exports[`Storyshots Common Components/Order Details OrderDetailsDropdown: open 1
     >
       <div
         className="dr-c css-1mti76v"
-        in={true}
-        onExited={[Function]}
       >
         <div>
           <div

--- a/services-js/registry-certs/client/birth/QuestionsPage.stories.tsx
+++ b/services-js/registry-certs/client/birth/QuestionsPage.stories.tsx
@@ -19,6 +19,7 @@ storiesOf('Birth/QuestionsFlowPage', module).add('1. Who is this for?', () => (
     siteAnalytics={{} as any}
     currentStep="forWhom"
     birthCertificateRequest={makeBirthCertificateRequest()}
+    testDontScroll
   />
 ));
 
@@ -32,6 +33,7 @@ storiesOf('Birth/QuestionsFlowPage', module).add(
         forSelf: false,
         howRelated: 'client',
       })}
+      testDontScroll
     />
   )
 );
@@ -43,6 +45,7 @@ storiesOf('Birth/QuestionsFlowPage', module).add('2. Born in Boston?', () => (
     birthCertificateRequest={makeBirthCertificateRequest({
       forSelf: true,
     })}
+    testDontScroll
   />
 ));
 
@@ -55,6 +58,7 @@ storiesOf('Birth/QuestionsFlowPage', module).add(
       birthCertificateRequest={makeBirthCertificateRequest({
         forSelf: true,
       })}
+      testDontScroll
     />
   )
 );
@@ -69,6 +73,7 @@ storiesOf('Birth/QuestionsFlowPage', module).add(
         forSelf: false,
         firstName: 'Stacy',
       })}
+      testDontScroll
     />
   )
 );
@@ -83,6 +88,7 @@ storiesOf('Birth/QuestionsFlowPage', module).add(
         forSelf: true,
         parentsMarried: 'no',
       })}
+      testDontScroll
     />
   )
 );

--- a/services-js/registry-certs/client/birth/QuestionsPage.tsx
+++ b/services-js/registry-certs/client/birth/QuestionsPage.tsx
@@ -28,7 +28,9 @@ interface InitialProps {
 
 interface Props
   extends InitialProps,
-    Pick<PageDependencies, 'birthCertificateRequest' | 'siteAnalytics'> {}
+    Pick<PageDependencies, 'birthCertificateRequest' | 'siteAnalytics'> {
+  testDontScroll?: boolean;
+}
 
 interface State {
   /**
@@ -117,12 +119,16 @@ export default class QuestionsPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    window.scroll(0, 0);
+    if (!this.props.testDontScroll) {
+      window.scroll(0, 0);
+    }
   }
 
   componentDidUpdate(prevProps: Props) {
     if (prevProps.currentStep !== this.props.currentStep) {
-      window.scroll(0, 0);
+      if (!this.props.testDontScroll) {
+        window.scroll(0, 0);
+      }
     }
   }
 

--- a/services-js/registry-certs/client/birth/ReviewRequestPage.stories.tsx
+++ b/services-js/registry-certs/client/birth/ReviewRequestPage.stories.tsx
@@ -36,5 +36,6 @@ storiesOf('Birth/ReviewRequestPage', module).add('default page', () => (
   <ReviewRequestPage
     birthCertificateRequest={birthCertificateRequest}
     siteAnalytics={new GaSiteAnalytics()}
+    testDontScroll
   />
 ));

--- a/services-js/registry-certs/client/birth/ReviewRequestPage.tsx
+++ b/services-js/registry-certs/client/birth/ReviewRequestPage.tsx
@@ -22,7 +22,9 @@ import { ServiceFeeDisclosure } from '../common/FeeDisclosures';
 import { BIRTH_CERTIFICATE_COST } from '../../lib/costs';
 
 interface Props
-  extends Pick<PageDependencies, 'birthCertificateRequest' | 'siteAnalytics'> {}
+  extends Pick<PageDependencies, 'birthCertificateRequest' | 'siteAnalytics'> {
+  testDontScroll?: boolean;
+}
 
 /**
  * Component which allows a user to review their request, and update the
@@ -34,9 +36,11 @@ interface Props
 @observer
 export default class ReviewRequestPage extends React.Component<Props> {
   componentDidMount() {
-    const { siteAnalytics } = this.props;
+    const { siteAnalytics, testDontScroll } = this.props;
 
-    window.scroll(0, 0);
+    if (!testDontScroll) {
+      window.scroll(0, 0);
+    }
 
     // Since user has provided all needed information by this point, we
     // will count this birth certificate as a trackable product.

--- a/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.stories.tsx
+++ b/services-js/registry-certs/client/birth/components/SupportingDocumentsInput.stories.tsx
@@ -7,7 +7,7 @@ import UploadableFile, { Status } from '../../models/UploadableFile';
 function sampleFile(status: Status, progress: number = 0) {
   return Object.assign(
     new UploadableFile(
-      new File([], 'sample.pdf', { type: 'application/pdf' }),
+      new File([], `sample-${status}.pdf`, { type: 'application/pdf' }),
       'sampleId'
     ),
     {

--- a/services-js/registry-certs/client/common/checkout/formik-util.ts
+++ b/services-js/registry-certs/client/common/checkout/formik-util.ts
@@ -12,6 +12,16 @@ import { Formik } from 'formik';
  * https://github.com/jaredpalmer/formik/issues/288#issuecomment-431670630
  */
 export async function runInitialValidation<T>(ref: React.RefObject<Formik<T>>) {
+  // This function is often run from componentDidMount, which gets called during
+  // Storyshots testing, but because this is async, it has no effect. This
+  // "await" delays our ref.current check by a tick. If this is being rendered
+  // with Storyshots, the component will have been unmounted and ref.current
+  // will be null.
+  //
+  // This prevents a "state update on an unmounted component" warning when
+  // running Storyshots.
+  await Promise.resolve('TICK');
+
   const errors = ref.current
     ? await ref.current.getFormikBag().validateForm()
     : [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -21543,9 +21543,9 @@ velocity-animate@^1.4.0, velocity-animate@^1.5.0:
   integrity sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==
 
 velocity-react@^1.3.3:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/velocity-react/-/velocity-react-1.4.1.tgz#1d0b41859cdf2521c08a8b57f44e93ed2d54b5fc"
-  integrity sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/velocity-react/-/velocity-react-1.4.3.tgz#63e41d92e334d5a3bea8b2fa02ee170f62ef4d36"
+  integrity sha512-zvefGm85A88S3KdF9/dz5vqyFLAiwKYlXGYkHH2EbXl+CZUD1OT0a0aS1tkX/WXWTa/FUYqjBaAzAEFYuSobBQ==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"


### PR DESCRIPTION
 - Guards against calling window.scroll when components mount
 - Changes file names in SupportingDocumentsInput to avoid key
   collisions
 - Delays Formik validation so it’s not running when the component
   unmounts
 - Upgrades velocity-react to the latest version that avoids warnings
 - Prevents a console.log in payment-webhooks
 - Mocks out window.scroll in RequestLayout tests