### PR TITLE
Fixes Ruby deploys to use packaged deploy-tools

### DIFF
--- a/services-ruby/codered-proxy/package.json
+++ b/services-ruby/codered-proxy/package.json
@@ -6,7 +6,7 @@
     "prepare": "bundle install --path vendor/bundle",
     "pretest": "yarn prepare",
     "test": "bundle exec rake test",
-    "codebuild-deploy": "codebuild-service-deploy --isolated-docker Dockerfile"
+    "codebuild-deploy": "npx -p ../../deploy-tools.tgz codebuild-service-deploy --isolated-docker Dockerfile"
   },
   "dependencies": {},
   "devDependencies": {

--- a/services-ruby/contactform/package.json
+++ b/services-ruby/contactform/package.json
@@ -6,7 +6,7 @@
     "prepare": "bundle install --path vendor/bundle",
     "pretest": "yarn prepare",
     "test": "bundle exec rake test",
-    "codebuild-deploy": "codebuild-service-deploy --isolated-docker Dockerfile"
+    "codebuild-deploy": "npx -p ../../deploy-tools.tgz codebuild-service-deploy --isolated-docker Dockerfile"
   },
   "dependencies": {},
   "devDependencies": {

--- a/services-ruby/official-header/package.json
+++ b/services-ruby/official-header/package.json
@@ -6,7 +6,7 @@
   "main": "header.js",
   "scripts": {
     "predeploy": "gulp build",
-    "codebuild-deploy": "codebuild-service-deploy --isolated-docker deploy/Dockerfile"
+    "codebuild-deploy": "npx -p ../../deploy-tools.tgz codebuild-service-deploy --isolated-docker deploy/Dockerfile"
   },
   "author": "City of Boston DoIT",
   "license": "CC0-1.0",


### PR DESCRIPTION
For some reason I left this change out of the one that established
deploy-tools.tgz.