### PR TITLE
Removes deploy-tools from Ruby devDependencies

### DIFF
--- a/services-ruby/codered-proxy/package.json
+++ b/services-ruby/codered-proxy/package.json
@@ -8,8 +8,5 @@
     "test": "bundle exec rake test",
     "codebuild-deploy": "npx -p ../../deploy-tools.tgz codebuild-service-deploy --isolated-docker Dockerfile"
   },
-  "dependencies": {},
-  "devDependencies": {
-    "@cityofboston/deploy-tools": "^0.0.0"
-  }
+  "dependencies": {}
 }

--- a/services-ruby/contactform/package.json
+++ b/services-ruby/contactform/package.json
@@ -8,8 +8,5 @@
     "test": "bundle exec rake test",
     "codebuild-deploy": "npx -p ../../deploy-tools.tgz codebuild-service-deploy --isolated-docker Dockerfile"
   },
-  "dependencies": {},
-  "devDependencies": {
-    "@cityofboston/deploy-tools": "^0.0.0"
-  }
+  "dependencies": {}
 }

--- a/services-ruby/official-header/package.json
+++ b/services-ruby/official-header/package.json
@@ -24,8 +24,5 @@
     "gulp-uglify": "^1.5.3",
     "gulp-watch": "^4.3.5",
     "require-dir": "^0.3.0"
-  },
-  "devDependencies": {
-    "@cityofboston/deploy-tools": "^0.0.0"
   }
 }


### PR DESCRIPTION
We’re running deploy-tools from the tgz, so we don’t need to depend on
it (which tries to run its build without first installing deps)