### PR TITLE
Next canary prep

### DIFF
--- a/modules-js/config-typescript/tsconfig.default.json
+++ b/modules-js/config-typescript/tsconfig.default.json
@@ -15,6 +15,8 @@
     "noImplicitThis": false,
     "resolveJsonModule": true,
     "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": false,
+    "skipLibCheck": true,
     "lib": [
       "dom",
       "es2017",

--- a/modules-js/hapi-next/src/hapi-next.ts
+++ b/modules-js/hapi-next/src/hapi-next.ts
@@ -11,12 +11,7 @@ import {
   ResponseToolkit,
   RequestQuery,
 } from 'hapi';
-import { IncomingMessage } from 'http';
 import { promisify } from 'util';
-
-export interface ExtendedIncomingMessage extends IncomingMessage {
-  payload: any;
-}
 
 /**
  * Makes a Hapi route object to render the Next app from the given module at the
@@ -149,10 +144,6 @@ export function makeNextHandler(
       ...(query as RequestQuery),
       ...params,
     };
-
-    // Pass any Hapi payload along so we can handle form POSTs in
-    // getInitialProps if we want to.
-    (req as ExtendedIncomingMessage).payload = request.payload;
 
     // Our actual pages are mounted at their expected paths (e.g.
     // /commissions/apply in the commissions app, not /apply) so we don’t

--- a/modules-js/next-client-common/src/RouterListener.ts
+++ b/modules-js/next-client-common/src/RouterListener.ts
@@ -11,13 +11,13 @@ export function makeNProgressStyle(height: number = 65) {
 }
 
 export type Dependencies = {
-  router: Router;
+  router: typeof Router;
   siteAnalytics?: SiteAnalytics;
   screenReaderSupport?: ScreenReaderSupport;
 };
 
 export default class RouterListener {
-  private router: Router | null = null;
+  private router: typeof Router | null = null;
   private siteAnalytics: SiteAnalytics | null = null;
   private screenReaderSupport: ScreenReaderSupport | null = null;
 
@@ -29,9 +29,9 @@ export default class RouterListener {
     this.siteAnalytics = siteAnalytics || null;
     this.screenReaderSupport = screenReaderSupport || null;
 
-    router.onRouteChangeStart = this.routeChangeStart;
-    router.onRouteChangeComplete = this.routeChangeComplete;
-    router.onRouteChangeError = this.routeChangeError;
+    router.events.on('routeChangeStart', this.routeChangeStart);
+    router.events.on('routeChangeComplete', this.routeChangeComplete);
+    router.events.on('routeChangeError', this.routeChangeError);
 
     NProgress.configure({ showSpinner: false });
 
@@ -47,9 +47,9 @@ export default class RouterListener {
 
   detach() {
     if (this.router) {
-      this.router.onRouteChangeStart = null;
-      this.router.onRouteChangeComplete = null;
-      this.router.onRouteChangeError = null;
+      this.router.events.off('routeChangeStart', this.routeChangeStart);
+      this.router.events.off('routeChangeComplete', this.routeChangeComplete);
+      this.router.events.off('routeChangeError', this.routeChangeError);
     }
 
     this.router = null;

--- a/modules-js/next-client-common/src/next-client-common.test.ts
+++ b/modules-js/next-client-common/src/next-client-common.test.ts
@@ -1,4 +1,4 @@
-import { fetchGraphql, gql } from './next-client-common';
+import { fetchGraphql, gql, getParam } from './next-client-common';
 
 it('is defined', () => {
   expect(fetchGraphql).toBeDefined();
@@ -9,5 +9,31 @@ describe('gql', () => {
     const VALUE = '3';
     const str = gql`value: ${VALUE}!`;
     expect(str).toEqual('value: 3!');
+  });
+});
+
+describe('getParam', () => {
+  it('returns the string', () => {
+    expect(getParam('foo')).toEqual('foo');
+  });
+
+  it('returns the first element', () => {
+    expect(getParam(['foo', 'bar'])).toEqual('foo');
+  });
+
+  it('returns undefined for empty array', () => {
+    expect(getParam([])).toBeUndefined();
+  });
+
+  it('returns undefined for undefined', () => {
+    expect(getParam(undefined)).toBeUndefined();
+  });
+
+  it('returns the default for undefined', () => {
+    expect(getParam(undefined, 'foo')).toEqual('foo');
+  });
+
+  it('returns the default for the empty array', () => {
+    expect(getParam([], 'foo')).toEqual('foo');
   });
 });

--- a/modules-js/next-client-common/src/next-client-common.ts
+++ b/modules-js/next-client-common/src/next-client-common.ts
@@ -18,7 +18,7 @@ export const GOOGLE_TRACKING_ID_KEY = 'googleTrackingId';
 // into the server-side getInitialProps methods by attaching them as properties
 // on the request. This is typically "IncomingMessage & CustomType"
 export interface NextContext<Req = IncomingMessage> {
-  query: { [key: string]: string };
+  query: { [key: string]: string | string[] | undefined };
   pathname: string;
   asPath: string;
   jsonPageRes?: Response;
@@ -356,4 +356,20 @@ export function gql(
   result.push(literals[literals.length - 1]);
 
   return result.join('');
+}
+
+/**
+ * Used to get the first or only value from a Next.js query parameter, which has
+ * type string | string[] | undefined.
+ *
+ * You can provide a fallback in case the param is not provided, in which case
+ * the return type is inferred from the value of the fallback.
+ */
+export function getParam<T = undefined>(
+  queryParam: string | string[] | undefined,
+  fallback?: T
+): string | T {
+  // fallback! at the end here because we don’t want TypeScript to consider the
+  // case where you set "T" explicitly but don’t provide a fallback value.
+  return (Array.isArray(queryParam) ? queryParam[0] : queryParam) || fallback!;
 }

--- a/services-js/311/components/case/CaseLayout.tsx
+++ b/services-js/311/components/case/CaseLayout.tsx
@@ -11,6 +11,7 @@ import CaseView from './CaseView';
 import { Request } from '../../data/types';
 import loadCase from '../../data/queries/load-case';
 import { GetInitialProps } from '../../pages/_app';
+import { getParam } from '@cityofboston/next-client-common';
 
 type CaseData = {
   request: Request | null;
@@ -27,7 +28,11 @@ export default class CaseLayout extends React.Component<Props> {
     'query' | 'res',
     'fetchGraphql'
   > = async ({ query, res }, { fetchGraphql }) => {
-    const { id } = query;
+    const id = getParam(query.id);
+
+    if (!id) {
+      throw new Error('id missing in CaseLayout');
+    }
 
     const request = await loadCase(fetchGraphql, id);
 

--- a/services-js/311/components/request/home/HomeDialog.tsx
+++ b/services-js/311/components/request/home/HomeDialog.tsx
@@ -7,6 +7,7 @@ import Router from 'next/router';
 import {
   FetchGraphql,
   GaSiteAnalytics,
+  getParam,
 } from '@cityofboston/next-client-common';
 
 import { ServiceSummary } from '../../../data/types';
@@ -64,7 +65,7 @@ export default class HomeDialog extends React.Component<Props> {
     return {
       topServiceSummaries: await loadTopServiceSummaries(fetchGraphql, 5),
       stage: stage === 'choose' ? stage : 'home',
-      description: description || '',
+      description: getParam(description, ''),
       bypassTranslateDialog: translate === '0',
     };
   };

--- a/services-js/311/components/request/request/RequestDialog.tsx
+++ b/services-js/311/components/request/request/RequestDialog.tsx
@@ -9,6 +9,7 @@ import { IPromiseBasedObservable } from 'mobx-utils';
 import {
   FetchGraphql,
   ScreenReaderSupport,
+  getParam,
 } from '@cityofboston/next-client-common';
 
 import { MEDIA_LARGE, HEADER_HEIGHT } from '@cityofboston/react-fleet';
@@ -82,7 +83,10 @@ export default class RequestDialog extends React.Component<Props> {
     'query' | 'res',
     'fetchGraphql'
   > = async ({ query, res }, { fetchGraphql }): Promise<InitialProps> => {
-    const { code, description } = query;
+    const { description } = query;
+    // We can't be routed to here unless code is provided
+    const code = getParam(query.code)!;
+
     let stage = query.stage;
 
     const service = await loadService(fetchGraphql, code);
@@ -102,7 +106,7 @@ export default class RequestDialog extends React.Component<Props> {
           serviceCode: code,
           service,
           stage,
-          description: description || '',
+          description: getParam(description, ''),
         };
       default:
         throw new Error(`Unknown stage: ${stage}`);

--- a/services-js/311/components/search/SearchLayout.tsx
+++ b/services-js/311/components/search/SearchLayout.tsx
@@ -25,6 +25,7 @@ import LocationMap from '../map/LocationMap';
 import RecentRequests from './RecentRequests';
 import RecentRequestsSearchForm from './RecentRequestsSearchForm';
 import { PageDependencies, GetInitialProps } from '../../pages/_app';
+import { getParam } from '@cityofboston/next-client-common';
 
 type SearchData = {
   view: 'search';
@@ -142,8 +143,8 @@ export default class SearchLayout extends React.Component<Props> {
 
     if (lat && lng) {
       location = {
-        lat: parseFloat(query.lat),
-        lng: parseFloat(query.lng),
+        lat: parseFloat(getParam(lat)!),
+        lng: parseFloat(getParam(lng)!),
       };
     } else {
       location = null;
@@ -152,9 +153,9 @@ export default class SearchLayout extends React.Component<Props> {
     return {
       data: {
         view: 'search',
-        query: query.q || '',
+        query: getParam(query.q, ''),
         location,
-        zoom: zoom ? parseInt(zoom, 10) : null,
+        zoom: zoom ? parseInt(getParam(zoom)!, 10) : null,
       },
     };
   };

--- a/services-js/311/pages/_app.tsx
+++ b/services-js/311/pages/_app.tsx
@@ -17,8 +17,6 @@ import {
   GraphqlCache,
 } from '@cityofboston/next-client-common';
 
-import { ExtendedIncomingMessage } from '@cityofboston/hapi-next';
-
 import RequestSearch from '../data/store/RequestSearch';
 import Ui from '../data/store/Ui';
 import BrowserLocation from '../data/store/BrowserLocation';
@@ -29,6 +27,7 @@ import parseLanguagePreferences, {
   LanguagePreference,
 } from '../data/store/BrowserLanguage';
 import { NextConfig } from '../lib/config';
+import { IncomingMessage } from 'http';
 
 // Adds server generated styles to emotion cache.
 // '__NEXT_DATA__.ids' is set in '_document.js'
@@ -53,10 +52,10 @@ export interface GetInitialPropsDependencies {
  */
 export type GetInitialProps<
   T,
-  C extends keyof NextContext<ExtendedIncomingMessage> = never,
+  C extends keyof NextContext = never,
   D extends keyof GetInitialPropsDependencies = never
 > = (
-  cxt: Pick<NextContext<ExtendedIncomingMessage>, C>,
+  cxt: Pick<NextContext, C>,
   deps: Pick<GetInitialPropsDependencies, D>
 ) => T | Promise<T>;
 
@@ -103,7 +102,7 @@ export interface PageDependencies {
 }
 
 interface AppGetInitialPropsContext {
-  ctx: NextContext<ExtendedIncomingMessage>;
+  ctx: NextContext;
   Component: any;
 }
 
@@ -130,7 +129,7 @@ let cachedInitialPageDependencies: GetInitialPropsDependencies;
  * dependency type that we give to getInitialProps.
  */
 function getInitialPageDependencies(
-  req?: ExtendedIncomingMessage
+  req?: IncomingMessage
 ): GetInitialPropsDependencies {
   if (cachedInitialPageDependencies) {
     return cachedInitialPageDependencies;

--- a/services-js/access-boston/src/pages/_app.tsx
+++ b/services-js/access-boston/src/pages/_app.tsx
@@ -15,8 +15,6 @@ import {
   ScreenReaderSupport,
 } from '@cityofboston/next-client-common';
 
-import { ExtendedIncomingMessage } from '@cityofboston/hapi-next';
-
 import CrumbContext from '../client/CrumbContext';
 import { RedirectError } from '../client/auth-helpers';
 ``;
@@ -35,7 +33,7 @@ export interface GetInitialPropsDependencies {
 }
 
 export type GetInitialProps<T> = (
-  cxt: NextContext<ExtendedIncomingMessage>,
+  cxt: NextContext,
   deps: GetInitialPropsDependencies
 ) => T | Promise<T>;
 
@@ -70,7 +68,7 @@ export interface PageDependencies {
 }
 
 interface AppInitialProps {
-  ctx: NextContext<ExtendedIncomingMessage>;
+  ctx: NextContext;
   Component: any;
 }
 

--- a/services-js/access-boston/src/pages/change-password.tsx
+++ b/services-js/access-boston/src/pages/change-password.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Router from 'next/router';
 import { Formik, FormikProps } from 'formik';
+import { format as formatUrl } from 'url';
 
 import { SectionHeader, PUBLIC_CSS_URL } from '@cityofboston/react-fleet';
 
@@ -112,11 +113,13 @@ export default class ChangePasswordPage extends React.Component<Props, State> {
             // then we can go straight to done.
             this.doneRedirectRef.current!.redirect();
           } else {
-            Router.push({
-              // clears out any query param since we're setting it below
-              pathname: successUrl(account).replace(/\?.*/, ''),
-              query: { message: FlashMessage.CHANGE_PASSWORD_SUCCESS },
-            });
+            Router.push(
+              formatUrl({
+                // clears out any query param since we're setting it below
+                pathname: successUrl(account).replace(/\?.*/, ''),
+                query: { message: FlashMessage.CHANGE_PASSWORD_SUCCESS },
+              })
+            );
           }
           break;
       }

--- a/services-js/access-boston/src/server/access-boston.ts
+++ b/services-js/access-boston/src/server/access-boston.ts
@@ -372,7 +372,7 @@ async function addNext(server: HapiServer) {
   const nextApp = next({
     dev,
     dir: 'src',
-    config,
+    conf: config,
   });
 
   // We have to manually add the CSRF token because the Next helpers

--- a/services-js/commissions-app/src/pages/commissions/apply.tsx
+++ b/services-js/commissions-app/src/pages/commissions/apply.tsx
@@ -15,6 +15,7 @@ import {
   NextContext,
   GtagSiteAnalytics,
   ScreenReaderSupport,
+  getParam,
 } from '@cityofboston/next-client-common';
 import { IncomingMessage } from 'http';
 import { Formik, FormikActions } from 'formik';
@@ -49,7 +50,10 @@ export default class ApplyPage extends React.Component<Props, State> {
     const commissions = await fetchCommissions();
     commissions.sort((current, next) => current.name.localeCompare(next.name));
 
-    return { commissions, commissionID };
+    return {
+      commissions,
+      commissionID: getParam(commissionID),
+    };
   }
 
   componentDidMount() {

--- a/services-js/commissions-app/src/server/commissions-app.ts
+++ b/services-js/commissions-app/src/server/commissions-app.ts
@@ -154,7 +154,7 @@ export async function makeServer(port, rollbar: Rollbar) {
     nextApp = next({
       dev,
       dir: 'src',
-      config,
+      conf: config,
     });
   } else {
     nextApp = null;

--- a/services-js/registry-certs/client/birth/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/birth/CheckoutPage.tsx
@@ -5,6 +5,8 @@ import { observer } from 'mobx-react';
 import Router from 'next/router';
 import Link from 'next/link';
 
+import { getParam } from '@cityofboston/next-client-common';
+
 import { PageDependencies, GetInitialProps } from '../../pages/_app';
 import Order, { OrderInfo } from '../models/Order';
 import { CERTIFICATE_COST } from '../../lib/costs';
@@ -85,9 +87,9 @@ export default class BirthCheckoutPage extends React.Component<Props, State> {
       case 'confirmation':
         info = {
           page: 'confirmation',
-          orderId: query.orderId || '',
-          contactEmail: query.contactEmail || '',
-          stepCount: parseInt(query.stepCount || '8'),
+          orderId: getParam(query.orderId, ''),
+          contactEmail: getParam(query.contactEmail, ''),
+          stepCount: parseInt(getParam(query.stepCount, '8')),
         };
         break;
       default:

--- a/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
+++ b/services-js/registry-certs/client/death/certificate/CertificatePage.tsx
@@ -9,6 +9,8 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Router from 'next/router';
 
+import { getParam } from '@cityofboston/next-client-common';
+
 import { PageDependencies, GetInitialProps } from '../../../pages/_app';
 import { DeathCertificate } from '../../types';
 
@@ -43,7 +45,9 @@ class CertificatePage extends React.Component<Props, State> {
     InitialProps,
     'query' | 'res',
     'deathCertificatesDao'
-  > = async ({ query: { id, backUrl }, res }, { deathCertificatesDao }) => {
+  > = async ({ query, res }, { deathCertificatesDao }) => {
+    const id = getParam(query.id);
+
     if (!id) {
       throw new Error('Missing id');
     }
@@ -57,7 +61,7 @@ class CertificatePage extends React.Component<Props, State> {
     return {
       id,
       certificate,
-      backUrl,
+      backUrl: getParam(query.backUrl, null),
     };
   };
 

--- a/services-js/registry-certs/client/death/certificate/__snapshots__/CertificatePage.test.tsx.snap
+++ b/services-js/registry-certs/client/death/certificate/__snapshots__/CertificatePage.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`getInitialProps handles a 404 1`] = `
 Object {
-  "backUrl": undefined,
+  "backUrl": null,
   "certificate": null,
   "id": "000002",
 }
@@ -10,7 +10,7 @@ Object {
 
 exports[`getInitialProps loads the cert passed in query 1`] = `
 Object {
-  "backUrl": undefined,
+  "backUrl": null,
   "certificate": Object {
     "age": "53",
     "birthDate": "5/1/1962",

--- a/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
+++ b/services-js/registry-certs/client/death/checkout/CheckoutPage.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import Router from 'next/router';
 
+import { getParam } from '@cityofboston/next-client-common';
+
 import { PageDependencies, GetInitialProps } from '../../../pages/_app';
 import Order, { OrderInfo } from '../../models/Order';
 
@@ -85,8 +87,8 @@ export default class CheckoutPageController extends React.Component<
       case 'confirmation':
         info = {
           page: 'confirmation',
-          orderId: query.orderId || '',
-          contactEmail: query.contactEmail || '',
+          orderId: getParam(query.orderId, ''),
+          contactEmail: getParam(query.contactEmail, ''),
         };
         break;
       default:

--- a/services-js/registry-certs/client/death/receipt/ReceiptPage.tsx
+++ b/services-js/registry-certs/client/death/receipt/ReceiptPage.tsx
@@ -9,6 +9,7 @@ import { DeathCertificateOrder } from '../../types';
 import { GetInitialProps } from '../../../pages/_app';
 
 import { BLACK, GRAY_200, MEDIA_PRINT, WHITE } from '@cityofboston/react-fleet';
+import { getParam } from '@cityofboston/next-client-common';
 
 interface Props {
   order: DeathCertificateOrder | null;
@@ -19,10 +20,10 @@ export default class ReceiptPage extends Component<Props> {
     Props,
     'query' | 'res',
     'deathCertificatesDao'
-  > = async (
-    { query: { id, contactEmail }, res },
-    { deathCertificatesDao }
-  ) => {
+  > = async ({ query, res }, { deathCertificatesDao }) => {
+    const id = getParam(query.id);
+    const contactEmail = getParam(query.contactEmail);
+
     if (!id) {
       throw new Error('Missing id');
     }

--- a/services-js/registry-certs/client/death/search/SearchPage.tsx
+++ b/services-js/registry-certs/client/death/search/SearchPage.tsx
@@ -6,6 +6,8 @@ import { ChangeEvent, Component, ComponentClass } from 'react';
 import Head from 'next/head';
 import Router from 'next/router';
 
+import { getParam } from '@cityofboston/next-client-common';
+
 import { DeathCertificateSearchResults } from '../../types';
 import { PageDependencies, GetInitialProps } from '../../../pages/_app';
 
@@ -47,13 +49,13 @@ class SearchPage extends Component<Props, State> {
     'query',
     'deathCertificatesDao'
   > = async ({ query }, { deathCertificatesDao }) => {
-    let q = query.q || '';
+    let q = getParam(query.q, '');
     let page = 1;
 
     let results: DeathCertificateSearchResults | null = null;
 
     if (q) {
-      page = parseInt(query.page, 10) || 1;
+      page = parseInt(getParam(query.page, '1'), 10);
 
       results = await deathCertificatesDao.search(q, page);
     }

--- a/services-js/registry-certs/pages/_app.tsx
+++ b/services-js/registry-certs/pages/_app.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
+import { IncomingMessage } from 'http';
 
 import App, { Container } from 'next/app';
 import Router from 'next/router';
 import getConfig from 'next/config';
 
 import { configure as mobxConfigure } from 'mobx';
-
-import { ExtendedIncomingMessage } from '@cityofboston/hapi-next';
 
 import {
   makeFetchGraphql,
@@ -38,10 +37,10 @@ export interface GetInitialPropsDependencies {
  */
 export type GetInitialProps<
   T,
-  C extends keyof NextContext<ExtendedIncomingMessage> = never,
+  C extends keyof NextContext = never,
   D extends keyof GetInitialPropsDependencies = never
 > = (
-  cxt: Pick<NextContext<ExtendedIncomingMessage>, C>,
+  cxt: Pick<NextContext, C>,
   deps: Pick<GetInitialPropsDependencies, D>
 ) => T | Promise<T>;
 
@@ -85,7 +84,7 @@ export interface PageDependencies extends GetInitialPropsDependencies {
 }
 
 interface AppInitialProps {
-  ctx: NextContext<ExtendedIncomingMessage>;
+  ctx: NextContext;
   Component: any;
 }
 
@@ -110,7 +109,7 @@ let cachedInitialPageDependencies: GetInitialPropsDependencies;
  * dependency type that we give to getInitialProps.
  */
 function getInitialPageDependencies(
-  req?: ExtendedIncomingMessage
+  req?: IncomingMessage
 ): GetInitialPropsDependencies {
   if (cachedInitialPageDependencies) {
     return cachedInitialPageDependencies;

--- a/services-js/registry-certs/server/server.ts
+++ b/services-js/registry-certs/server/server.ts
@@ -104,7 +104,7 @@ export async function makeServer({ rollbar }: ServerArgs) {
   const app = next({
     dev: nextDev,
     quiet: process.env.NODE_ENV === 'test',
-    config,
+    conf: config,
   });
 
   const externalAssetUrl = process.env.ASSET_HOST


### PR DESCRIPTION
An upcoming version of Next.js will have native TypeScript types. This
change adjusts some of our Next.js usage to be more compatible with
those changes when they land. (It still works on Next 8.0, though.)

 - Changes the "query" context property’s values to include string[],
   and makes it explicit that they might be undefined. Adds a "getParam"
   helper to next-client-common that can convert those values to a
   string.
 - Corrects the usage of the "conf" key when creating Next app objects.
   This seems to have only have worked because we were mutating a
   required module.
 - Calls url.format on Router.push’s argument to turn it into a string.
   Router.push did this before, but it looks like it won’t be part of
   the public API.
 - Changes Router event listening to use on/off instead of
   specially-named properties, since they won’t be in the public API.
 - Removes the unused ExtendedIncomingMessage type and adding "payload"
   to it.
 - Adds some defaults to tsconfig.default.json that the canaries are
   requiring be specified on tsconfig.json files. This introduces
   skipLibCheck, which may speed up compilation by not type-checking the
   (typically) auto-generated .d.ts files from packages.