### PR TITLE
Calls compactRange after deleting keys

### DIFF
--- a/services-js/permit-finder/package.json
+++ b/services-js/permit-finder/package.json
@@ -84,6 +84,7 @@
     "@types/graphql": "^14.2.0",
     "@types/jest": "24.x.x",
     "@types/levelup": "*",
+    "@types/leveldown": "*",
     "@types/moment-timezone": "^0.5.12",
     "@types/node": "^8.0.0",
     "@types/react": "^16.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,6 +2990,14 @@
   dependencies:
     "@types/geojson" "*"
 
+"@types/leveldown@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/leveldown/-/leveldown-4.0.0.tgz#3725cd6593f723435c5d72215369ef969a2fcce5"
+  integrity sha512-1+h/AaqhhQK1/Q1Nr1sHyy7JDcVmKosL9uYLb4bhdLf7MQP4f4daWRLuFQKp8n/pRbai2XPUpR7z33N85m2Hng==
+  dependencies:
+    "@types/abstract-leveldown" "*"
+    "@types/node" "*"
+
 "@types/levelup@*":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@types/levelup/-/levelup-3.1.0.tgz#e04f6a8eaf707f88d7c6e043a9067dda431f4538"


### PR DESCRIPTION
Helps keep the database’s size small, rather than having to wait for
this to happen naturally.

Also adds logging for database stats.