### PR TITLE
Resolves #492; adds links to other products on order confirmation page

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -542,17 +542,39 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
                 </a>
                 .
               </p>
-              <div
-                className="ta-c m-v700"
+              <p
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
               >
+                Order a new 
                 <a
-                  className="btn"
                   href="/birth"
                   onClick={[Function]}
                 >
-                  Back to start
+                  birth
                 </a>
-              </div>
+                ,
+                 
+                <a
+                  href="/marriage"
+                  onClick={[Function]}
+                >
+                  marriage
+                </a>
+                , or
+                 
+                <a
+                  href="/death"
+                  onClick={[Function]}
+                >
+                  death
+                </a>
+                 certificate.
+              </p>
             </div>
           </div>
         </div>
@@ -6073,7 +6095,7 @@ exports[`Storyshots Birth/Question Components/ClientInstructions default 1`] = `
           className="lh--400"
         >
           <p>
-            If you are a legal representative making a request for a client, you need these items to get a record:
+            If you are an attorney making a request for a client, you need these items to get a record:
           </p>
           <ol>
             <li>
@@ -6090,16 +6112,16 @@ exports[`Storyshots Birth/Question Components/ClientInstructions default 1`] = `
             You must complete this process in person at Boston City Hall or by mail. In person, the cost per request is $12. We take cash, credit or debit cards, checks, or money orders. By mail, the cost per request is $14. We accept checks or money orders payable to the City of Boston.
           </p>
           <p>
-            You can find more information online at
+            For more information, you can email us at
              
-            <strong>
-              <a
-                href="https://www.boston.gov/birth"
-              >
-                boston.gov/
-                birth
-              </a>
-            </strong>
+            <a
+              href="mailto:birth@boston.gov"
+              onClick={[Function]}
+            >
+              birth
+              @boston.gov
+            </a>
+            .
           </p>
           <p>
             <strong
@@ -12171,7 +12193,7 @@ exports[`Storyshots Birth/QuestionsFlowPage 1a. Client instructions 1`] = `
                   className="lh--400"
                 >
                   <p>
-                    If you are a legal representative making a request for a client, you need these items to get a record:
+                    If you are an attorney making a request for a client, you need these items to get a record:
                   </p>
                   <ol>
                     <li>
@@ -12188,16 +12210,16 @@ exports[`Storyshots Birth/QuestionsFlowPage 1a. Client instructions 1`] = `
                     You must complete this process in person at Boston City Hall or by mail. In person, the cost per request is $12. We take cash, credit or debit cards, checks, or money orders. By mail, the cost per request is $14. We accept checks or money orders payable to the City of Boston.
                   </p>
                   <p>
-                    You can find more information online at
+                    For more information, you can email us at
                      
-                    <strong>
-                      <a
-                        href="https://www.boston.gov/birth"
-                      >
-                        boston.gov/
-                        birth
-                      </a>
-                    </strong>
+                    <a
+                      href="mailto:birth@boston.gov"
+                      onClick={[Function]}
+                    >
+                      birth
+                      @boston.gov
+                    </a>
+                    .
                   </p>
                   <p>
                     <strong
@@ -17713,17 +17735,39 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent birth 1`
                 </a>
                 .
               </p>
-              <div
-                className="ta-c m-v700"
+              <p
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
               >
+                Order a new 
                 <a
-                  className="btn"
                   href="/birth"
                   onClick={[Function]}
                 >
-                  Back to start
+                  birth
                 </a>
-              </div>
+                ,
+                 
+                <a
+                  href="/marriage"
+                  onClick={[Function]}
+                >
+                  marriage
+                </a>
+                , or
+                 
+                <a
+                  href="/death"
+                  onClick={[Function]}
+                >
+                  death
+                </a>
+                 certificate.
+              </p>
             </div>
           </div>
         </div>
@@ -18276,17 +18320,39 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent marriage
                 </a>
                 .
               </p>
-              <div
-                className="ta-c m-v700"
+              <p
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
               >
+                Order a new 
                 <a
-                  className="btn"
+                  href="/birth"
+                  onClick={[Function]}
+                >
+                  birth
+                </a>
+                ,
+                 
+                <a
                   href="/marriage"
                   onClick={[Function]}
                 >
-                  Back to start
+                  marriage
                 </a>
-              </div>
+                , or
+                 
+                <a
+                  href="/death"
+                  onClick={[Function]}
+                >
+                  death
+                </a>
+                 certificate.
+              </p>
             </div>
           </div>
         </div>
@@ -53903,7 +53969,22 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
             >
               registry@boston.gov
             </a>
-            .
+            . You can also order a 
+            <a
+              href="/birth"
+              onClick={[Function]}
+            >
+              birth
+            </a>
+             or
+             
+            <a
+              href="/marriage"
+              onClick={[Function]}
+            >
+              marriage
+            </a>
+             certificate online.
           </p>
           <div
             className="m-t500 ta-c t--info"
@@ -61879,17 +61960,39 @@ exports[`Storyshots Marriage/CheckoutPage confirmation 1`] = `
                 </a>
                 .
               </p>
-              <div
-                className="ta-c m-v700"
+              <p
+                className="t--info"
+                style={
+                  Object {
+                    "fontStyle": "normal",
+                  }
+                }
               >
+                Order a new 
                 <a
-                  className="btn"
+                  href="/birth"
+                  onClick={[Function]}
+                >
+                  birth
+                </a>
+                ,
+                 
+                <a
                   href="/marriage"
                   onClick={[Function]}
                 >
-                  Back to start
+                  marriage
                 </a>
-              </div>
+                , or
+                 
+                <a
+                  href="/death"
+                  onClick={[Function]}
+                >
+                  death
+                </a>
+                 certificate.
+              </p>
             </div>
           </div>
         </div>
@@ -65215,7 +65318,7 @@ exports[`Storyshots Marriage/Question Components/ClientInstructions default 1`] 
           className="lh--400"
         >
           <p>
-            If you are a legal representative making a request for a client, you need these items to get a record:
+            If you are an attorney making a request for a client, you need these items to get a record:
           </p>
           <ol>
             <li>
@@ -65232,16 +65335,16 @@ exports[`Storyshots Marriage/Question Components/ClientInstructions default 1`] 
             You must complete this process in person at Boston City Hall or by mail. In person, the cost per request is $12. We take cash, credit or debit cards, checks, or money orders. By mail, the cost per request is $14. We accept checks or money orders payable to the City of Boston.
           </p>
           <p>
-            You can find more information online at
+            For more information, you can email us at
              
-            <strong>
-              <a
-                href="https://www.boston.gov/marriage"
-              >
-                boston.gov/
-                marriage
-              </a>
-            </strong>
+            <a
+              href="mailto:registry@boston.gov"
+              onClick={[Function]}
+            >
+              registry
+              @boston.gov
+            </a>
+            .
           </p>
           <p>
             <strong
@@ -73929,7 +74032,7 @@ exports[`Storyshots Marriage/QuestionsFlowPage 1a. Client instructions 1`] = `
                   className="lh--400"
                 >
                   <p>
-                    If you are a legal representative making a request for a client, you need these items to get a record:
+                    If you are an attorney making a request for a client, you need these items to get a record:
                   </p>
                   <ol>
                     <li>
@@ -73946,16 +74049,16 @@ exports[`Storyshots Marriage/QuestionsFlowPage 1a. Client instructions 1`] = `
                     You must complete this process in person at Boston City Hall or by mail. In person, the cost per request is $12. We take cash, credit or debit cards, checks, or money orders. By mail, the cost per request is $14. We accept checks or money orders payable to the City of Boston.
                   </p>
                   <p>
-                    You can find more information online at
+                    For more information, you can email us at
                      
-                    <strong>
-                      <a
-                        href="https://www.boston.gov/marriage"
-                      >
-                        boston.gov/
-                        marriage
-                      </a>
-                    </strong>
+                    <a
+                      href="mailto:registry@boston.gov"
+                      onClick={[Function]}
+                    >
+                      registry
+                      @boston.gov
+                    </a>
+                    .
                   </p>
                   <p>
                     <strong

--- a/services-js/registry-certs/client/common/checkout/OrderConfirmationContent.tsx
+++ b/services-js/registry-certs/client/common/checkout/OrderConfirmationContent.tsx
@@ -74,11 +74,11 @@ export default function OrderConfirmationContent({
             <a href={`mailto:${registryEmail}`}>{registryEmail}</a>.
           </p>
 
-          <div className="ta-c m-v700">
-            <Link href={`/${certificateType}`}>
-              <a className="btn">Back to start</a>
-            </Link>
-          </div>
+          <p className="t--info" style={{ fontStyle: 'normal' }}>
+            Order a new <Link href="/birth">birth</Link>,{' '}
+            <Link href="/marriage">marriage</Link>, or{' '}
+            <Link href="/death">death</Link> certificate.
+          </p>
         </div>
       </div>
     </div>

--- a/services-js/registry-certs/client/common/question-components/ClientInstructionsContent.tsx
+++ b/services-js/registry-certs/client/common/question-components/ClientInstructionsContent.tsx
@@ -5,6 +5,7 @@ import { jsx } from '@emotion/core';
 import { CertificateType } from '../../types';
 
 import { SECTION_HEADING_STYLING } from './styling';
+import { ContactForm } from '@cityofboston/react-fleet';
 
 interface Props {
   certificateType: CertificateType;
@@ -12,6 +13,7 @@ interface Props {
 
 export default function ClientInstructionsContent(props: Props): JSX.Element {
   const { certificateType } = props;
+  const emailUser = certificateType === 'birth' ? 'birth' : 'registry';
 
   return (
     <div className="m-t500">
@@ -21,8 +23,8 @@ export default function ClientInstructionsContent(props: Props): JSX.Element {
 
       <div className="lh--400">
         <p>
-          If you are a legal representative making a request for a client, you
-          need these items to get a record:
+          If you are an attorney making a request for a client, you need these
+          items to get a record:
         </p>
 
         <ol>
@@ -48,12 +50,16 @@ export default function ClientInstructionsContent(props: Props): JSX.Element {
         </p>
 
         <p>
-          You can find more information online at{' '}
-          <strong>
-            <a href={`https://www.boston.gov/${certificateType}`}>
-              boston.gov/{certificateType}
-            </a>
-          </strong>
+          For more information, you can email us at{' '}
+          <a
+            href={`mailto:${emailUser}@boston.gov`}
+            onClick={ContactForm.makeMailtoClickHandler(
+              `${certificateType}-cert-feedback-form`
+            )}
+          >
+            {emailUser}@boston.gov
+          </a>
+          .
         </p>
 
         <p>

--- a/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
@@ -60,7 +60,9 @@ export default class ConfirmationContent extends React.Component<Props> {
           <p className="t--info" style={{ fontStyle: 'normal' }}>
             Have any questions? Contact the Registry on weekdays from 9 a.m. – 4
             p.m. at <a href="tel:617-635-4175">617-635-4175</a>, or email{' '}
-            <a href="mailto:registry@boston.gov">registry@boston.gov</a>.
+            <a href="mailto:registry@boston.gov">registry@boston.gov</a>. You
+            can also order a <Link href="/birth">birth</Link> or{' '}
+            <Link href="/marriage">marriage</Link> certificate online.
           </p>
 
           <div className="m-t500 ta-c t--info">

--- a/services-js/registry-certs/client/marriage/questions/ForWhom.tsx
+++ b/services-js/registry-certs/client/marriage/questions/ForWhom.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/core';
+import { jsx } from '@emotion/core';
 
 import { Component, MouseEvent } from 'react';
 
@@ -10,12 +10,10 @@ import RadioItemComponent from '../../common/question-components/RadioItemCompon
 import QuestionComponent from '../../common/question-components/QuestionComponent';
 import FieldsetComponent from '../../common/question-components/FieldsetComponent';
 import RelatedIcon from '../../common/icons/RelatedIcon';
-import ClientInstructionsContent from '../../common/question-components/ClientInstructionsContent';
 
 import MarriageCertificateRequest from '../../store/MarriageCertificateRequest';
 
 import {
-  NOTE_BOX_CLASSNAME,
   SECTION_HEADING_STYLING,
   RADIOGROUP_STYLING,
 } from '../../common/question-components/styling';
@@ -153,20 +151,8 @@ export default class ForWhom extends Component<Props, State> {
               <RelatedIcon name="client" />
             </RadioItemComponent>
           </div>
-
-          {forWhom === 'client' && (
-            <div className={NOTE_BOX_CLASSNAME} css={WARNING_BOX_STYLING}>
-              <ClientInstructionsContent certificateType="marriage" />
-            </div>
-          )}
         </FieldsetComponent>
       </QuestionComponent>
     );
   }
 }
-
-const WARNING_BOX_STYLING = css({
-  '> div': {
-    marginTop: '-0.25rem',
-  },
-});


### PR DESCRIPTION
Small updates following a conversation with Patty:
- added links to other Registry products on request confirmation page (all certs)
- tweaks to language and behavior for legal requests

There will be a new marriage-specific email address, but it’s not yet active - pr will follow once I receive confirmation.