### PR TITLE
Quick fix to allow orders with date range to go through

### DIFF
--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -550,7 +550,8 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
                   }
                 }
               >
-                Order a new 
+                Order a new
+                 
                 <a
                   href="/birth"
                   onClick={[Function]}
@@ -573,7 +574,8 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
                 >
                   death
                 </a>
-                 certificate.
+                 
+                certificate.
               </p>
             </div>
           </div>
@@ -17743,7 +17745,8 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent birth 1`
                   }
                 }
               >
-                Order a new 
+                Order a new
+                 
                 <a
                   href="/birth"
                   onClick={[Function]}
@@ -17766,7 +17769,8 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent birth 1`
                 >
                   death
                 </a>
-                 certificate.
+                 
+                certificate.
               </p>
             </div>
           </div>
@@ -18328,7 +18332,8 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent marriage
                   }
                 }
               >
-                Order a new 
+                Order a new
+                 
                 <a
                   href="/birth"
                   onClick={[Function]}
@@ -18351,7 +18356,8 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent marriage
                 >
                   death
                 </a>
-                 certificate.
+                 
+                certificate.
               </p>
             </div>
           </div>
@@ -39380,7 +39386,7 @@ exports[`Storyshots Common Components/Order Details OrderDetails: marriage 1`] =
         <div
           className="emotion-2"
         >
-          Married: 6/10/2015
+          
         </div>
       </div>
     </div>
@@ -40182,7 +40188,7 @@ exports[`Storyshots Common Components/Order Details OrderDetailsDropdown: marria
               <div
                 className="emotion-4"
               >
-                Married: 6/10/2015
+                
               </div>
             </div>
           </div>
@@ -53969,14 +53975,16 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
             >
               registry@boston.gov
             </a>
-            . You can also order a 
+            . You can also order a
+             
             <a
               href="/birth"
               onClick={[Function]}
             >
               birth
             </a>
-             or
+             
+            or
              
             <a
               href="/marriage"
@@ -53984,7 +53992,8 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
             >
               marriage
             </a>
-             certificate online.
+             
+            certificate online.
           </p>
           <div
             className="m-t500 ta-c t--info"
@@ -60359,7 +60368,7 @@ exports[`Storyshots Email/Marriage/Receipt HTML 1`] = `
       >
         <tr>
                   <td style=\\"padding: 0 25px\\">
-                    <i>1 × Certified marriage certificate for Laurel Johnson &amp; Terry Johnson </i></td>
+                    <i>1 × Certified marriage certificate </i></td>
                   <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$14.00</b></td>
                 </tr>
     
@@ -60632,7 +60641,7 @@ Nancy Whitehead
 Boston, MA 02141
 
 Your order:
-  1 x Certified marriage certificate for Laurel Johnson &amp; Terry Johnson  $14.00
+  1 x Certified marriage certificate  $14.00
   Card processing fee*  $0.00
   Total  $14.56
 
@@ -61147,7 +61156,7 @@ exports[`Storyshots Email/Marriage/Shipped HTML 1`] = `
       >
         <tr>
                   <td style=\\"padding: 0 25px\\">
-                    <i>1 × Certified marriage certificate for Laurel Johnson &amp; Terry Johnson </i></td>
+                    <i>1 × Certified marriage certificate </i></td>
                   <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$14.00</b></td>
                 </tr>
     
@@ -61420,7 +61429,7 @@ Nancy Whitehead
 Boston, MA 02141
 
 Your order:
-  1 x Certified marriage certificate for Laurel Johnson &amp; Terry Johnson  $14.00
+  1 x Certified marriage certificate  $14.00
   Card processing fee*  $0.00
   Total  $14.56
 
@@ -61968,7 +61977,8 @@ exports[`Storyshots Marriage/CheckoutPage confirmation 1`] = `
                   }
                 }
               >
-                Order a new 
+                Order a new
+                 
                 <a
                   href="/birth"
                   onClick={[Function]}
@@ -61991,7 +62001,8 @@ exports[`Storyshots Marriage/CheckoutPage confirmation 1`] = `
                 >
                   death
                 </a>
-                 certificate.
+                 
+                certificate.
               </p>
             </div>
           </div>

--- a/services-js/registry-certs/client/common/CertificateRow.tsx
+++ b/services-js/registry-certs/client/common/CertificateRow.tsx
@@ -173,11 +173,22 @@ function birthRequestProps(request): CertificateProps {
 }
 
 function marriageRequestProps(request): CertificateProps {
-  const { fullNames, dateString } = request;
+  const {
+    fullNames,
+    // dateString
+  } = request;
+
+  // todo: temporary hack - 8/29 jm
+  // return {
+  //   fullNames,
+  //   subinfo: `Married: ${dateString}`,
+  //   pending: false,
+  //   type: 'marriage',
+  // };
 
   return {
     fullNames,
-    subinfo: `Married: ${dateString}`,
+    subinfo: '',
     pending: false,
     type: 'marriage',
   };

--- a/services-js/registry-certs/client/common/ReviewCertificateRequest.tsx
+++ b/services-js/registry-certs/client/common/ReviewCertificateRequest.tsx
@@ -43,7 +43,7 @@ interface Props {
 @observer
 export default class ReviewCertificateRequest extends Component<Props> {
   componentDidMount() {
-    const { certificateType, siteAnalytics } = this.props;
+    const { certificateRequest, certificateType, siteAnalytics } = this.props;
 
     window.scroll(0, 0);
 
@@ -54,11 +54,20 @@ export default class ReviewCertificateRequest extends Component<Props> {
         '0',
         'Birth certificate',
         'Birth certificate',
-        this.props.certificateRequest.quantity,
+        certificateRequest.quantity,
         CERTIFICATE_COST.BIRTH / 100
       );
 
       siteAnalytics.setProductAction('detail');
+    }
+
+    // todo: temporary hack - 8/24 jm
+    if (certificateType === 'marriage') {
+      if (!certificateRequest.requestInformation.dateOfMarriageExact) {
+        certificateRequest.answerQuestion({
+          dateOfMarriageExact: new Date(1870, 0, 1),
+        });
+      }
     }
   }
 

--- a/services-js/registry-certs/client/common/checkout/OrderConfirmationContent.tsx
+++ b/services-js/registry-certs/client/common/checkout/OrderConfirmationContent.tsx
@@ -74,9 +74,19 @@ export default function OrderConfirmationContent({
           </p>
 
           <p className="t--info" style={{ fontStyle: 'normal' }}>
-            Order a new <Link href="/birth">birth</Link>,{' '}
-            <Link href="/marriage">marriage</Link>, or{' '}
-            <Link href="/death">death</Link> certificate.
+            Order a new{' '}
+            <Link href="/birth">
+              <a>birth</a>
+            </Link>
+            ,{' '}
+            <Link href="/marriage">
+              <a>marriage</a>
+            </Link>
+            , or{' '}
+            <Link href="/death">
+              <a>death</a>
+            </Link>{' '}
+            certificate.
           </p>
         </div>
       </div>

--- a/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
+++ b/services-js/registry-certs/client/death/checkout/ConfirmationContent.tsx
@@ -61,8 +61,15 @@ export default class ConfirmationContent extends React.Component<Props> {
             Have any questions? Contact the Registry on weekdays from 9 a.m. – 4
             p.m. at <a href="tel:617-635-4175">617-635-4175</a>, or email{' '}
             <a href="mailto:registry@boston.gov">registry@boston.gov</a>. You
-            can also order a <Link href="/birth">birth</Link> or{' '}
-            <Link href="/marriage">marriage</Link> certificate online.
+            can also order a{' '}
+            <Link href="/birth">
+              <a>birth</a>
+            </Link>{' '}
+            or{' '}
+            <Link href="/marriage">
+              <a>marriage</a>
+            </Link>{' '}
+            certificate online.
           </p>
 
           <div className="m-t500 ta-c t--info">

--- a/services-js/registry-certs/server/email/EmailTemplates.ts
+++ b/services-js/registry-certs/server/email/EmailTemplates.ts
@@ -197,11 +197,12 @@ export class EmailTemplates {
         registryEmail,
         subtotal: null,
 
+        // todo: provide enhanced information for marriage orders
         items: receipt.items.map(({ cost, quantity, name, date }) => ({
           quantity,
           cost,
-          description: `Certified ${orderType} certificate for ${name} ${
-            orderType === 'birth' ? dateString(date) : ''
+          description: `Certified ${orderType} certificate ${
+            orderType === 'birth' ? `for ${name} ${dateString(date)}` : ''
           }`,
         })),
 

--- a/services-js/registry-certs/server/email/__snapshots__/EmailTemplates.test.ts.snap
+++ b/services-js/registry-certs/server/email/__snapshots__/EmailTemplates.test.ts.snap
@@ -4134,7 +4134,7 @@ exports[`receipt Marriage certificate 2`] = `
       >
         <tr>
                   <td style=\\"padding: 0 25px\\">
-                    <i>1 × Certified marriage certificate for Laurel Johnson &amp; Terry Johnson </i></td>
+                    <i>1 × Certified marriage certificate </i></td>
                   <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$14.00</b></td>
                 </tr>
     
@@ -4401,7 +4401,7 @@ Nancy Whitehead
 Boston, MA 02141
 
 Your order:
-  1 x Certified marriage certificate for Laurel Johnson &amp; Terry Johnson  $14.00
+  1 x Certified marriage certificate  $14.00
   Card processing fee*  $0.00
   Total  $14.56
 
@@ -4910,7 +4910,7 @@ exports[`receipt Marriage certificate shipped 2`] = `
       >
         <tr>
                   <td style=\\"padding: 0 25px\\">
-                    <i>1 × Certified marriage certificate for Laurel Johnson &amp; Terry Johnson </i></td>
+                    <i>1 × Certified marriage certificate </i></td>
                   <td style=\\"padding: 0 25px; white-space: nowrap;\\" align=\\"right\\"><b>$14.00</b></td>
                 </tr>
     
@@ -5177,7 +5177,7 @@ Nancy Whitehead
 Boston, MA 02141
 
 Your order:
-  1 x Certified marriage certificate for Laurel Johnson &amp; Terry Johnson  $14.00
+  1 x Certified marriage certificate  $14.00
   Card processing fee*  $0.00
   Total  $14.56
 

--- a/services-js/registry-certs/server/services/RegistryDb.ts
+++ b/services-js/registry-certs/server/services/RegistryDb.ts
@@ -442,10 +442,12 @@ export default class RegistryDb {
       .input('certificateMaidenName2', certificateMaidenName2)
       .input('certificateAltSpellings1', certificateAltSpellings1)
       .input('certificateAltSpellings2', certificateAltSpellings2)
-      .input(
-        dateOfMarriageExact ? 'dateOfMarriageExact' : 'dateOfMarriageUnsure',
-        dateOfMarriageExact ? dateOfMarriageExact : dateOfMarriageUnsure
-      )
+      // .input(
+      //   dateOfMarriageExact ? 'dateOfMarriageExact' : 'dateOfMarriageUnsure',
+      //   dateOfMarriageExact ? dateOfMarriageExact : dateOfMarriageUnsure
+      // )
+      .input('dateOfMarriageExact', dateOfMarriageExact)
+      .input('dateOfMarriageUnsure', dateOfMarriageUnsure)
       .input('requestDetails', requestDetails)
       .input('quantity', quantity)
       .input('unitCost', `$${certificateCost.toFixed(2)}`)


### PR DESCRIPTION
The db is not accepting a null value for the exact date field, so customers who are submitting a range get a server error upon submission. It sounds like the db issue won’t be resolved until after the long weekend, so I added a hack to include the date 1/1/1870 as the exact date in those cases so the orders will go through.