### PR TITLE
Upgrades Next.js from 8.x.x to 9.x.x

### DIFF
--- a/modules-js/config-babel/browser.js
+++ b/modules-js/config-babel/browser.js
@@ -17,6 +17,7 @@ module.exports = api => ({
       require('@babel/preset-env'),
       {
         useBuiltIns: 'usage',
+        corejs: 2,
         modules: api.env('esm') ? false : undefined,
       },
     ],

--- a/modules-js/config-babel/next.js
+++ b/modules-js/config-babel/next.js
@@ -14,6 +14,7 @@ module.exports = () => ({
       {
         'preset-env': {
           useBuiltIns: 'usage',
+          corejs: 2,
         },
       },
     ],

--- a/modules-js/config-babel/package.json
+++ b/modules-js/config-babel/package.json
@@ -5,15 +5,15 @@
   "license": "CC0-1.0",
   "private": true,
   "dependencies": {
-    "@babel/core": "7.1.2",
-    "@babel/plugin-proposal-class-properties": "7.1.0",
-    "@babel/plugin-proposal-decorators": "7.0.0",
-    "@babel/plugin-transform-runtime": "7.0.0",
-    "@babel/preset-env": "7.1.0",
-    "@babel/preset-react": "7.0.0",
-    "@babel/preset-typescript": "^7.3.2",
+    "@babel/core": "^7.6.0",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-proposal-decorators": "^7.6.0",
+    "@babel/plugin-transform-runtime": "^7.6.0",
+    "@babel/preset-env": "^7.6.0",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/preset-typescript": "^7.6.0",
     "babel-plugin-require-context-hook": "^1.0.0",
-    "next": "8.0.3"
+    "next": "^9.0.6"
   },
   "devDependencies": {
     "core-js": "^2.6.4"

--- a/modules-js/form-common/package.json
+++ b/modules-js/form-common/package.json
@@ -27,13 +27,13 @@
     "core-js": "^2.6.4"
   },
   "peerDependencies": {
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "react": "16.8.5"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
-    "@babel/runtime": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/jest": "24.x.x",

--- a/modules-js/graphql-typescript/package.json
+++ b/modules-js/graphql-typescript/package.json
@@ -23,8 +23,8 @@
     "core-js": "^2.6.4"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/jest": "24.x.x",

--- a/modules-js/hapi-common/package.json
+++ b/modules-js/hapi-common/package.json
@@ -31,7 +31,7 @@
     "inert": "5.x.x"
   },
   "devDependencies": {
-    "@babel/core": "7.1.2",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/hoek": "^4.1.3",

--- a/modules-js/hapi-next/package.json
+++ b/modules-js/hapi-next/package.json
@@ -22,12 +22,12 @@
   "dependencies": {
     "compression": "^1.6.2",
     "core-js": "^2.6.4",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "react": "16.8.5",
     "react-dom": "16.8.5"
   },
   "devDependencies": {
-    "@babel/core": "7.1.2",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/hapi": "^17.0.19",

--- a/modules-js/hapi-next/src/hapi-next.ts
+++ b/modules-js/hapi-next/src/hapi-next.ts
@@ -1,5 +1,4 @@
 import querystring from 'querystring';
-import next from 'next';
 import compression from 'compression';
 
 import {
@@ -34,7 +33,7 @@ import { promisify } from 'util';
  * );
  */
 export function makeRoutesForNextApp(
-  app: next.Server,
+  app: any, // Next server object
   pathPrefix: string = '/',
   pageRouteOptions: RouteOptions | ((server: HapiServer) => RouteOptions) = {},
   staticRouteOptions:
@@ -121,7 +120,7 @@ export function makeRoutesForNextApp(
  * path. E.g.: /certificates/12345 should be handled by the "certificates" page.
  */
 export function makeNextHandler(
-  app: next.Server,
+  app: any, // Next server object
   page: string | null = null
 ): Lifecycle.Method {
   return async (request: HapiRequest, h: ResponseToolkit) => {

--- a/modules-js/mssql-common/package.json
+++ b/modules-js/mssql-common/package.json
@@ -24,7 +24,7 @@
     "mssql": "^4.2.1"
   },
   "devDependencies": {
-    "@babel/core": "7.1.2",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/jest": "24.x.x",

--- a/modules-js/next-client-common/package.json
+++ b/modules-js/next-client-common/package.json
@@ -28,14 +28,14 @@
     "isomorphic-fetch": "^2.2.1"
   },
   "peerDependencies": {
-    "@babel/runtime": "7.1.2",
-    "next": "8.0.3",
+    "@babel/runtime": "^7.6.0",
+    "next": "^9.0.6",
     "nprogress": "^0.2.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
-    "@babel/runtime": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/google.analytics": "^0.0.39",
@@ -47,7 +47,7 @@
     "concurrently": "^3.5.1",
     "cross-env": "^5.2.0",
     "jest": "^24.8.0",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "nprogress": "^0.2.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.60.1",

--- a/modules-js/react-fleet/package.json
+++ b/modules-js/react-fleet/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.10",
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "detect-browser": "^3.0.1",
     "prop-types": "^15.6.0",
     "react": "16.8.5",
@@ -42,10 +42,9 @@
     "string-hash": "^1.1.3"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
-    "@babel/preset-react": "7.0.0",
-    "@babel/runtime": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
+    "@babel/runtime": "^7.1.2",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@cityofboston/percy-common": "^0.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
       "templates/js-*/build/*"
     ],
     "nohoist": [
-      "**/@cityofboston/config-typescript"
+      "**/@cityofboston/config-typescript",
+      "**/acorn",
+      "**/acorn-dynamic-import"
     ]
   },
   "scripts": {

--- a/services-js/311-indexer/package.json
+++ b/services-js/311-indexer/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/srv-decrypt-env": "^0.0.0",
     "aws-sdk": "^2.100.0",
     "cometd": "^4.0.3",
@@ -43,9 +43,9 @@
     "url-search-params": "^0.10.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
-    "@babel/node": "7.0.0",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
+    "@babel/node": "^7.6.1",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/cometd": "^4.0.4",

--- a/services-js/311/README.md
+++ b/services-js/311/README.md
@@ -4,28 +4,40 @@ The source code for the future [311.boston.gov](https://311.boston.gov).
 
 [![Build Status](https://travis-ci.org/CityOfBoston/311.svg?branch=develop)](https://travis-ci.org/CityOfBoston/311)
 
+### todo note: 9/23/19
+
+All apps have been upgraded from Next.js 8.x.x => 9.x.x **except** for this one!
+
+After upgrading (along with Babel from 7.1.x to 7.6.x), running Jest throws
+
+```
+[mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[RecentRequestRow#3350.render()] { Invariant Violation: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
+```
+
+Since this application is not in production and it is unknown whether it ever will be, it was decided to leave it as-is for the time being.
+
 ## Developers
 
 This is a Node project using the [Next.js](https://github.com/zeit/next.js/)
 framework for server-side rendering.
 
- * **Development Server**: `npm run dev` <http://localhost:3000/>
- * **React Storybook**: `npm run storybook` <http://localhost:9001/>
- * **Tests**: `npm test` or `npm test -- --watch`
- * **Lint**: `npm run lint` (uses [ESLint](http://eslint.org/) `--fix` to fix common style errors)
+- **Development Server**: `npm run dev` <http://localhost:3000/>
+- **React Storybook**: `npm run storybook` <http://localhost:9001/>
+- **Tests**: `npm test` or `npm test -- --watch`
+- **Lint**: `npm run lint` (uses [ESLint](http://eslint.org/) `--fix` to fix common style errors)
 
 ### Getting started
 
-__Make sure you have at least Node 8.2 installed, preferrably with `nvm` or
+**Make sure you have at least Node 8.2 installed, preferrably with `nvm` or
 equivalent so you automatically pick up our `.nvmrc` file. Also, `npm` >= 5.3
-(installed by default with Node 8.2 and up) and `gulp-cli`.__
+(installed by default with Node 8.2 and up) and `gulp-cli`.**
 
- 1. Get the Open311 api_key and URL from a friend
- 1. Copy `.env.sample` to `.env` and fill in the endpoint and keys
- 1. Get other API keys: Mapbox, Searchly, &c. and put them in .env
- 1. `yarn install`
- 1. `yarn dev`
- 1. Visit <http://localhost:3000/> in your browser
+1.  Get the Open311 api_key and URL from a friend
+1.  Copy `.env.sample` to `.env` and fill in the endpoint and keys
+1.  Get other API keys: Mapbox, Searchly, &c. and put them in .env
+1.  `yarn install`
+1.  `yarn dev`
+1.  Visit <http://localhost:3000/> in your browser
 
 ### JavaScript
 
@@ -37,9 +49,9 @@ preset.
 
 Please make full use of:
 
- * [Object rest spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/): `{ foo: 1, ...bar }`
- * [Async functions](https://babeljs.io/docs/plugins/transform-async-to-generator/): `async (promisedNum) => (3 + await promisedNum)`
- * [Class properties](https://babeljs.io/docs/plugins/transform-class-properties/): `class MyComponent { onClick = () => { this.setState({ clicked: true })} }`
+- [Object rest spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/): `{ foo: 1, ...bar }`
+- [Async functions](https://babeljs.io/docs/plugins/transform-async-to-generator/): `async (promisedNum) => (3 + await promisedNum)`
+- [Class properties](https://babeljs.io/docs/plugins/transform-class-properties/): `class MyComponent { onClick = () => { this.setState({ clicked: true })} }`
 
 Code style is enforced by ESLint, which can be run (in `--fix` mode) with
 `npm run lint`. Committed code must contain no errors or warnings. On a per-file
@@ -78,8 +90,7 @@ Components and containers are organized under `/components` by page.
 For UI-focused development, use [React Storybook](https://getstorybook.io/) by
 running `npm run storybook` and visiting <http://localhost:9001>
 
-**Local use of patterns library:** After running `gulp` and `npx fractal
-start -- --watch` in the patterns directory, change `stylesheets.json` to
+**Local use of patterns library:** After running `gulp` and `npx fractal start -- --watch` in the patterns directory, change `stylesheets.json` to
 reference `https://localhost:3001` instead of `cob-patterns-staging`.
 
 ## Public domain
@@ -94,6 +105,6 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [LICE
 
 If you're interested in helping this project, there are three ways to help. Be sure to checkout our [Guide to Contributing](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md).
 
-* [Report issues on Boston.gov](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md#reporting-bugs)
-* [Suggest new features](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md#suggest-new-features)
-* [Contributing to development](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md#contributing-to-development)
+- [Report issues on Boston.gov](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md#reporting-bugs)
+- [Suggest new features](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md#suggest-new-features)
+- [Contributing to development](https://github.com/CityOfBoston/boston.gov/blob/develop/guides/03-contributing-to-boston.gov.md#contributing-to-development)

--- a/services-js/311/components/request/home/HomeDialog.test.tsx
+++ b/services-js/311/components/request/home/HomeDialog.test.tsx
@@ -115,7 +115,8 @@ describe('choose page', () => {
   });
 });
 
-describe('integration', () => {
+// disabled as per Reilly 9/23 jm
+xdescribe('integration', () => {
   let wrapper;
   let resolveSuggestions;
 

--- a/services-js/311/data/store/AddressSearch.test.ts
+++ b/services-js/311/data/store/AddressSearch.test.ts
@@ -65,7 +65,8 @@ describe('searching', () => {
     addressSearch.stop();
   });
 
-  it('updates address and location on success', async () => {
+  // disabled as per Reilly 9/23 jm
+  xit('updates address and location on success', async () => {
     addressSearch.query = '1 City Hall Plaza';
     addressSearch.search(false);
 
@@ -85,7 +86,8 @@ describe('searching', () => {
     expect(addressSearch.intent).toEqual('ADDRESS');
   });
 
-  it('searches for an intersection and uses LATLNG intent', async () => {
+  // disabled as per Reilly 9/23 jm
+  xit('searches for an intersection and uses LATLNG intent', async () => {
     addressSearch.query = 'Milk and Washington';
     addressSearch.search(false);
 
@@ -115,7 +117,7 @@ describe('searching', () => {
     expect(addressSearch.addressId).toEqual(null);
   });
 
-  it('has no selection when search returns multilpe things', async () => {
+  it('has no selection when search returns multiple things', async () => {
     addressSearch.query = '1 City Hall Plaza';
     addressSearch.search(false);
 

--- a/services-js/311/package.json
+++ b/services-js/311/package.json
@@ -125,6 +125,7 @@
     "@types/storybook__addon-actions": "^3.4.2",
     "@types/storybook__addon-storyshots": "^3.4.8",
     "@types/storybook__react": "^4.0.1",
+    "@zeit/next-typescript": "1.1.1",
     "babel-core": "^7.0.0-0",
     "babel-plugin-inline-import": "^2.0.6",
     "cheerio": "^1.0.0-rc.2",

--- a/services-js/311/pages/_app.tsx
+++ b/services-js/311/pages/_app.tsx
@@ -157,16 +157,16 @@ function getInitialPageDependencies(
  *  - GetInitialPropsDependencies are passed as a second argument to getInitialProps
  *  - PageDependencies are spread as props for the page
  */
-export default class Three11App extends App {
+export default class Three11App extends App<Props | any> {
   // TypeScript doesn't know that App already has a props member.
-  protected props: Props;
+  props: Props | any;
 
   private pageDependencies: PageDependencies;
 
   static async getInitialProps({
     Component,
     ctx,
-  }: AppGetInitialPropsContext): Promise<InitialProps> {
+  }: AppGetInitialPropsContext | any): Promise<InitialProps> {
     const deps = getInitialPageDependencies(ctx.req);
 
     const pageProps = Component.getInitialProps
@@ -182,7 +182,7 @@ export default class Three11App extends App {
     };
   }
 
-  constructor(props: Props) {
+  constructor(props: Props | any) {
     super(props);
 
     // We're a little hacky here because TypeScript doesn't have type

--- a/services-js/311/pages/_document.tsx
+++ b/services-js/311/pages/_document.tsx
@@ -22,8 +22,8 @@ type Props = {
   rollbarEnvironment: string | undefined;
 };
 
-export default class extends Document {
-  props: Props;
+export default class extends Document<Props> {
+  props: Props | any;
 
   static async getInitialProps({ renderPage }) {
     const page = renderPage();
@@ -44,7 +44,7 @@ export default class extends Document {
     };
   }
 
-  constructor(props: Props) {
+  constructor(props: Props | any) {
     super(props);
 
     this.props = props;
@@ -68,7 +68,7 @@ export default class extends Document {
     } = getConfig();
 
     return (
-      <html lang="en" className="js flexbox">
+      <html lang="en-US" className="js flexbox">
         <Head>
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/services-js/access-boston/next.config.js
+++ b/services-js/access-boston/next.config.js
@@ -1,9 +1,6 @@
 const path = require('path');
-const withTypescript = require('@zeit/next-typescript');
 const withPolyfill = require('@cityofboston/next-client-common/with-polyfill')();
 
-module.exports = withTypescript(
-  withPolyfill({
-    distDir: path.join('..', 'build', '.next'),
-  })
-);
+module.exports = withPolyfill({
+  distDir: path.join('..', 'build', '.next'),
+});

--- a/services-js/access-boston/package.json
+++ b/services-js/access-boston/package.json
@@ -35,7 +35,7 @@
     "graphql": "0.13.2"
   },
   "dependencies": {
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/deploy-tools": "^0.0.0",
     "@cityofboston/form-common": "^0.0.0",
     "@cityofboston/hapi-common": "^0.0.0",
@@ -63,7 +63,7 @@
     "js-yaml": "^3.12.0",
     "jws": "^3.1.5",
     "moment-timezone": "^0.5.14",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "next-cookies": "^1.0.2",
     "node-cleanup": "^2.1.2",
     "node-fetch": "^2.2.0",
@@ -78,8 +78,8 @@
     "yup": "0.27.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@cityofboston/graphql-typescript": "^0.0.0",
@@ -104,7 +104,6 @@
     "@types/storybook__react": "^4.0.1",
     "@types/yar": "^9.0.4",
     "@types/yup": "^0.26.0",
-    "@zeit/next-typescript": "1.1.1",
     "babel-core": "^7.0.0-0",
     "babel-plugin-inline-import": "^2.0.6",
     "concurrently": "^3.5.1",

--- a/services-js/access-boston/src/next-env.d.ts
+++ b/services-js/access-boston/src/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/services-js/access-boston/src/pages/_document.tsx
+++ b/services-js/access-boston/src/pages/_document.tsx
@@ -1,4 +1,11 @@
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, {
+  Head,
+  Main,
+  NextScript,
+  DocumentInitialProps,
+  DocumentContext,
+  DocumentProps,
+} from 'next/document';
 import { extractCritical } from 'emotion-server';
 
 import {
@@ -10,13 +17,25 @@ import { CompatibilityWarning, StatusModal } from '@cityofboston/react-fleet';
 
 import { HEADER_HEIGHT } from '../client/styles';
 
-export default class MyDocument extends Document {
+type Props = {
+  userAgent: string;
+  rollbarAccessToken: string | undefined;
+  rollbarEnvironment: string | undefined;
+
+  css: string;
+  ids: string[];
+};
+
+export default class MyDocument extends Document<Props> {
   props: any;
 
-  static getInitialProps({ renderPage, req }) {
-    const page = renderPage();
+  static async getInitialProps({
+    renderPage,
+    req,
+  }: DocumentContext): Promise<Props & DocumentInitialProps> {
+    const page = await renderPage();
     const styles = extractCritical(page.html);
-    const userAgent = req.headers['user-agent'];
+    const userAgent = req!.headers['user-agent'] || '';
     return {
       ...page,
       ...styles,
@@ -27,12 +46,12 @@ export default class MyDocument extends Document {
     };
   }
 
-  constructor(props) {
+  constructor(props: Props & DocumentProps) {
     super(props);
 
     const { __NEXT_DATA__, ids } = props;
     if (ids) {
-      __NEXT_DATA__.ids = ids;
+      (__NEXT_DATA__ as any).ids = ids;
     }
   }
 
@@ -40,7 +59,7 @@ export default class MyDocument extends Document {
     const { userAgent, rollbarAccessToken, rollbarEnvironment } = this.props;
 
     return (
-      <html>
+      <html lang="en-US">
         <Head>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
 

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 
+import { css } from 'emotion';
+
 import { differenceInCalendarDays } from 'date-fns';
 
 import {
@@ -10,7 +12,6 @@ import {
   CHARLES_BLUE,
   MEDIA_LARGE_MAX,
 } from '@cityofboston/react-fleet';
-import { css } from 'emotion';
 
 import AccessBostonHeader from '../client/AccessBostonHeader';
 import fetchAccountAndApps, {
@@ -70,15 +71,6 @@ export default class IndexPage extends React.Component<Props> {
       account,
       apps,
     };
-  };
-
-  sendEvent2GA = labelVal => {
-    (window as any).dataLayer.push({
-      event: 'access_boston',
-      eventCategory: 'Access Boston',
-      eventAction: 'Landing Page App Clicks',
-      eventLabel: labelVal,
-    });
   };
 
   render() {
@@ -191,17 +183,17 @@ export default class IndexPage extends React.Component<Props> {
       <ul className="ul m-v500">
         {apps.map(({ title, url, description }) => (
           <li key={title}>
-            <Link href={url}>
-              <a
-                className={`p-a300 ${APP_ROW_STYLE}`}
-                target={url.startsWith('/') ? '_self' : '_blank'}
-              >
-                <div className="t--info" style={{ color: 'inherit' }}>
-                  {title}
-                </div>
-                <div style={{ color: CHARLES_BLUE }}>{description}</div>
-              </a>
-            </Link>
+            <a
+              href={url}
+              id={`app-link-${title}`}
+              className={`p-a300 ${APP_ROW_STYLE}`}
+              target={url.startsWith('/') ? '_self' : '_blank'}
+            >
+              <div className="t--info" style={{ color: 'inherit' }}>
+                {title}
+              </div>
+              <div style={{ color: CHARLES_BLUE }}>{description}</div>
+            </a>
           </li>
         ))}
       </ul>
@@ -212,24 +204,22 @@ export default class IndexPage extends React.Component<Props> {
     return (
       <div className="g">
         {apps.map(({ title, url, iconUrl }) => (
-          <Link href={url} key={title}>
-            <a
-              onClick={() => this.sendEvent2GA(title)}
-              className="lwi m-t200 g--3 g--3--sl"
-              target={url.startsWith('/') ? '_self' : '_blank'}
-            >
-              <span className="lwi-ic">
-                <img
-                  src={
-                    iconUrl || 'https://patterns.boston.gov/images/b-dark.svg'
-                  }
-                  alt=""
-                  className={`lwi-i ${APP_IMAGE_STYLE}`}
-                />
-              </span>
-              <span className="lwi-t">{title}</span>
-            </a>
-          </Link>
+          <a
+            href={url}
+            key={title + url}
+            id={`app-icon-${title}`}
+            className="lwi m-t200 g--3 g--3--sl"
+            target={url.startsWith('/') ? '_self' : '_blank'}
+          >
+            <span className="lwi-ic">
+              <img
+                src={iconUrl || 'https://patterns.boston.gov/images/b-dark.svg'}
+                alt=""
+                className={`lwi-i ${APP_IMAGE_STYLE}`}
+              />
+            </span>
+            <span className="lwi-t">{title}</span>
+          </a>
         ))}
       </div>
     );

--- a/services-js/access-boston/src/server/access-boston.ts
+++ b/services-js/access-boston/src/server/access-boston.ts
@@ -11,7 +11,7 @@ import yar from 'yar';
 import cleanup from 'node-cleanup';
 import acceptLanguagePlugin from 'hapi-accept-language2';
 import hapiDevErrors from 'hapi-dev-errors';
-import next from 'next';
+const next = require('next');
 import { ApolloServer } from 'apollo-server-hapi';
 
 import { parse, Compile } from 'velocityjs';

--- a/services-js/access-boston/src/server/start.ts
+++ b/services-js/access-boston/src/server/start.ts
@@ -6,7 +6,10 @@
  */
 
 // We don't want any local configurations to affect the test runs
-if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'testcafe') {
+if (
+  process.env.NODE_ENV !== 'test' &&
+  process.env.NODE_ENV !== ('testcafe' as any)
+) {
   require('dotenv').config();
 }
 
@@ -27,3 +30,5 @@ startServer(rollbar).catch((err: Error) => {
   console.error('Error starting server', err);
   process.exit(1);
 });
+
+export {};

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -50,6 +50,7 @@ exports[`Storyshots AccessBostonHeader default 1`] = `
     <a
       href="/"
       onClick={[Function]}
+      onMouseEnter={[Function]}
       style={
         Object {
           "color": "inherit",
@@ -102,6 +103,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -410,6 +412,7 @@ Array [
               <a
                 href="/"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 Cancel and go back to Access Boston
               </a>
@@ -480,6 +483,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -862,6 +866,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -1249,6 +1254,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -1557,6 +1563,7 @@ Array [
               <a
                 href="/"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 Cancel and go back to Access Boston
               </a>
@@ -1682,6 +1689,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -1990,6 +1998,7 @@ Array [
               <a
                 href="/"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 Cancel and go back to Access Boston
               </a>
@@ -2093,6 +2102,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -2401,6 +2411,7 @@ Array [
               <a
                 href="/"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 Cancel and go back to Access Boston
               </a>
@@ -2493,6 +2504,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -3581,6 +3593,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -3676,7 +3689,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://baisfn.cityhall.boston.cob/"
-            onClick={[Function]}
+            id="app-icon-BAIS FN"
             target="_blank"
           >
             <span
@@ -3697,7 +3710,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://hcm.cityhall.boston.cob/"
-            onClick={[Function]}
+            id="app-icon-BAIS HCM"
             target="_blank"
           >
             <span
@@ -3718,7 +3731,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://boston.maps.arcgis.com/"
-            onClick={[Function]}
+            id="app-icon-Boston Maps"
             target="_blank"
           >
             <span
@@ -3739,7 +3752,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://employeeconnect-boston.icims.com/"
-            onClick={[Function]}
+            id="app-icon-Current Job Openings"
             target="_blank"
           >
             <span
@@ -3760,7 +3773,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://careercenter-boston.icims.com/jobs/"
-            onClick={[Function]}
+            id="app-icon-Current Job Openings"
             target="_blank"
           >
             <span
@@ -3781,7 +3794,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://boston.icims.com/platform"
-            onClick={[Function]}
+            id="app-icon-Career Center"
             target="_blank"
           >
             <span
@@ -3802,7 +3815,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://ess.boston.gov/"
-            onClick={[Function]}
+            id="app-icon-Employee Self-Service"
             target="_blank"
           >
             <span
@@ -3823,7 +3836,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://edit-dev-hub.boston.gov/user"
-            onClick={[Function]}
+            id="app-icon-The Hub"
             target="_blank"
           >
             <span
@@ -3844,7 +3857,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://login.us2.oraclecloud.com/"
-            onClick={[Function]}
+            id="app-icon-Hyperion"
             target="_blank"
           >
             <span
@@ -3865,7 +3878,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://platform.civisanalytics.com/"
-            onClick={[Function]}
+            id="app-icon-Civis"
             target="_blank"
           >
             <span
@@ -3886,7 +3899,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://identity.boston.gov/identityiq/"
-            onClick={[Function]}
+            id="app-icon-IIQ"
             target="_blank"
           >
             <span
@@ -3907,7 +3920,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://https://sso.e-builder.net/"
-            onClick={[Function]}
+            id="app-icon-E-builder"
             target="_blank"
           >
             <span
@@ -3928,7 +3941,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://login.frontlineeducation.com/"
-            onClick={[Function]}
+            id="app-icon-Employee Training"
             target="_blank"
           >
             <span
@@ -3949,7 +3962,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://bostonpublicschools.tedk12.com/hire/index.aspx"
-            onClick={[Function]}
+            id="app-icon-BPS TalentEd"
             target="_blank"
           >
             <span
@@ -3993,7 +4006,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/createSponsor.jsf"
-                onClick={[Function]}
+                id="app-link-Create Sponsored Account"
                 target="_blank"
               >
                 <div
@@ -4021,7 +4034,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="http://boston.getlocalmotion.com/"
-                onClick={[Function]}
+                id="app-link-FleetHub"
                 target="_blank"
               >
                 <div
@@ -4049,7 +4062,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://goo.gl/forms/Xobh9aZeGXSnKH2m2"
-                onClick={[Function]}
+                id="app-link-International Travel"
                 target="_blank"
               >
                 <div
@@ -4077,7 +4090,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://boston.seamlessdocs.com/f/geol18cumhw"
-                onClick={[Function]}
+                id="app-link-Unblock Website Request"
                 target="_blank"
               >
                 <div
@@ -4105,7 +4118,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://eamtst.cityhall.boston.cob:5443/WebMaint/"
-                onClick={[Function]}
+                id="app-link-Building Maintenance"
                 target="_blank"
               >
                 <div
@@ -4133,7 +4146,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/requestPsfn.jsf"
-                onClick={[Function]}
+                id="app-link-Request FN Access"
                 target="_blank"
               >
                 <div
@@ -4180,7 +4193,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="/change-password"
-                onClick={[Function]}
+                id="app-link-Change My Password"
                 target="_self"
               >
                 <div
@@ -4208,7 +4221,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://desktop.pingone.com/boston-dev/Selection?cmd=devices"
-                onClick={[Function]}
+                id="app-link-Manage My Device(s)"
                 target="_blank"
               >
                 <div
@@ -4255,7 +4268,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/identityVerification.jsf"
-                onClick={[Function]}
+                id="app-link-Identity Verification"
                 target="_blank"
               >
                 <div
@@ -4283,7 +4296,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/lcm/chooseIdentities.jsf?quickLink=COB-QuickLink-ViewIdentityOnly"
-                onClick={[Function]}
+                id="app-link-View User Information"
                 target="_blank"
               >
                 <div
@@ -4311,7 +4324,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="#"
-                onClick={[Function]}
+                id="app-link-Edit Group"
                 target="_blank"
               >
                 <div
@@ -4358,7 +4371,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/dashboard/editPreferences.jsf"
-                onClick={[Function]}
+                id="app-link-Set a Delegate"
                 target="_blank"
               >
                 <div
@@ -4386,7 +4399,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/manage/workItems/workItems.jsf?workItemType=Approval"
-                onClick={[Function]}
+                id="app-link-My Approvals"
                 target="_blank"
               >
                 <div
@@ -4414,7 +4427,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/extendSponsor.jsf"
-                onClick={[Function]}
+                id="app-link-Manage Sponsored Account"
                 target="_blank"
               >
                 <div
@@ -4494,6 +4507,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -4571,7 +4585,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://baisfn.cityhall.boston.cob/"
-            onClick={[Function]}
+            id="app-icon-BAIS FN"
             target="_blank"
           >
             <span
@@ -4592,7 +4606,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://hcm.cityhall.boston.cob/"
-            onClick={[Function]}
+            id="app-icon-BAIS HCM"
             target="_blank"
           >
             <span
@@ -4613,7 +4627,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://boston.maps.arcgis.com/"
-            onClick={[Function]}
+            id="app-icon-Boston Maps"
             target="_blank"
           >
             <span
@@ -4634,7 +4648,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://employeeconnect-boston.icims.com/"
-            onClick={[Function]}
+            id="app-icon-Current Job Openings"
             target="_blank"
           >
             <span
@@ -4655,7 +4669,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://careercenter-boston.icims.com/jobs/"
-            onClick={[Function]}
+            id="app-icon-Current Job Openings"
             target="_blank"
           >
             <span
@@ -4676,7 +4690,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://boston.icims.com/platform"
-            onClick={[Function]}
+            id="app-icon-Career Center"
             target="_blank"
           >
             <span
@@ -4697,7 +4711,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://ess.boston.gov/"
-            onClick={[Function]}
+            id="app-icon-Employee Self-Service"
             target="_blank"
           >
             <span
@@ -4718,7 +4732,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://edit-dev-hub.boston.gov/user"
-            onClick={[Function]}
+            id="app-icon-The Hub"
             target="_blank"
           >
             <span
@@ -4739,7 +4753,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://login.us2.oraclecloud.com/"
-            onClick={[Function]}
+            id="app-icon-Hyperion"
             target="_blank"
           >
             <span
@@ -4760,7 +4774,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://platform.civisanalytics.com/"
-            onClick={[Function]}
+            id="app-icon-Civis"
             target="_blank"
           >
             <span
@@ -4781,7 +4795,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://identity.boston.gov/identityiq/"
-            onClick={[Function]}
+            id="app-icon-IIQ"
             target="_blank"
           >
             <span
@@ -4802,7 +4816,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://https://sso.e-builder.net/"
-            onClick={[Function]}
+            id="app-icon-E-builder"
             target="_blank"
           >
             <span
@@ -4823,7 +4837,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://login.frontlineeducation.com/"
-            onClick={[Function]}
+            id="app-icon-Employee Training"
             target="_blank"
           >
             <span
@@ -4844,7 +4858,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://bostonpublicschools.tedk12.com/hire/index.aspx"
-            onClick={[Function]}
+            id="app-icon-BPS TalentEd"
             target="_blank"
           >
             <span
@@ -4888,7 +4902,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/createSponsor.jsf"
-                onClick={[Function]}
+                id="app-link-Create Sponsored Account"
                 target="_blank"
               >
                 <div
@@ -4916,7 +4930,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="http://boston.getlocalmotion.com/"
-                onClick={[Function]}
+                id="app-link-FleetHub"
                 target="_blank"
               >
                 <div
@@ -4944,7 +4958,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://goo.gl/forms/Xobh9aZeGXSnKH2m2"
-                onClick={[Function]}
+                id="app-link-International Travel"
                 target="_blank"
               >
                 <div
@@ -4972,7 +4986,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://boston.seamlessdocs.com/f/geol18cumhw"
-                onClick={[Function]}
+                id="app-link-Unblock Website Request"
                 target="_blank"
               >
                 <div
@@ -5000,7 +5014,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://eamtst.cityhall.boston.cob:5443/WebMaint/"
-                onClick={[Function]}
+                id="app-link-Building Maintenance"
                 target="_blank"
               >
                 <div
@@ -5028,7 +5042,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/requestPsfn.jsf"
-                onClick={[Function]}
+                id="app-link-Request FN Access"
                 target="_blank"
               >
                 <div
@@ -5075,7 +5089,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="/change-password"
-                onClick={[Function]}
+                id="app-link-Change My Password"
                 target="_self"
               >
                 <div
@@ -5103,7 +5117,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://desktop.pingone.com/boston-dev/Selection?cmd=devices"
-                onClick={[Function]}
+                id="app-link-Manage My Device(s)"
                 target="_blank"
               >
                 <div
@@ -5150,7 +5164,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/identityVerification.jsf"
-                onClick={[Function]}
+                id="app-link-Identity Verification"
                 target="_blank"
               >
                 <div
@@ -5178,7 +5192,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/lcm/chooseIdentities.jsf?quickLink=COB-QuickLink-ViewIdentityOnly"
-                onClick={[Function]}
+                id="app-link-View User Information"
                 target="_blank"
               >
                 <div
@@ -5206,7 +5220,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="#"
-                onClick={[Function]}
+                id="app-link-Edit Group"
                 target="_blank"
               >
                 <div
@@ -5253,7 +5267,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/dashboard/editPreferences.jsf"
-                onClick={[Function]}
+                id="app-link-Set a Delegate"
                 target="_blank"
               >
                 <div
@@ -5281,7 +5295,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/manage/workItems/workItems.jsf?workItemType=Approval"
-                onClick={[Function]}
+                id="app-link-My Approvals"
                 target="_blank"
               >
                 <div
@@ -5309,7 +5323,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/extendSponsor.jsf"
-                onClick={[Function]}
+                id="app-link-Manage Sponsored Account"
                 target="_blank"
               >
                 <div
@@ -5389,6 +5403,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -5472,6 +5487,7 @@ Array [
               className="btn"
               href="/mfa"
               onClick={[Function]}
+              onMouseEnter={[Function]}
               style={
                 Object {
                   "whiteSpace": "nowrap",
@@ -5519,7 +5535,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://baisfn.cityhall.boston.cob/"
-            onClick={[Function]}
+            id="app-icon-BAIS FN"
             target="_blank"
           >
             <span
@@ -5540,7 +5556,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://hcm.cityhall.boston.cob/"
-            onClick={[Function]}
+            id="app-icon-BAIS HCM"
             target="_blank"
           >
             <span
@@ -5561,7 +5577,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://boston.maps.arcgis.com/"
-            onClick={[Function]}
+            id="app-icon-Boston Maps"
             target="_blank"
           >
             <span
@@ -5582,7 +5598,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://employeeconnect-boston.icims.com/"
-            onClick={[Function]}
+            id="app-icon-Current Job Openings"
             target="_blank"
           >
             <span
@@ -5603,7 +5619,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://careercenter-boston.icims.com/jobs/"
-            onClick={[Function]}
+            id="app-icon-Current Job Openings"
             target="_blank"
           >
             <span
@@ -5624,7 +5640,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://boston.icims.com/platform"
-            onClick={[Function]}
+            id="app-icon-Career Center"
             target="_blank"
           >
             <span
@@ -5645,7 +5661,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://ess.boston.gov/"
-            onClick={[Function]}
+            id="app-icon-Employee Self-Service"
             target="_blank"
           >
             <span
@@ -5666,7 +5682,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://edit-dev-hub.boston.gov/user"
-            onClick={[Function]}
+            id="app-icon-The Hub"
             target="_blank"
           >
             <span
@@ -5687,7 +5703,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://login.us2.oraclecloud.com/"
-            onClick={[Function]}
+            id="app-icon-Hyperion"
             target="_blank"
           >
             <span
@@ -5708,7 +5724,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://platform.civisanalytics.com/"
-            onClick={[Function]}
+            id="app-icon-Civis"
             target="_blank"
           >
             <span
@@ -5729,7 +5745,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://identity.boston.gov/identityiq/"
-            onClick={[Function]}
+            id="app-icon-IIQ"
             target="_blank"
           >
             <span
@@ -5750,7 +5766,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://https://sso.e-builder.net/"
-            onClick={[Function]}
+            id="app-icon-E-builder"
             target="_blank"
           >
             <span
@@ -5771,7 +5787,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://login.frontlineeducation.com/"
-            onClick={[Function]}
+            id="app-icon-Employee Training"
             target="_blank"
           >
             <span
@@ -5792,7 +5808,7 @@ Array [
           <a
             className="lwi m-t200 g--3 g--3--sl"
             href="https://bostonpublicschools.tedk12.com/hire/index.aspx"
-            onClick={[Function]}
+            id="app-icon-BPS TalentEd"
             target="_blank"
           >
             <span
@@ -5836,7 +5852,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/createSponsor.jsf"
-                onClick={[Function]}
+                id="app-link-Create Sponsored Account"
                 target="_blank"
               >
                 <div
@@ -5864,7 +5880,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="http://boston.getlocalmotion.com/"
-                onClick={[Function]}
+                id="app-link-FleetHub"
                 target="_blank"
               >
                 <div
@@ -5892,7 +5908,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://goo.gl/forms/Xobh9aZeGXSnKH2m2"
-                onClick={[Function]}
+                id="app-link-International Travel"
                 target="_blank"
               >
                 <div
@@ -5920,7 +5936,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://boston.seamlessdocs.com/f/geol18cumhw"
-                onClick={[Function]}
+                id="app-link-Unblock Website Request"
                 target="_blank"
               >
                 <div
@@ -5948,7 +5964,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://eamtst.cityhall.boston.cob:5443/WebMaint/"
-                onClick={[Function]}
+                id="app-link-Building Maintenance"
                 target="_blank"
               >
                 <div
@@ -5976,7 +5992,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/requestPsfn.jsf"
-                onClick={[Function]}
+                id="app-link-Request FN Access"
                 target="_blank"
               >
                 <div
@@ -6023,7 +6039,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="/change-password"
-                onClick={[Function]}
+                id="app-link-Change My Password"
                 target="_self"
               >
                 <div
@@ -6051,7 +6067,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://desktop.pingone.com/boston-dev/Selection?cmd=devices"
-                onClick={[Function]}
+                id="app-link-Manage My Device(s)"
                 target="_blank"
               >
                 <div
@@ -6098,7 +6114,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/identityVerification.jsf"
-                onClick={[Function]}
+                id="app-link-Identity Verification"
                 target="_blank"
               >
                 <div
@@ -6126,7 +6142,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/lcm/chooseIdentities.jsf?quickLink=COB-QuickLink-ViewIdentityOnly"
-                onClick={[Function]}
+                id="app-link-View User Information"
                 target="_blank"
               >
                 <div
@@ -6154,7 +6170,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="#"
-                onClick={[Function]}
+                id="app-link-Edit Group"
                 target="_blank"
               >
                 <div
@@ -6201,7 +6217,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/dashboard/editPreferences.jsf"
-                onClick={[Function]}
+                id="app-link-Set a Delegate"
                 target="_blank"
               >
                 <div
@@ -6229,7 +6245,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/manage/workItems/workItems.jsf?workItemType=Approval"
-                onClick={[Function]}
+                id="app-link-My Approvals"
                 target="_blank"
               >
                 <div
@@ -6257,7 +6273,7 @@ Array [
               <a
                 className="p-a300 css-v7ibj3"
                 href="https://identity.boston.gov/identityiq/extendSponsor.jsf"
-                onClick={[Function]}
+                id="app-link-Manage Sponsored Account"
                 target="_blank"
               >
                 <div
@@ -6702,6 +6718,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -6911,6 +6928,7 @@ Array [
           <a
             href="/mfa?email=1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             Get codes via personal email
           </a>
@@ -6979,6 +6997,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -7125,6 +7144,7 @@ Array [
           <a
             href="/mfa"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             get codes via phone call or text
           </a>
@@ -7204,6 +7224,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -7413,6 +7434,7 @@ Array [
           <a
             href="/mfa?email=1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             Get codes via personal email
           </a>
@@ -7749,6 +7771,7 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationForm code sending error 1`
         <a
           href="/mfa?email=1"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
           Get codes via personal email
         </a>
@@ -7866,6 +7889,7 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationForm email with error 1`] 
         <a
           href="/mfa"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
           get codes via phone call or text
         </a>
@@ -8057,6 +8081,7 @@ exports[`Storyshots RegisterMfaPage/DeviceVerificationForm phone 1`] = `
         <a
           href="/mfa?email=1"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
           Get codes via personal email
         </a>
@@ -8678,6 +8703,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -8776,6 +8802,7 @@ Array [
               className="btn"
               href="/change-password"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
               Get Started
             </a>
@@ -8872,6 +8899,7 @@ Array [
       <a
         href="/"
         onClick={[Function]}
+        onMouseEnter={[Function]}
         style={
           Object {
             "color": "inherit",
@@ -8971,6 +8999,7 @@ Array [
               className="btn"
               href="/mfa"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
               Get Started
             </a>

--- a/services-js/access-boston/src/tsconfig.json
+++ b/services-js/access-boston/src/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "noEmit": true,
+    "module": "esnext",
+    "allowJs": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/services-js/commissions-app/next.config.js
+++ b/services-js/commissions-app/next.config.js
@@ -1,9 +1,6 @@
 const path = require('path');
-const withTypescript = require('@zeit/next-typescript');
 const withPolyfill = require('@cityofboston/next-client-common/with-polyfill')();
 
-module.exports = withTypescript(
-  withPolyfill({
-    distDir: path.join('..', 'build', '.next'),
-  })
-);
+module.exports = withPolyfill({
+  distDir: path.join('..', 'build', '.next'),
+});

--- a/services-js/commissions-app/package.json
+++ b/services-js/commissions-app/package.json
@@ -35,7 +35,7 @@
     "graphql": "0.13.2"
   },
   "dependencies": {
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/form-common": "^0.0.0",
     "@cityofboston/hapi-common": "^0.0.0",
     "@cityofboston/hapi-next": "^0.0.0",
@@ -60,7 +60,7 @@
     "isomorphic-fetch": "^2.2.1",
     "mjml": "^4.3.1",
     "mssql": "^4.2.1",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "node-cleanup": "^2.1.2",
     "postmark": "^1.6.1",
     "react": "16.8.5",
@@ -70,8 +70,8 @@
     "yup": "0.27.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@cityofboston/graphql-typescript": "^0.0.0",
@@ -96,7 +96,6 @@
     "@types/storybook__addon-actions": "^3.4.2",
     "@types/storybook__addon-storyshots": "^3.4.8",
     "@types/storybook__react": "^4.0.1",
-    "@zeit/next-typescript": "1.1.1",
     "babel-core": "^7.0.0-0",
     "concurrently": "^3.5.1",
     "eslint-plugin-graphql": "^3.0.3",

--- a/services-js/commissions-app/src/next-env.d.ts
+++ b/services-js/commissions-app/src/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/services-js/commissions-app/src/pages/_app.tsx
+++ b/services-js/commissions-app/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import App, { Container } from 'next/app';
+import App, { AppProps } from 'next/app';
 import Router from 'next/router';
 import { hydrate, cache as emotionCache } from 'emotion';
 import { CacheProvider } from '@emotion/core';
@@ -16,34 +16,13 @@ if (typeof window !== 'undefined') {
   hydrate((window as any).__NEXT_DATA__.ids);
 }
 
-interface Props {
-  pageProps: any;
-  Component: any;
-}
-
 export default class CommissionsApp extends App {
-  // TypeScript doesn't know that App already has a props member.
-  protected props: Props;
-
   private routerListener: RouterListener;
   private siteAnalytics: SiteAnalytics;
   private screenReaderSupport: ScreenReaderSupport;
 
-  static async getInitialProps({ Component, ctx }) {
-    const pageProps = Component.getInitialProps
-      ? await Component.getInitialProps(ctx)
-      : {};
-
-    return { pageProps };
-  }
-
-  constructor(props: Props) {
+  constructor(props: AppProps) {
     super(props);
-
-    // We're a little hacky here because TypeScript doesn't have type
-    // information about App and doesn't know it's a component and that the
-    // super call above actually does this.
-    this.props = props;
 
     this.routerListener = new RouterListener();
     this.siteAnalytics = new GtagSiteAnalytics();
@@ -69,9 +48,7 @@ export default class CommissionsApp extends App {
 
     return (
       <CacheProvider value={emotionCache}>
-        <Container>
-          <Component {...pageProps} />
-        </Container>
+        <Component {...pageProps} />
       </CacheProvider>
     );
   }

--- a/services-js/commissions-app/src/pages/_document.tsx
+++ b/services-js/commissions-app/src/pages/_document.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, {
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentInitialProps,
+  DocumentProps,
+} from 'next/document';
 import { extractCritical } from 'emotion-server';
 
 import {
@@ -13,13 +20,23 @@ import {
   ScreenReaderSupport,
 } from '@cityofboston/next-client-common';
 
-export default class MyDocument extends Document {
-  props: any;
+type Props = {
+  userAgent: string;
+  rollbarAccessToken: string | undefined;
+  rollbarEnvironment: string | undefined;
 
-  static getInitialProps({ renderPage, req }) {
-    const page = renderPage();
+  ids: string[];
+  css: string;
+};
+
+export default class CommissionsDocument extends Document<Props> {
+  static async getInitialProps({
+    renderPage,
+    req,
+  }: DocumentContext): Promise<DocumentInitialProps & Props> {
+    const page = await renderPage();
     const styles = extractCritical(page.html);
-    const userAgent = req.headers['user-agent'];
+    const userAgent = req!.headers['user-agent'] || '';
     return {
       ...page,
       ...styles,
@@ -30,12 +47,12 @@ export default class MyDocument extends Document {
     };
   }
 
-  constructor(props) {
+  constructor(props: DocumentProps & Props) {
     super(props);
 
     const { __NEXT_DATA__, ids } = props;
     if (ids) {
-      __NEXT_DATA__.ids = ids;
+      (__NEXT_DATA__ as any).ids = ids;
     }
   }
 

--- a/services-js/commissions-app/src/server/commissions-app.ts
+++ b/services-js/commissions-app/src/server/commissions-app.ts
@@ -7,7 +7,7 @@ import { boomify } from 'boom';
 import Inert from 'inert';
 import cleanup from 'node-cleanup';
 import acceptLanguagePlugin from 'hapi-accept-language2';
-import next from 'next';
+const next = require('next');
 import Rollbar from 'rollbar';
 import { Client as PostmarkClient } from 'postmark';
 import { ApolloServer } from 'apollo-server-hapi';

--- a/services-js/commissions-app/src/server/start.ts
+++ b/services-js/commissions-app/src/server/start.ts
@@ -23,3 +23,5 @@ startServer(rollbar).catch((err: Error) => {
   console.error('Error starting server', err);
   process.exit(1);
 });
+
+export {};

--- a/services-js/commissions-app/src/tsconfig.json
+++ b/services-js/commissions-app/src/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowJs": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/services-js/internal-slack-bot/package.json
+++ b/services-js/internal-slack-bot/package.json
@@ -43,8 +43,8 @@
     "rollbar": "^2.5.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@types/aws-sdk": "^2.7.0",

--- a/services-js/permit-finder/next.config.js
+++ b/services-js/permit-finder/next.config.js
@@ -1,9 +1,6 @@
 const path = require('path');
-const withTypescript = require('@zeit/next-typescript');
 const withPolyfill = require('@cityofboston/next-client-common/with-polyfill')();
 
-module.exports = withTypescript(
-  withPolyfill({
-    distDir: path.join('..', 'build', '.next'),
-  })
-);
+module.exports = withPolyfill({
+  distDir: path.join('..', 'build', '.next'),
+});

--- a/services-js/permit-finder/package.json
+++ b/services-js/permit-finder/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/deploy-tools": "^0.0.0",
     "@cityofboston/hapi-common": "^0.0.0",
     "@cityofboston/hapi-next": "^0.0.0",
@@ -53,7 +53,7 @@
     "inert": "^5.1.0",
     "level": "^5.0.1",
     "moment-timezone": "^0.5.14",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "node-cleanup": "^2.1.2",
     "node-fetch": "^2.2.0",
     "pump": "^3.0.0",
@@ -65,8 +65,8 @@
     "tmp": "0.0.33"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@cityofboston/graphql-typescript": "^0.0.0",
@@ -94,7 +94,6 @@
     "@types/storybook__react": "^4.0.1",
     "@types/yar": "^9.0.4",
     "@types/yup": "^0.26.0",
-    "@zeit/next-typescript": "1.1.1",
     "babel-core": "^7.0.0-0",
     "babel-plugin-inline-import": "^2.0.6",
     "concurrently": "^3.5.1",

--- a/services-js/permit-finder/src/next-env.d.ts
+++ b/services-js/permit-finder/src/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/services-js/permit-finder/src/pages/_app.tsx
+++ b/services-js/permit-finder/src/pages/_app.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import App, { Container } from 'next/app';
+import App, { AppProps, AppContext, AppInitialProps } from 'next/app';
 import Router from 'next/router';
 import getConfig from 'next/config';
+import { NextPageContext } from 'next';
 
 import {
   FetchGraphql,
   makeFetchGraphql,
   RouterListener,
-  NextContext,
   GtagSiteAnalytics,
   ScreenReaderSupport,
   SiteAnalytics,
@@ -23,10 +23,10 @@ export interface GetInitialPropsDependencies {
 
 export type GetInitialProps<
   T,
-  C extends keyof NextContext = never,
+  C extends keyof NextPageContext = never,
   D extends keyof GetInitialPropsDependencies = never
 > = (
-  cxt: Pick<NextContext, C>,
+  cxt: Pick<NextPageContext, C>,
   deps: Pick<GetInitialPropsDependencies, D>
 ) => T | Promise<T>;
 
@@ -71,19 +71,6 @@ export interface PageDependencies {
   screenReaderSupport: ScreenReaderSupport;
 }
 
-interface AppInitialProps {
-  ctx: NextContext;
-  Component: any;
-}
-
-interface InitialProps {
-  pageProps: any;
-}
-
-interface Props extends InitialProps {
-  Component: any;
-}
-
 /**
  * Custom app wrapper for setting up global dependencies:
  *
@@ -91,22 +78,23 @@ interface Props extends InitialProps {
  *  - PageDependencies are spread as props for the page
  */
 export default class AccessBostonApp extends App {
-  // TypeScript doesn't know that App already has a props member.
-  protected props: Props;
-
   private pageDependencies: PageDependencies;
 
   static async getInitialProps({
     Component,
     ctx,
-  }: AppInitialProps): Promise<InitialProps> {
+  }: AppContext): Promise<AppInitialProps> {
     try {
       const initialPageDependencies: GetInitialPropsDependencies = {
         fetchGraphql: makeFetchGraphql(getConfig(), ctx.req),
       };
 
       const pageProps = Component.getInitialProps
-        ? await Component.getInitialProps(ctx, initialPageDependencies)
+        ? await (Component.getInitialProps as GetInitialProps<
+            any,
+            keyof NextPageContext,
+            keyof GetInitialPropsDependencies
+          >)(ctx, initialPageDependencies)
         : {};
 
       return { pageProps };
@@ -129,13 +117,8 @@ export default class AccessBostonApp extends App {
     }
   }
 
-  constructor(props: Props) {
+  constructor(props: AppProps<any>) {
     super(props);
-
-    // We're a little hacky here because TypeScript doesn't have type
-    // information about App and doesn't know it's a component and that the
-    // super call above actually does this.
-    this.props = props;
 
     this.pageDependencies = {
       routerListener: new RouterListener(),
@@ -176,10 +159,6 @@ export default class AccessBostonApp extends App {
   render() {
     const { Component, pageProps } = this.props;
 
-    return (
-      <Container>
-        <Component {...this.pageDependencies} {...pageProps} />
-      </Container>
-    );
+    return <Component {...this.pageDependencies} {...pageProps} />;
   }
 }

--- a/services-js/permit-finder/src/pages/_document.tsx
+++ b/services-js/permit-finder/src/pages/_document.tsx
@@ -1,4 +1,10 @@
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, {
+  Head,
+  Main,
+  NextScript,
+  DocumentInitialProps,
+  DocumentContext,
+} from 'next/document';
 
 import {
   makeNProgressStyle,
@@ -7,12 +13,19 @@ import {
 } from '@cityofboston/next-client-common';
 import { CompatibilityWarning, StatusModal } from '@cityofboston/react-fleet';
 
-export default class PermitFinderDocument extends Document {
-  props: any;
+type Props = {
+  userAgent: string;
+  rollbarAccessToken: string | undefined;
+  rollbarEnvironment: string | undefined;
+};
 
-  static async getInitialProps({ renderPage, req }) {
+export default class PermitFinderDocument extends Document<Props> {
+  static async getInitialProps({
+    renderPage,
+    req,
+  }: DocumentContext): Promise<Props & DocumentInitialProps> {
     const page = await renderPage();
-    const userAgent = req.headers['user-agent'];
+    const userAgent = req!.headers['user-agent'] || '';
 
     return {
       ...page,
@@ -27,10 +40,10 @@ export default class PermitFinderDocument extends Document {
     const { userAgent, rollbarAccessToken, rollbarEnvironment } = this.props;
 
     return (
-      <html>
+      <html lang="en-US">
         <Head>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link
             rel="shortcut icon"
             href="/assets/favicon.ico"

--- a/services-js/permit-finder/src/server/permit-finder.ts
+++ b/services-js/permit-finder/src/server/permit-finder.ts
@@ -12,7 +12,7 @@ import {
 import Inert from 'inert';
 import cleanup from 'node-cleanup';
 import hapiDevErrors from 'hapi-dev-errors';
-import next from 'next';
+const next = require('next');
 import { ApolloServer } from 'apollo-server-hapi';
 import AWS from 'aws-sdk';
 
@@ -137,7 +137,7 @@ export async function makeServer(port, rollbar: Rollbar) {
     route: {
       cors: true,
       auth:
-        apiKeys.length || process.env.NODE_ENV == 'staging'
+        apiKeys.length || process.env.NODE_ENV == ('staging' as any)
           ? 'apiHeaderKeys'
           : false,
     },

--- a/services-js/permit-finder/src/server/start.ts
+++ b/services-js/permit-finder/src/server/start.ts
@@ -6,7 +6,10 @@
  */
 
 // We don't want any local configurations to affect the test runs
-if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'testcafe') {
+if (
+  process.env.NODE_ENV !== 'test' &&
+  process.env.NODE_ENV !== ('testcafe' as any)
+) {
   require('dotenv').config();
 }
 
@@ -27,3 +30,5 @@ startServer(rollbar).catch((err: Error) => {
   console.error('Error starting server', err);
   process.exit(1);
 });
+
+export {};

--- a/services-js/permit-finder/src/tsconfig.json
+++ b/services-js/permit-finder/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "noEmit": true,
+    "module": "esnext",
+    "allowJs": true
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/services-js/public-notices/next.config.js
+++ b/services-js/public-notices/next.config.js
@@ -1,23 +1,20 @@
 require('dotenv').config();
 
 const path = require('path');
-const withTypescript = require('@zeit/next-typescript');
 const withSourceMaps = require('@zeit/next-source-maps')();
 const withPolyfill = require('@cityofboston/next-client-common/with-polyfill')();
 
-module.exports = withTypescript(
-  withSourceMaps(
-    withPolyfill({
-      distDir: path.join('..', 'build', '.next'),
-      assetPrefix: process.env.ASSET_PREFIX || '/',
-      publicRuntimeConfig: {
-        noticesApiUrl:
-          process.env.NOTICES_API_URL ||
-          'https://www.boston.gov/api/v2/public-notices',
-        rollbarAccessToken: process.env.ROLLBAR_BROWSER_ACCESS_TOKEN,
-        rollbarEnvironment:
-          process.env.ROLLBAR_ENVIRONMENT || process.env.NODE_ENV,
-      },
-    })
-  )
+module.exports = withSourceMaps(
+  withPolyfill({
+    distDir: path.join('..', 'build', '.next'),
+    assetPrefix: process.env.ASSET_PREFIX || '/',
+    publicRuntimeConfig: {
+      noticesApiUrl:
+        process.env.NOTICES_API_URL ||
+        'https://www.boston.gov/api/v2/public-notices',
+      rollbarAccessToken: process.env.ROLLBAR_BROWSER_ACCESS_TOKEN,
+      rollbarEnvironment:
+        process.env.ROLLBAR_ENVIRONMENT || process.env.NODE_ENV,
+    },
+  })
 );

--- a/services-js/public-notices/package.json
+++ b/services-js/public-notices/package.json
@@ -36,7 +36,7 @@
     "mobx": "^4.3.0",
     "mobx-react": "^5.2.0",
     "mobx-utils": "^4.0.0",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "react": "16.8.5",
     "react-dom": "16.8.5"
   },
@@ -59,7 +59,6 @@
     "@types/storybook__addon-actions": "^3.4.2",
     "@types/storybook__addon-storyshots": "^3.4.8",
     "@types/storybook__react": "^4.0.1",
-    "@zeit/next-typescript": "1.1.1",
     "babel-core": "^7.0.0-0",
     "jest": "^24.8.0",
     "rimraf": "^2.6.2",

--- a/services-js/public-notices/src/next-env.d.ts
+++ b/services-js/public-notices/src/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/services-js/public-notices/src/pages/_app.tsx
+++ b/services-js/public-notices/src/pages/_app.tsx
@@ -1,23 +1,10 @@
 import React from 'react';
-import App, { Container } from 'next/app';
+import App, { AppContext, AppProps, AppInitialProps } from 'next/app';
 
 import { configure as mobxConfigure } from 'mobx';
 
 import { cache as emotionCache, hydrate } from 'emotion';
 import { CacheProvider } from '@emotion/core';
-
-interface AppInitialProps {
-  ctx: any;
-  Component: any;
-}
-
-interface InitialProps {
-  pageProps: any;
-}
-
-interface Props extends InitialProps {
-  Component: any;
-}
 
 if (typeof window !== 'undefined') {
   const nextData = (window as any).__NEXT_DATA__;
@@ -31,14 +18,12 @@ if (typeof window !== 'undefined') {
  * Component to initialize Emotion and MobX.
  */
 export default class PublicNoticesApp extends App {
-  // TypeScript doesn't know that App already has a props member.
-  protected props: Props;
   private versionInterval: number | null = null;
 
   static async getInitialProps({
     Component,
     ctx,
-  }: AppInitialProps): Promise<InitialProps> {
+  }: AppContext): Promise<AppInitialProps> {
     const pageProps = Component.getInitialProps
       ? await Component.getInitialProps(ctx)
       : {};
@@ -48,13 +33,8 @@ export default class PublicNoticesApp extends App {
     };
   }
 
-  constructor(props: Props) {
+  constructor(props: AppProps) {
     super(props);
-
-    // We're a little hacky here because TypeScript doesn't have type
-    // information about App and doesn't know it's a component and that the
-    // super call above actually does this.
-    this.props = props;
 
     if (typeof window !== 'undefined') {
       const nextData = (window as any).__NEXT_DATA__;
@@ -86,9 +66,7 @@ export default class PublicNoticesApp extends App {
 
     return (
       <CacheProvider value={emotionCache}>
-        <Container>
-          <Component {...pageProps} />
-        </Container>
+        <Component {...pageProps} />
       </CacheProvider>
     );
   }

--- a/services-js/public-notices/src/pages/_document.tsx
+++ b/services-js/public-notices/src/pages/_document.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
-import { DocumentContext } from 'next';
 import getConfig from 'next/config';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, {
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentProps,
+  DocumentInitialProps,
+} from 'next/document';
 import { extractCritical } from 'emotion-server';
 
 type Props = {
-  __NEXT_DATA__: any;
   // From Emotion’s hydration
   ids?: string[];
   css: string;
 };
 
-export default class extends Document {
-  props: Props;
-
-  static getInitialProps({ renderPage }: DocumentContext): Props {
-    const page = renderPage();
+export default class extends Document<Props> {
+  static async getInitialProps({
+    renderPage,
+  }: DocumentContext): Promise<Props & DocumentInitialProps> {
+    const page = await renderPage();
     const styles = extractCritical(page.html);
 
     return {
@@ -24,15 +29,14 @@ export default class extends Document {
     };
   }
 
-  constructor(props: Props) {
+  constructor(props: Props & DocumentProps) {
     super(props);
-    this.props = props;
 
     const { __NEXT_DATA__, ids } = props;
 
     // These are the ids for Emotion classes already on the page.
     if (ids) {
-      __NEXT_DATA__.ids = ids;
+      (__NEXT_DATA__ as any).ids = ids;
     }
   }
 

--- a/services-js/public-notices/src/tsconfig.json
+++ b/services-js/public-notices/src/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "module": "esnext"
+  },
+  "exclude": ["node_modules"]
+}

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -555,6 +555,7 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
                 <a
                   href="/birth"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   birth
                 </a>
@@ -563,6 +564,7 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
                 <a
                   href="/marriage"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   marriage
                 </a>
@@ -571,6 +573,7 @@ exports[`Storyshots Birth/CheckoutPage confirmation 1`] = `
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   death
                 </a>
@@ -894,6 +897,7 @@ exports[`Storyshots Birth/CheckoutPage no birth certificate request 1`] = `
                 className="btn"
                 href="/birth"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 Back to Start
               </a>
@@ -1367,6 +1371,7 @@ exports[`Storyshots Birth/CheckoutPage payment 1`] = `
                           aria-label="Edit shipping address"
                           href="/birth/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -1513,6 +1518,7 @@ exports[`Storyshots Birth/CheckoutPage payment 1`] = `
                   <a
                     href="/birth/checkout?page=shipping"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -2065,6 +2071,7 @@ exports[`Storyshots Birth/CheckoutPage review 1`] = `
                           aria-label="Edit contact information"
                           href="/birth/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -2108,6 +2115,7 @@ exports[`Storyshots Birth/CheckoutPage review 1`] = `
                           aria-label="Edit shipping address"
                           href="/birth/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -2155,6 +2163,7 @@ exports[`Storyshots Birth/CheckoutPage review 1`] = `
                           aria-label="Edit payment information"
                           href="/birth/checkout?page=payment"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -3758,6 +3767,7 @@ exports[`Storyshots Birth/CheckoutPage shipping 1`] = `
                   <a
                     href="/birth/review"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -17750,6 +17760,7 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent birth 1`
                 <a
                   href="/birth"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   birth
                 </a>
@@ -17758,6 +17769,7 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent birth 1`
                 <a
                   href="/marriage"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   marriage
                 </a>
@@ -17766,6 +17778,7 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent birth 1`
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   death
                 </a>
@@ -18337,6 +18350,7 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent marriage
                 <a
                   href="/birth"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   birth
                 </a>
@@ -18345,6 +18359,7 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent marriage
                 <a
                   href="/marriage"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   marriage
                 </a>
@@ -18353,6 +18368,7 @@ exports[`Storyshots Common Components/Checkout/OrderConfirmationContent marriage
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   death
                 </a>
@@ -18751,6 +18767,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent Stripe error 1`] =
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -19417,6 +19434,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent Stripe error 1`] =
                 <a
                   href="/death/checkout?page=shipping"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -19810,6 +19828,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent ZIP code error 1`]
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -20435,6 +20454,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent ZIP code error 1`]
                 <a
                   href="/death/checkout?page=shipping"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -20914,6 +20934,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent birth certificate 
                           aria-label="Edit shipping address"
                           href="/birth/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -21539,6 +21560,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent birth certificate 
                   <a
                     href="/birth/checkout?page=shipping"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -21953,6 +21975,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent credit card error 
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -22103,6 +22126,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent credit card error 
                 <a
                   href="/death/checkout?page=shipping"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -22496,6 +22520,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent default 1`] = `
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -22642,6 +22667,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent default 1`] = `
                 <a
                   href="/death/checkout?page=shipping"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -23035,6 +23061,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent existing billing 1
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -23660,6 +23687,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent existing billing 1
                 <a
                   href="/death/checkout?page=shipping"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -24139,6 +24167,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent marriage certifica
                           aria-label="Edit shipping address"
                           href="/marriage/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -24764,6 +24793,7 @@ exports[`Storyshots Common Components/Checkout/PaymentContent marriage certifica
                   <a
                     href="/marriage/checkout?page=shipping"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -25316,6 +25346,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent birth certificate 1
                           aria-label="Edit contact information"
                           href="/birth/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -25359,6 +25390,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent birth certificate 1
                           aria-label="Edit shipping address"
                           href="/birth/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -25406,6 +25438,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent birth certificate 1
                           aria-label="Edit payment information"
                           href="/birth/checkout?page=payment"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -25992,6 +26025,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent cart has pending ce
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26073,6 +26107,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent cart has pending ce
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26116,6 +26151,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent cart has pending ce
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26163,6 +26199,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent cart has pending ce
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26389,6 +26426,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent cart has pending ce
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -26785,6 +26823,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent default 1`] = `
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26866,6 +26905,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent default 1`] = `
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26909,6 +26949,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent default 1`] = `
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -26956,6 +26997,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent default 1`] = `
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -27155,6 +27197,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent default 1`] = `
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -27551,6 +27594,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent empty cart 1`] = `
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -27632,6 +27676,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent empty cart 1`] = `
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -27675,6 +27720,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent empty cart 1`] = `
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -27722,6 +27768,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent empty cart 1`] = `
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -27921,6 +27968,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent empty cart 1`] = `
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -28317,6 +28365,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent invalid order 1`] =
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -28398,6 +28447,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent invalid order 1`] =
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -28441,6 +28491,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent invalid order 1`] =
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -28475,6 +28526,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent invalid order 1`] =
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -28658,6 +28710,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent invalid order 1`] =
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -29205,6 +29258,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent marriage certificat
                           aria-label="Edit contact information"
                           href="/marriage/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -29248,6 +29302,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent marriage certificat
                           aria-label="Edit shipping address"
                           href="/marriage/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -29295,6 +29350,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent marriage certificat
                           aria-label="Edit payment information"
                           href="/marriage/checkout?page=payment"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -29883,6 +29939,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent payment error 1`] =
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -29964,6 +30021,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent payment error 1`] =
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -30007,6 +30065,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent payment error 1`] =
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -30054,6 +30113,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent payment error 1`] =
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -30256,6 +30316,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent payment error 1`] =
                       className="btn"
                       href="/death/checkout?page=payment"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       Re-try
                     </a>
@@ -30287,6 +30348,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent payment error 1`] =
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -30691,6 +30753,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submission error 1`
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -30772,6 +30835,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submission error 1`
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -30815,6 +30879,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submission error 1`
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -30862,6 +30927,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submission error 1`
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -31102,6 +31168,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submission error 1`
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -31506,6 +31573,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submitting 1`] = `
                         aria-label="Edit cart"
                         href="/death/cart"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -31587,6 +31655,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submitting 1`] = `
                         aria-label="Edit contact information"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -31630,6 +31699,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submitting 1`] = `
                         aria-label="Edit shipping address"
                         href="/death/checkout?page=shipping"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -31677,6 +31747,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submitting 1`] = `
                         aria-label="Edit payment information"
                         href="/death/checkout?page=payment"
                         onClick={[Function]}
+                        onMouseEnter={[Function]}
                       >
                         edit
                       </a>
@@ -31898,6 +31969,7 @@ exports[`Storyshots Common Components/Checkout/ReviewContent submitting 1`] = `
               <a
                 href="/death"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 I’m not done yet, go back to search
               </a>
@@ -33008,6 +33080,7 @@ exports[`Storyshots Common Components/Checkout/ShippingContent birth certificate
                   <a
                     href="/birth/review"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -34037,6 +34110,7 @@ exports[`Storyshots Common Components/Checkout/ShippingContent default 1`] = `
                 <a
                   href="/death/cart"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -35045,6 +35119,7 @@ exports[`Storyshots Common Components/Checkout/ShippingContent email error 1`] =
                 <a
                   href="/death/cart"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -36053,6 +36128,7 @@ exports[`Storyshots Common Components/Checkout/ShippingContent existing address 
                 <a
                   href="/death/cart"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -37147,6 +37223,7 @@ exports[`Storyshots Common Components/Checkout/ShippingContent marriage certific
                   <a
                     href="/marriage/review"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -39003,6 +39080,7 @@ exports[`Storyshots Common Components/Nav default 1`] = `
       <a
         className="nv-s-l-b emotion-1"
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         View Cart 
         <span
@@ -39945,6 +40023,7 @@ exports[`Storyshots Common Components/Order Details OrderDetailsDropdown: death 
           <a
             href="/death/cart"
             onClick={[Function]}
+            onMouseEnter={[Function]}
             style={
               Object {
                 "display": "block",
@@ -40232,6 +40311,7 @@ exports[`Storyshots Common Components/Pagination 2 pages 1`] = `
         className="pg-li-i pg-li-i--link pg-li-i--a"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         1
       </a>
@@ -40243,6 +40323,7 @@ exports[`Storyshots Common Components/Pagination 2 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         2
       </a>
@@ -40254,6 +40335,7 @@ exports[`Storyshots Common Components/Pagination 2 pages 1`] = `
         className="pg-li-i pg-li-i--link"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         ≫
       </a>
@@ -40274,6 +40356,7 @@ exports[`Storyshots Common Components/Pagination 7 pages 1`] = `
         className="pg-li-i pg-li-i--link"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         ≪
       </a>
@@ -40285,6 +40368,7 @@ exports[`Storyshots Common Components/Pagination 7 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         1
       </a>
@@ -40296,6 +40380,7 @@ exports[`Storyshots Common Components/Pagination 7 pages 1`] = `
         className="pg-li-i pg-li-i--link pg-li-i--a"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         2
       </a>
@@ -40307,6 +40392,7 @@ exports[`Storyshots Common Components/Pagination 7 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         3
       </a>
@@ -40318,6 +40404,7 @@ exports[`Storyshots Common Components/Pagination 7 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         4
       </a>
@@ -40329,6 +40416,7 @@ exports[`Storyshots Common Components/Pagination 7 pages 1`] = `
         className="pg-li-i pg-li-i--link"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         ≫
       </a>
@@ -40349,6 +40437,7 @@ exports[`Storyshots Common Components/Pagination 20 pages 1`] = `
         className="pg-li-i pg-li-i--link"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         ≪
       </a>
@@ -40360,6 +40449,7 @@ exports[`Storyshots Common Components/Pagination 20 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         17
       </a>
@@ -40371,6 +40461,7 @@ exports[`Storyshots Common Components/Pagination 20 pages 1`] = `
         className="pg-li-i pg-li-i--link pg-li-i--a"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         18
       </a>
@@ -40382,6 +40473,7 @@ exports[`Storyshots Common Components/Pagination 20 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         19
       </a>
@@ -40393,6 +40485,7 @@ exports[`Storyshots Common Components/Pagination 20 pages 1`] = `
         className="pg-li-i pg-li-i--link "
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         20
       </a>
@@ -40404,6 +40497,7 @@ exports[`Storyshots Common Components/Pagination 20 pages 1`] = `
         className="pg-li-i pg-li-i--link"
         href=""
         onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         ≫
       </a>
@@ -48807,6 +48901,7 @@ exports[`Storyshots Death/CartPage empty cart 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -48923,6 +49018,7 @@ exports[`Storyshots Death/CartPage empty cart 1`] = `
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -49247,6 +49343,7 @@ exports[`Storyshots Death/CartPage loading 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -49363,6 +49460,7 @@ exports[`Storyshots Death/CartPage loading 1`] = `
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -49537,6 +49635,7 @@ exports[`Storyshots Death/CartPage loading 1`] = `
                     className="btn"
                     href="/death/checkout"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                   >
                     Go to checkout
                   </a>
@@ -49918,6 +50017,7 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -50034,6 +50134,7 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -50355,6 +50456,7 @@ exports[`Storyshots Death/CartPage normal page 1`] = `
                     className="btn"
                     href="/death/checkout"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                   >
                     Go to checkout
                   </a>
@@ -50731,6 +50833,7 @@ exports[`Storyshots Death/CertificatePage certificate in cart 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -51043,6 +51146,7 @@ exports[`Storyshots Death/CertificatePage certificate in cart 1`] = `
                 <a
                   href="/search?q=Jayn"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -51315,6 +51419,7 @@ exports[`Storyshots Death/CertificatePage missing certificate 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -51456,6 +51561,7 @@ exports[`Storyshots Death/CertificatePage missing certificate 1`] = `
                 <a
                   href="/search?q=Jayn"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -51837,6 +51943,7 @@ exports[`Storyshots Death/CertificatePage normal certificate 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -52149,6 +52256,7 @@ exports[`Storyshots Death/CertificatePage normal certificate 1`] = `
                 <a
                   href="/search?q=Jayn"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -52530,6 +52638,7 @@ exports[`Storyshots Death/CertificatePage normal certificate — not from search
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -52842,6 +52951,7 @@ exports[`Storyshots Death/CertificatePage normal certificate — not from search
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -53223,6 +53333,7 @@ exports[`Storyshots Death/CertificatePage pending certificate 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -53530,6 +53641,7 @@ exports[`Storyshots Death/CertificatePage pending certificate 1`] = `
                 <a
                   href="/search?q=Jayn"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                   style={
                     Object {
                       "fontStyle": "italic",
@@ -53802,6 +53914,7 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -53980,6 +54093,7 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
             <a
               href="/birth"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
               birth
             </a>
@@ -53989,6 +54103,7 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
             <a
               href="/marriage"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
               marriage
             </a>
@@ -54001,6 +54116,7 @@ exports[`Storyshots Death/ConfirmationContent default 1`] = `
             <a
               href="/death"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
               Back to search
             </a>
@@ -54619,6 +54735,7 @@ exports[`Storyshots Death/SearchPage no results 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -55067,6 +55184,7 @@ exports[`Storyshots Death/SearchPage no search 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -55554,6 +55672,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
           <a
             className="nv-s-l-b emotion-1"
             onClick={[Function]}
+            onMouseEnter={[Function]}
           >
             View Cart 
             <span
@@ -55753,6 +55872,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
               <a
                 href="/death/certificate/000002"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 <div
                   className="p-v300 br b--w br-b100 emotion-9"
@@ -55784,6 +55904,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
               <a
                 href="/death/certificate/000001"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 <div
                   className="p-v300 br b--w br-b100 emotion-9"
@@ -55835,6 +55956,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
               <a
                 href="/death/certificate/000003"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 <div
                   className="p-v300 br b--w br-b100 emotion-9"
@@ -55876,6 +55998,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
                       className="pg-li-i pg-li-i--link"
                       href="/death?q=Jayn Doe&page=1"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       ≪
                     </a>
@@ -55887,6 +56010,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
                       className="pg-li-i pg-li-i--link "
                       href="/death?q=Jayn Doe&page=1"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       1
                     </a>
@@ -55898,6 +56022,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
                       className="pg-li-i pg-li-i--link pg-li-i--a"
                       href="/death?q=Jayn Doe&page=2"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       2
                     </a>
@@ -55909,6 +56034,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
                       className="pg-li-i pg-li-i--link "
                       href="/death?q=Jayn Doe&page=3"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       3
                     </a>
@@ -55920,6 +56046,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
                       className="pg-li-i pg-li-i--link "
                       href="/death?q=Jayn Doe&page=4"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       4
                     </a>
@@ -55931,6 +56058,7 @@ exports[`Storyshots Death/SearchPage with results 1`] = `
                       className="pg-li-i pg-li-i--link"
                       href="/death?q=Jayn Doe&page=3"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
                       ≫
                     </a>
@@ -56061,6 +56189,7 @@ exports[`Storyshots Death/SearchResult certificate without death date 1`] = `
   <a
     href="/death/certificate/000003"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
     <div
       className="p-v300 br b--w br-b100 emotion-4"
@@ -56139,6 +56268,7 @@ exports[`Storyshots Death/SearchResult typical certificate 1`] = `
   <a
     href="/death/certificate/000002"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
     <div
       className="p-v300 br b--w br-b100 emotion-4"
@@ -61982,6 +62112,7 @@ exports[`Storyshots Marriage/CheckoutPage confirmation 1`] = `
                 <a
                   href="/birth"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   birth
                 </a>
@@ -61990,6 +62121,7 @@ exports[`Storyshots Marriage/CheckoutPage confirmation 1`] = `
                 <a
                   href="/marriage"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   marriage
                 </a>
@@ -61998,6 +62130,7 @@ exports[`Storyshots Marriage/CheckoutPage confirmation 1`] = `
                 <a
                   href="/death"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
                   death
                 </a>
@@ -62321,6 +62454,7 @@ exports[`Storyshots Marriage/CheckoutPage no marriage certificate request 1`] = 
                 className="btn"
                 href="/marriage"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
                 Back to Start
               </a>
@@ -62794,6 +62928,7 @@ exports[`Storyshots Marriage/CheckoutPage payment 1`] = `
                           aria-label="Edit shipping address"
                           href="/marriage/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -62940,6 +63075,7 @@ exports[`Storyshots Marriage/CheckoutPage payment 1`] = `
                   <a
                     href="/marriage/checkout?page=shipping"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",
@@ -63492,6 +63628,7 @@ exports[`Storyshots Marriage/CheckoutPage review 1`] = `
                           aria-label="Edit contact information"
                           href="/marriage/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -63535,6 +63672,7 @@ exports[`Storyshots Marriage/CheckoutPage review 1`] = `
                           aria-label="Edit shipping address"
                           href="/marriage/checkout?page=shipping"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -63582,6 +63720,7 @@ exports[`Storyshots Marriage/CheckoutPage review 1`] = `
                           aria-label="Edit payment information"
                           href="/marriage/checkout?page=payment"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
                           edit
                         </a>
@@ -65179,6 +65318,7 @@ exports[`Storyshots Marriage/CheckoutPage shipping 1`] = `
                   <a
                     href="/marriage/review"
                     onClick={[Function]}
+                    onMouseEnter={[Function]}
                     style={
                       Object {
                         "fontStyle": "italic",

--- a/services-js/registry-certs/client/death/receipt/ReceiptPage.tsx
+++ b/services-js/registry-certs/client/death/receipt/ReceiptPage.tsx
@@ -28,7 +28,7 @@ export default class ReceiptPage extends Component<Props> {
       throw new Error('Missing id');
     }
 
-    if (!contactEmail) {
+    if (!contactEmail || Array.isArray(contactEmail)) {
       throw new Error('Missing contactEmail');
     }
 

--- a/services-js/registry-certs/lib/test/jest-polyfills.js
+++ b/services-js/registry-certs/lib/test/jest-polyfills.js
@@ -6,3 +6,5 @@ global.requestAnimationFrame = function(callback) {
 // “Error: Not implemented: window.scroll” from printing to the console
 // when running tests.
 window.scroll = () => {};
+
+export {};

--- a/services-js/registry-certs/next-env.d.ts
+++ b/services-js/registry-certs/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/services-js/registry-certs/next.config.js
+++ b/services-js/registry-certs/next.config.js
@@ -1,20 +1,18 @@
 const path = require('path');
-const withTypescript = require('@zeit/next-typescript');
+
 const withSourceMaps = require('@zeit/next-source-maps')();
 const withPolyfill = require('@cityofboston/next-client-common/with-polyfill')();
 
-module.exports = withTypescript(
-  withSourceMaps(
-    withPolyfill({
-      distDir: path.join('build', '.next'),
-      webpack: function(config) {
-        config.module.rules.push({
-          test: /\.html$/,
-          use: 'raw-loader',
-        });
+module.exports = withSourceMaps(
+  withPolyfill({
+    distDir: path.join('build', '.next'),
+    webpack: function(config) {
+      config.module.rules.push({
+        test: /\.html$/,
+        use: 'raw-loader',
+      });
 
-        return config;
-      },
-    })
-  )
+      return config;
+    },
+  })
 );

--- a/services-js/registry-certs/package.json
+++ b/services-js/registry-certs/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "7.1.2",
+    "@babel/runtime": "^7.6.0",
     "@cityofboston/hapi-common": "^0.0.0",
     "@cityofboston/hapi-next": "^0.0.0",
     "@cityofboston/mssql-common": "^0.0.0",
@@ -79,7 +79,7 @@
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.14",
     "mssql": "^4.2.1",
-    "next": "8.0.3",
+    "next": "^9.0.6",
     "nock": "^10.0.6",
     "node-cleanup": "^2.1.2",
     "nprogress": "^0.2.0",
@@ -97,9 +97,9 @@
     "word-wrap": "^1.2.3"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.2",
-    "@babel/node": "7.0.0",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
+    "@babel/node": "^7.6.1",
     "@cityofboston/config-babel": "^0.0.0",
     "@cityofboston/config-typescript": "^0.0.0",
     "@cityofboston/deploy-tools": "^0.0.0",
@@ -128,7 +128,6 @@
     "@types/storybook__react": "^4.0.1",
     "@types/stripe": "^5.x.x",
     "@types/stripe-v3": "^3.0.8",
-    "@zeit/next-typescript": "1.1.1",
     "babel-core": "^7.0.0-0",
     "babel-loader": "8.0.2",
     "concurrently": "^3.5.1",

--- a/services-js/registry-certs/pages/_app.tsx
+++ b/services-js/registry-certs/pages/_app.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { IncomingMessage } from 'http';
 
-import App, { Container } from 'next/app';
+import App, { AppContext, AppInitialProps, AppProps } from 'next/app';
 import Router from 'next/router';
 import getConfig from 'next/config';
+import { NextPageContext } from 'next';
 
 import { configure as mobxConfigure } from 'mobx';
 
 import {
   makeFetchGraphql,
-  NextContext,
   ScreenReaderSupport,
   RouterListener,
   GaSiteAnalytics,
@@ -39,10 +39,10 @@ export interface GetInitialPropsDependencies {
  */
 export type GetInitialProps<
   T,
-  C extends keyof NextContext = never,
+  C extends keyof NextPageContext = never,
   D extends keyof GetInitialPropsDependencies = never
 > = (
-  cxt: Pick<NextContext, C>,
+  cxt: Pick<NextPageContext, C>,
   deps: Pick<GetInitialPropsDependencies, D>
 ) => T | Promise<T>;
 
@@ -86,19 +86,6 @@ export interface PageDependencies extends GetInitialPropsDependencies {
   siteAnalytics: GaSiteAnalytics;
 }
 
-interface AppInitialProps {
-  ctx: NextContext;
-  Component: any;
-}
-
-interface InitialProps {
-  pageProps: any;
-}
-
-interface Props extends InitialProps {
-  Component: any;
-}
-
 // It’s important to cache the dependencies passed to getInitialProps because
 // they won’t be automatically re-used the way that the dependencies passed as
 // props are.
@@ -140,20 +127,18 @@ function getInitialPageDependencies(
  *  - PageDependencies are spread as props for the page
  */
 export default class RegistryCertsApp extends App {
-  // TypeScript doesn't know that App already has a props member.
-  protected props: Props;
-
   private pageDependencies: PageDependencies;
 
   static async getInitialProps({
     Component,
     ctx,
-  }: AppInitialProps): Promise<InitialProps> {
+  }: AppContext): Promise<AppInitialProps> {
     const pageProps = Component.getInitialProps
-      ? await Component.getInitialProps(
-          ctx,
-          getInitialPageDependencies(ctx.req)
-        )
+      ? await (Component.getInitialProps as GetInitialProps<
+          any,
+          keyof NextPageContext,
+          keyof GetInitialPropsDependencies
+        >)(ctx, getInitialPageDependencies(ctx.req))
       : {};
 
     return {
@@ -161,13 +146,8 @@ export default class RegistryCertsApp extends App {
     };
   }
 
-  constructor(props: Props) {
+  constructor(props: AppProps) {
     super(props);
-
-    // We're a little hacky here because TypeScript doesn't have type
-    // information about App and doesn't know it's a component and that the
-    // super call above actually does this.
-    this.props = props;
 
     mobxConfigure({ enforceActions: true });
 
@@ -294,10 +274,6 @@ export default class RegistryCertsApp extends App {
   render() {
     const { Component, pageProps } = this.props;
 
-    return (
-      <Container>
-        <Component {...this.pageDependencies} {...pageProps} />
-      </Container>
-    );
+    return <Component {...this.pageDependencies} {...pageProps} />;
   }
 }

--- a/services-js/registry-certs/pages/_document.tsx
+++ b/services-js/registry-certs/pages/_document.tsx
@@ -1,7 +1,12 @@
 /* eslint react/no-danger: 0 */
 import React from 'react';
-import { DocumentContext } from 'next';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, {
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentInitialProps,
+} from 'next/document';
 
 import { ScreenReaderSupport } from '@cityofboston/next-client-common';
 import { StatusModal, ContactForm } from '@cityofboston/react-fleet';
@@ -9,18 +14,17 @@ import { StatusModal, ContactForm } from '@cityofboston/react-fleet';
 import styleTags from '../client/common/utility/style-tags';
 
 type Props = {
-  __NEXT_DATA__: any;
   cacheParam: string;
   rollbarAccessToken: string | undefined;
   rollbarEnvironment: string;
   rollbarVersion: string | undefined;
 };
 
-export default class extends Document {
-  props: Props;
-
-  static getInitialProps({ renderPage }: DocumentContext): Props {
-    const page = renderPage();
+export default class extends Document<Props> {
+  static async getInitialProps({
+    renderPage,
+  }: DocumentContext): Promise<DocumentInitialProps & Props> {
+    const page = await renderPage();
 
     // This is set by our standard deployment process.
     const cacheParam =
@@ -34,15 +38,11 @@ export default class extends Document {
       cacheParam,
       rollbarAccessToken: process.env.ROLLBAR_BROWSER_ACCESS_TOKEN,
       rollbarEnvironment:
-        process.env.ROLLBAR_ENVIRONMENT || process.env.NODE_ENV,
+        process.env.ROLLBAR_ENVIRONMENT ||
+        process.env.NODE_ENV ||
+        'development',
       rollbarVersion: process.env.GIT_REVISION,
     };
-  }
-
-  constructor(props: Props) {
-    super(props);
-
-    this.props = props;
   }
 
   render() {

--- a/services-js/registry-certs/server/index.ts
+++ b/services-js/registry-certs/server/index.ts
@@ -29,3 +29,5 @@ try {
   console.error(e);
   process.exit(-1);
 }
+
+export {};

--- a/services-js/registry-certs/server/server.ts
+++ b/services-js/registry-certs/server/server.ts
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 import Hapi from 'hapi';
-import next from 'next';
+const next = require('next');
 import Boom from 'boom';
 import Inert from 'inert';
 import fs from 'fs';
@@ -384,3 +384,5 @@ export default async function startServer(args: ServerArgs) {
 
   console.log(`> Ready on http://localhost:${port}`);
 }
+
+export {};

--- a/services-js/registry-certs/tsconfig.json
+++ b/services-js/registry-certs/tsconfig.json
@@ -5,12 +5,16 @@
     "outDir": "build",
     "allowJs": true,
     "sourceMap": true,
-    "declaration": false
+    "declaration": false,
+    "noEmit": true,
+    "module": "esnext",
+    "isolatedModules": true
   },
   "include": [
     "client/**/*",
     "lib/**/*",
     "pages/**/*",
     "server/**/*"
-  ]
+  ],
+  "exclude": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,31 @@
 # yarn lockfile v1
 
 
+"@ampproject/toolbox-core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-core/-/toolbox-core-1.0.1.tgz#e32b7d9e84a3bd0a3e1bd40ebdcdc7dd37bf3e55"
+  integrity sha512-8aONoeOAVujavLUezSCtpUjg9khkVndpArbn25cLab6/UG+ZgrFPvU3A7z1TjBvB31bte4pXxH6U004BC0VdfA==
+  dependencies:
+    node-fetch "2.6.0"
+
+"@ampproject/toolbox-optimizer@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-optimizer/-/toolbox-optimizer-1.0.1.tgz#5eeda7bc84c23237479c35442d4696c4bdbeb1d3"
+  integrity sha512-zz1cJsQWBvfg2h1ce2/bbgNdSkTjIY7PaF7QhWMzYVcfvdxGSAykA+Ajt+F13H6adNAtIn09s96z/+6pn7XiXQ==
+  dependencies:
+    "@ampproject/toolbox-core" "^1.0.1"
+    "@ampproject/toolbox-runtime-version" "^1.0.1"
+    css "2.2.4"
+    parse5 "5.1.0"
+    parse5-htmlparser2-tree-adapter "5.1.0"
+
+"@ampproject/toolbox-runtime-version@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-runtime-version/-/toolbox-runtime-version-1.0.1.tgz#2c13a17c08d1376ef55f44ef6679c25ff03828e0"
+  integrity sha512-OFky5rUfP9Hw/NlvEH+/8LqeSZ5DiXY2/RUvWSnY0r0/Uk4ooPyRCWEcVgRF7Y+wY+K1oro5UBZfE9MRYz+hpA==
+  dependencies:
+    "@ampproject/toolbox-core" "^1.0.1"
+
 "@apollographql/apollo-tools@^0.3.6-alpha.1":
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.3.6.tgz#ac10b170a4f42854d9d2ad14e0635897a6986681"
@@ -31,9 +56,33 @@
   optionalDependencies:
     chokidar "^2.0.3"
 
+"@babel/cli@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.6.0.tgz#1470a04394eaf37862989ea4912adf440fa6ff8d"
+  integrity sha512-1CTDyGUjQqW3Mz4gfKZ04KGOckyyaNmKneAMlABPS+ZyuxWv3FrVEVz7Ag08kNIztVx8VaJ8YgvYLSNlMKAT5Q==
+  dependencies:
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.13"
+    mkdirp "^0.5.1"
+    output-file-sync "^2.0.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.1.8"
+
 "@babel/code-frame@7.0.0", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
@@ -77,6 +126,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
+  integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.5"
+    "@babel/types" "^7.4.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.4.3", "@babel/core@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
@@ -97,6 +166,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
+  integrity sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.0"
+    "@babel/helpers" "^7.6.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.1.2", "@babel/generator@^7.2.2", "@babel/generator@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
@@ -105,6 +194,17 @@
     "@babel/types" "^7.4.4"
     jsesc "^2.5.1"
     lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
+  integrity sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==
+  dependencies:
+    "@babel/types" "^7.6.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -138,6 +238,15 @@
     "@babel/traverse" "^7.4.0"
     "@babel/types" "^7.4.0"
 
+"@babel/helper-call-delegate@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz#87c1f8ca19ad552a736a7a27b1c1fcf8b1ff1f43"
+  integrity sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-create-class-features-plugin@^7.3.0", "@babel/helper-create-class-features-plugin@^7.4.0":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz#5bbd279c6c3ac6a60266b89bbfe7f8021080a1ef"
@@ -150,6 +259,18 @@
     "@babel/helper-replace-supers" "^7.4.0"
     "@babel/helper-split-export-declaration" "^7.4.0"
 
+"@babel/helper-create-class-features-plugin@^7.4.4", "@babel/helper-create-class-features-plugin@^7.5.5", "@babel/helper-create-class-features-plugin@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz#769711acca889be371e9bc2eb68641d55218021f"
+  integrity sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.5.5"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+
 "@babel/helper-define-map@^7.1.0", "@babel/helper-define-map@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz#cbfd8c1b2f12708e262c26f600cd16ed6a3bc6c9"
@@ -158,6 +279,15 @@
     "@babel/helper-function-name" "^7.1.0"
     "@babel/types" "^7.4.0"
     lodash "^4.17.11"
+
+"@babel/helper-define-map@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz#3dec32c2046f37e09b28c93eb0b103fd2a25d369"
+  integrity sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.5.5"
+    lodash "^4.17.13"
 
 "@babel/helper-explode-assignable-expression@^7.1.0":
   version "7.1.0"
@@ -187,11 +317,25 @@
   dependencies:
     "@babel/types" "^7.4.0"
 
+"@babel/helper-hoist-variables@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz#0298b5f25c8c09c53102d52ac4a98f773eb2850a"
+  integrity sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-member-expression-to-functions@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-member-expression-to-functions@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz#1fb5b8ec4453a93c439ee9fe3aeea4a84b76b590"
+  integrity sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==
+  dependencies:
+    "@babel/types" "^7.5.5"
 
 "@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
@@ -211,6 +355,18 @@
     "@babel/types" "^7.2.2"
     lodash "^4.17.11"
 
+"@babel/helper-module-transforms@^7.4.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz#f84ff8a09038dcbca1fd4355661a500937165b4a"
+  integrity sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/types" "^7.5.5"
+    lodash "^4.17.13"
+
 "@babel/helper-optimise-call-expression@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
@@ -227,6 +383,13 @@
   integrity sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==
   dependencies:
     lodash "^4.17.11"
+
+"@babel/helper-regex@^7.4.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351"
+  integrity sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==
+  dependencies:
+    lodash "^4.17.13"
 
 "@babel/helper-remap-async-to-generator@^7.1.0":
   version "7.1.0"
@@ -247,6 +410,16 @@
     "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/traverse" "^7.4.0"
     "@babel/types" "^7.4.0"
+
+"@babel/helper-replace-supers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz#f84ce43df031222d2bad068d2626cb5799c34bc2"
+  integrity sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.5.5"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
 
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
@@ -280,6 +453,15 @@
     "@babel/traverse" "^7.4.4"
     "@babel/types" "^7.4.4"
 
+"@babel/helpers@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
+  integrity sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==
+  dependencies:
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -291,6 +473,7 @@
 "@babel/node@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.0.0.tgz#20e55bb0e015700a0f6ff281c712de7619ad56f4"
+  integrity sha512-mKbN8Bb1TzH9YnKMWMhBRX+o5MVJHtUSalNcsiGa4FRgVfY7ozqkbttuIDWqeXxZ3rwI9ZqmCUr9XsPV2VYlSw==
   dependencies:
     "@babel/polyfill" "^7.0.0"
     "@babel/register" "^7.0.0"
@@ -300,10 +483,27 @@
     output-file-sync "^2.0.0"
     v8flags "^3.1.1"
 
+"@babel/node@^7.6.1":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.6.1.tgz#84f8f4f1d86647d99537a681f32e65e70bb59f19"
+  integrity sha512-q2sJw+7aES/5wwjccECJfOuIgM1XIbZcn7b63JZM6VpaZwvOq913jL+tXRIn41Eg/Hr+BeIGWnvnjLTuT579pA==
+  dependencies:
+    "@babel/polyfill" "^7.6.0"
+    "@babel/register" "^7.6.0"
+    commander "^2.8.1"
+    lodash "^4.17.13"
+    node-environment-flags "^1.0.5"
+    v8flags "^3.1.1"
+
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.3", "@babel/parser@^7.2.2", "@babel/parser@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
   integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
+
+"@babel/parser@^7.4.5", "@babel/parser@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
+  integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.1.0", "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -334,6 +534,14 @@
     "@babel/helper-create-class-features-plugin" "^7.3.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.4.tgz#93a6486eed86d53452ab9bab35e368e9461198ce"
+  integrity sha512-WjKTI8g8d5w1Bc9zgwSz2nfrsNQsXcCf9J9cdCvrJV6RF56yztwm4TmJC0MgJ9tvwO9gUA/mcYe89bLdGfiXFg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-proposal-class-properties@^7.3.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz#d70db61a2f1fd79de927eea91f6411c964e084b8"
@@ -342,12 +550,13 @@
     "@babel/helper-create-class-features-plugin" "^7.4.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-proposal-decorators@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.0.0.tgz#33e7e683ca9f8ec3f72104ed11096839d48df502"
+"@babel/plugin-proposal-class-properties@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz#a974cfae1e37c3110e71f3c6a2e48b8e71958cd4"
+  integrity sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==
   dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.5.5"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-decorators" "^7.0.0"
 
 "@babel/plugin-proposal-decorators@7.3.0":
   version "7.3.0"
@@ -357,6 +566,23 @@
     "@babel/helper-create-class-features-plugin" "^7.3.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-decorators" "^7.2.0"
+
+"@babel/plugin-proposal-decorators@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.6.0.tgz#6659d2572a17d70abd68123e89a12a43d90aa30c"
+  integrity sha512-ZSyYw9trQI50sES6YxREXKu+4b7MAg6Qx2cvyDDYjP2Hpzd3FleOUwC9cqn1+za8d0A2ZU8SHujxFao956efUg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.6.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-decorators" "^7.2.0"
+
+"@babel/plugin-proposal-dynamic-import@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz#e532202db4838723691b10a67b8ce509e397c506"
+  integrity sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
 
 "@babel/plugin-proposal-json-strings@^7.0.0", "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
@@ -369,6 +595,7 @@
 "@babel/plugin-proposal-object-rest-spread@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz#9a17b547f64d0676b6c9cecd4edf74a82ab85e7e"
+  integrity sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
@@ -381,7 +608,23 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.3.1", "@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3":
+"@babel/plugin-proposal-object-rest-spread@7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz#1ef173fcf24b3e2df92a678f027673b55e7e3005"
+  integrity sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.4.4", "@babel/plugin-proposal-object-rest-spread@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
+  integrity sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.3.1", "@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz#be27cd416eceeba84141305b93c282f5de23bbb4"
   integrity sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==
@@ -397,7 +640,16 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.0.0", "@babel/plugin-proposal-unicode-property-regex@^7.2.0", "@babel/plugin-proposal-unicode-property-regex@^7.4.0":
+"@babel/plugin-proposal-unicode-property-regex@^7.0.0", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz#501ffd9826c0b91da22690720722ac7cb1ca9c78"
+  integrity sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.2.0", "@babel/plugin-proposal-unicode-property-regex@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz#202d91ee977d760ef83f4f416b280d568be84623"
   integrity sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==
@@ -414,12 +666,13 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-syntax-class-properties@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz#23b3b7b9bcdabd73672a9149f728cd3be6214812"
+  integrity sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-decorators@^7.0.0", "@babel/plugin-syntax-decorators@^7.2.0":
+"@babel/plugin-syntax-decorators@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz#c50b1b957dcc69e4b1127b65e1c33eef61570c1b"
   integrity sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==
@@ -429,6 +682,7 @@
 "@babel/plugin-syntax-dynamic-import@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz#6dfb7d8b6c3be14ce952962f658f3b7eb54c33ee"
+  integrity sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -488,7 +742,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-async-to-generator@^7.1.0", "@babel/plugin-transform-async-to-generator@^7.2.0", "@babel/plugin-transform-async-to-generator@^7.4.0":
+"@babel/plugin-transform-async-to-generator@^7.1.0", "@babel/plugin-transform-async-to-generator@^7.4.4", "@babel/plugin-transform-async-to-generator@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz#89a3848a0166623b5bc481164b5936ab947e887e"
+  integrity sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+
+"@babel/plugin-transform-async-to-generator@^7.2.0", "@babel/plugin-transform-async-to-generator@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz#234fe3e458dce95865c0d152d256119b237834b0"
   integrity sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==
@@ -504,7 +767,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-block-scoping@^7.0.0", "@babel/plugin-transform-block-scoping@^7.2.0", "@babel/plugin-transform-block-scoping@^7.4.0":
+"@babel/plugin-transform-block-scoping@^7.0.0", "@babel/plugin-transform-block-scoping@^7.4.4", "@babel/plugin-transform-block-scoping@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz#c49e21228c4bbd4068a35667e6d951c75439b1dc"
+  integrity sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.13"
+
+"@babel/plugin-transform-block-scoping@^7.2.0", "@babel/plugin-transform-block-scoping@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz#164df3bb41e3deb954c4ca32ffa9fcaa56d30bcb"
   integrity sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==
@@ -526,7 +797,21 @@
     "@babel/helper-split-export-declaration" "^7.0.0"
     globals "^11.1.0"
 
-"@babel/plugin-transform-classes@^7.1.0", "@babel/plugin-transform-classes@^7.2.0", "@babel/plugin-transform-classes@^7.4.3":
+"@babel/plugin-transform-classes@^7.1.0", "@babel/plugin-transform-classes@^7.4.4", "@babel/plugin-transform-classes@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz#d094299d9bd680a14a2a0edae38305ad60fb4de9"
+  integrity sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    globals "^11.1.0"
+
+"@babel/plugin-transform-classes@^7.2.0", "@babel/plugin-transform-classes@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz#adc7a1137ab4287a555d429cc56ecde8f40c062c"
   integrity sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==
@@ -554,14 +839,30 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.2.0", "@babel/plugin-transform-destructuring@^7.4.3":
+"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.4.4", "@babel/plugin-transform-destructuring@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz#44bbe08b57f4480094d57d9ffbcd96d309075ba6"
+  integrity sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-destructuring@^7.2.0", "@babel/plugin-transform-destructuring@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz#1a95f5ca2bf2f91ef0648d5de38a8d472da4350f"
   integrity sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-dotall-regex@^7.0.0", "@babel/plugin-transform-dotall-regex@^7.2.0", "@babel/plugin-transform-dotall-regex@^7.4.3":
+"@babel/plugin-transform-dotall-regex@^7.0.0", "@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz#361a148bc951444312c69446d76ed1ea8e4450c3"
+  integrity sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
+
+"@babel/plugin-transform-dotall-regex@^7.2.0", "@babel/plugin-transform-dotall-regex@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz#fceff1c16d00c53d32d980448606f812cd6d02bf"
   integrity sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==
@@ -570,7 +871,14 @@
     "@babel/helper-regex" "^7.4.3"
     regexpu-core "^4.5.4"
 
-"@babel/plugin-transform-duplicate-keys@^7.0.0", "@babel/plugin-transform-duplicate-keys@^7.2.0":
+"@babel/plugin-transform-duplicate-keys@^7.0.0", "@babel/plugin-transform-duplicate-keys@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz#c5dbf5106bf84cdf691222c0974c12b1df931853"
+  integrity sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-duplicate-keys@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz#d952c4930f312a4dbfff18f0b2914e60c35530b3"
   integrity sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==
@@ -601,14 +909,29 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.2.0"
 
-"@babel/plugin-transform-for-of@^7.0.0", "@babel/plugin-transform-for-of@^7.2.0", "@babel/plugin-transform-for-of@^7.4.3":
+"@babel/plugin-transform-for-of@^7.0.0", "@babel/plugin-transform-for-of@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz#0267fc735e24c808ba173866c6c4d1440fc3c556"
+  integrity sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-for-of@^7.2.0", "@babel/plugin-transform-for-of@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz#c36ff40d893f2b8352202a2558824f70cd75e9fe"
   integrity sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-function-name@^7.1.0", "@babel/plugin-transform-function-name@^7.2.0", "@babel/plugin-transform-function-name@^7.4.3":
+"@babel/plugin-transform-function-name@^7.1.0", "@babel/plugin-transform-function-name@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz#e1436116abb0610c2259094848754ac5230922ad"
+  integrity sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-function-name@^7.2.0", "@babel/plugin-transform-function-name@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz#130c27ec7fb4f0cba30e958989449e5ec8d22bbd"
   integrity sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==
@@ -630,7 +953,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-modules-amd@^7.1.0", "@babel/plugin-transform-modules-amd@^7.2.0":
+"@babel/plugin-transform-modules-amd@^7.1.0", "@babel/plugin-transform-modules-amd@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz#ef00435d46da0a5961aa728a1d2ecff063e4fb91"
+  integrity sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-amd@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz#82a9bce45b95441f617a24011dc89d12da7f4ee6"
   integrity sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==
@@ -641,12 +973,32 @@
 "@babel/plugin-transform-modules-commonjs@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz#0a9d86451cbbfb29bd15186306897c67f6f9a05c"
+  integrity sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==
   dependencies:
     "@babel/helper-module-transforms" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
 
-"@babel/plugin-transform-modules-commonjs@^7.1.0", "@babel/plugin-transform-modules-commonjs@^7.2.0", "@babel/plugin-transform-modules-commonjs@^7.4.3":
+"@babel/plugin-transform-modules-commonjs@7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz#0bef4713d30f1d78c2e59b3d6db40e60192cac1e"
+  integrity sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.1.0", "@babel/plugin-transform-modules-commonjs@^7.4.4", "@babel/plugin-transform-modules-commonjs@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz#39dfe957de4420445f1fcf88b68a2e4aa4515486"
+  integrity sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.2.0", "@babel/plugin-transform-modules-commonjs@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz#3917f260463ac08f8896aa5bd54403f6e1fed165"
   integrity sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==
@@ -655,7 +1007,16 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
 
-"@babel/plugin-transform-modules-systemjs@^7.0.0", "@babel/plugin-transform-modules-systemjs@^7.2.0", "@babel/plugin-transform-modules-systemjs@^7.4.0":
+"@babel/plugin-transform-modules-systemjs@^7.0.0", "@babel/plugin-transform-modules-systemjs@^7.4.4", "@babel/plugin-transform-modules-systemjs@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz#e75266a13ef94202db2a0620977756f51d52d249"
+  integrity sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.2.0", "@babel/plugin-transform-modules-systemjs@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz#c2495e55528135797bc816f5d50f851698c586a1"
   integrity sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==
@@ -678,6 +1039,13 @@
   dependencies:
     regexp-tree "^0.1.0"
 
+"@babel/plugin-transform-named-capturing-groups-regex@^7.4.5", "@babel/plugin-transform-named-capturing-groups-regex@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz#1e6e663097813bb4f53d42df0750cf28ad3bb3f1"
+  integrity sha512-jem7uytlmrRl3iCAuQyw8BpB4c4LWvSpvIeXKpMb+7j84lkx4m4mYr5ErAcmN5KM7B6BqrAvRGjBIbbzqCczew==
+  dependencies:
+    regexp-tree "^0.1.13"
+
 "@babel/plugin-transform-new-target@^7.0.0", "@babel/plugin-transform-new-target@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz#67658a1d944edb53c8d4fa3004473a0dd7838150"
@@ -685,7 +1053,22 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-object-super@^7.1.0", "@babel/plugin-transform-object-super@^7.2.0":
+"@babel/plugin-transform-new-target@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz#18d120438b0cc9ee95a47f2c72bc9768fbed60a5"
+  integrity sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-object-super@^7.1.0", "@babel/plugin-transform-object-super@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz#c70021df834073c65eb613b8679cc4a381d1a9f9"
+  integrity sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
+
+"@babel/plugin-transform-object-super@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"
   integrity sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==
@@ -693,7 +1076,16 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-replace-supers" "^7.1.0"
 
-"@babel/plugin-transform-parameters@^7.1.0", "@babel/plugin-transform-parameters@^7.2.0", "@babel/plugin-transform-parameters@^7.4.3":
+"@babel/plugin-transform-parameters@^7.1.0", "@babel/plugin-transform-parameters@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz#7556cf03f318bd2719fe4c922d2d808be5571e16"
+  integrity sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
+  dependencies:
+    "@babel/helper-call-delegate" "^7.4.4"
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-parameters@^7.2.0", "@babel/plugin-transform-parameters@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz#e5ff62929fdf4cf93e58badb5e2430303003800d"
   integrity sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==
@@ -754,6 +1146,13 @@
   dependencies:
     regenerator-transform "^0.13.4"
 
+"@babel/plugin-transform-regenerator@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz#629dc82512c55cee01341fb27bdfcb210354680f"
+  integrity sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==
+  dependencies:
+    regenerator-transform "^0.14.0"
+
 "@babel/plugin-transform-reserved-words@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz#4792af87c998a49367597d07fedf02636d2e1634"
@@ -761,17 +1160,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-runtime@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0.tgz#0f1443c07bac16dba8efa939e0c61d6922740062"
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    resolve "^1.8.1"
-
 "@babel/plugin-transform-runtime@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz#9f76920d42551bb577e2dc594df229b5f7624b63"
+  integrity sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -782,6 +1174,26 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
   integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-runtime@7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz#a50f5d16e9c3a4ac18a1a9f9803c107c380bce08"
+  integrity sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-runtime@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz#85a3cce402b28586138e368fce20ab3019b9713e"
+  integrity sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -810,7 +1222,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
 
-"@babel/plugin-transform-template-literals@^7.0.0", "@babel/plugin-transform-template-literals@^7.2.0":
+"@babel/plugin-transform-template-literals@^7.0.0", "@babel/plugin-transform-template-literals@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
+  integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-template-literals@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz#d87ed01b8eaac7a92473f608c97c089de2ba1e5b"
   integrity sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==
@@ -825,7 +1245,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typescript@^7.1.0", "@babel/plugin-transform-typescript@^7.3.2":
+"@babel/plugin-transform-typescript@^7.1.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.4.tgz#93e9c3f2a546e6d3da1e9cc990e30791b807aa9f"
   integrity sha512-rwDvjaMTx09WC0rXGBRlYSSkEHOKRrecY6hEr3SVIPKII8DVWXtapNAfAyMC0dovuO+zYArcAuKeu3q9DNRfzA==
@@ -833,7 +1253,25 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
-"@babel/plugin-transform-unicode-regex@^7.0.0", "@babel/plugin-transform-unicode-regex@^7.2.0", "@babel/plugin-transform-unicode-regex@^7.4.3":
+"@babel/plugin-transform-typescript@^7.3.2", "@babel/plugin-transform-typescript@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.0.tgz#48d78405f1aa856ebeea7288a48a19ed8da377a6"
+  integrity sha512-yzw7EopOOr6saONZ3KA3lpizKnWRTe+rfBqg4AmQbSow7ik7fqmzrfIqt053osLwLE2AaTqGinLM2tl6+M/uog==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.6.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
+"@babel/plugin-transform-unicode-regex@^7.0.0", "@babel/plugin-transform-unicode-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
+  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
+
+"@babel/plugin-transform-unicode-regex@^7.2.0", "@babel/plugin-transform-unicode-regex@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz#3868703fc0e8f443dda65654b298df576f7b863b"
   integrity sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==
@@ -842,16 +1280,18 @@
     "@babel/helper-regex" "^7.4.3"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0.tgz#c8ff65c9ec3be6a1ba10113ebd40e8750fb90bff"
+"@babel/polyfill@^7.0.0", "@babel/polyfill@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.6.0.tgz#6d89203f8b6cd323e8d946e47774ea35dc0619cc"
+  integrity sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==
   dependencies:
-    core-js "^2.5.7"
-    regenerator-runtime "^0.11.1"
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
 
 "@babel/preset-env@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.1.0.tgz#e67ea5b0441cfeab1d6f41e9b5c79798800e8d11"
+  integrity sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -944,6 +1384,60 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/preset-env@7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.5.tgz#2fad7f62983d5af563b5f3139242755884998a58"
+  integrity sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.4.4"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.4.4"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.4.4"
+    "@babel/plugin-transform-classes" "^7.4.4"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/plugin-transform-modules-systemjs" "^7.4.4"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.5"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.2.0"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.5"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    browserslist "^4.6.0"
+    core-js-compat "^3.1.1"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
+
 "@babel/preset-env@^7.1.6", "@babel/preset-env@^7.4.1", "@babel/preset-env@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.3.tgz#e71e16e123dc0fbf65a52cbcbcefd072fbd02880"
@@ -998,6 +1492,62 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/preset-env@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.6.0.tgz#aae4141c506100bb2bfaa4ac2a5c12b395619e50"
+  integrity sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-dynamic-import" "^7.5.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.5.5"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.5.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.6.0"
+    "@babel/plugin-transform-classes" "^7.5.5"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.6.0"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.5.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.5.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.6.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.5.0"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.6.0"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.5.5"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.5"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.4.4"
+    "@babel/types" "^7.6.0"
+    browserslist "^4.6.0"
+    core-js-compat "^3.1.1"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
+
 "@babel/preset-flow@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0.tgz#afd764835d9535ec63d8c7d4caf1c06457263da2"
@@ -1015,14 +1565,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/preset-typescript@7.1.0", "@babel/preset-typescript@^7.0.0":
+"@babel/preset-typescript@7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz#49ad6e2084ff0bfb5f1f7fb3b5e76c434d442c7f"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
-"@babel/preset-typescript@^7.3.2":
+"@babel/preset-typescript@7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz#88669911053fa16b2b276ea2ede2ca603b3f307a"
   integrity sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==
@@ -1030,14 +1580,21 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
 
-"@babel/register@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
+"@babel/preset-typescript@^7.0.0", "@babel/preset-typescript@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz#25768cb8830280baf47c45ab1a519a9977498c98"
+  integrity sha512-4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==
   dependencies:
-    core-js "^2.5.7"
-    find-cache-dir "^1.0.0"
-    home-or-tmp "^3.0.0"
-    lodash "^4.17.10"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.6.0"
+
+"@babel/register@^7.0.0", "@babel/register@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.6.0.tgz#76b6f466714680f4becafd45beeb2a7b87431abf"
+  integrity sha512-78BomdN8el+x/nkup9KwtjJXuptW5oXMFmP11WoM2VJBjxrKv4grC3qjpLL8RGGUYUGsm57xnjYFM2uom+jWUQ==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.13"
     mkdirp "^0.5.1"
     pirates "^4.0.0"
     source-map-support "^0.5.9"
@@ -1049,6 +1606,14 @@
   dependencies:
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
+
+"@babel/runtime-corejs2@7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.4.5.tgz#3d892f0560df21bafb384dd7727e33853e95d3c9"
+  integrity sha512-5yLuwzvIDecKwYMzJtiarky4Fb5643H3Ao5jwX0HrMR5oM5mn2iHH9wSZonxwNK0oAjAFUQAiOd4jT7/9Y2jMQ==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
 
 "@babel/runtime@7.0.0":
   version "7.0.0"
@@ -1071,10 +1636,24 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.3.tgz#79888e452034223ad9609187a0ad1fe0d2ad4bdc"
   integrity sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
+  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -1096,6 +1675,15 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
+"@babel/template@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
+  integrity sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.2.2", "@babel/traverse@^7.4.0", "@babel/traverse@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
@@ -1111,6 +1699,21 @@
     globals "^11.1.0"
     lodash "^4.17.11"
 
+"@babel/traverse@^7.4.5", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
+  integrity sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
@@ -1118,6 +1721,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.5.5", "@babel/types@^7.6.0":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
+  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -3275,20 +3887,44 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
     "@webassemblyjs/wast-parser" "1.7.11"
 
+"@webassemblyjs/ast@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
+  integrity sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==
+  dependencies:
+    "@webassemblyjs/helper-module-context" "1.8.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
+    "@webassemblyjs/wast-parser" "1.8.5"
+
 "@webassemblyjs/floating-point-hex-parser@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz#a69f0af6502eb9a3c045555b1a6129d3d3f2e313"
   integrity sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==
+
+"@webassemblyjs/floating-point-hex-parser@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
+  integrity sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==
 
 "@webassemblyjs/helper-api-error@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz#c7b6bb8105f84039511a2b39ce494f193818a32a"
   integrity sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==
 
+"@webassemblyjs/helper-api-error@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz#c49dad22f645227c5edb610bdb9697f1aab721f7"
+  integrity sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==
+
 "@webassemblyjs/helper-buffer@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz#3122d48dcc6c9456ed982debe16c8f37101df39b"
   integrity sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==
+
+"@webassemblyjs/helper-buffer@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz#fea93e429863dd5e4338555f42292385a653f204"
+  integrity sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==
 
 "@webassemblyjs/helper-code-frame@1.7.11":
   version "1.7.11"
@@ -3297,20 +3933,45 @@
   dependencies:
     "@webassemblyjs/wast-printer" "1.7.11"
 
+"@webassemblyjs/helper-code-frame@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz#9a740ff48e3faa3022b1dff54423df9aa293c25e"
+  integrity sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==
+  dependencies:
+    "@webassemblyjs/wast-printer" "1.8.5"
+
 "@webassemblyjs/helper-fsm@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz#df38882a624080d03f7503f93e3f17ac5ac01181"
   integrity sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==
+
+"@webassemblyjs/helper-fsm@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz#ba0b7d3b3f7e4733da6059c9332275d860702452"
+  integrity sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==
 
 "@webassemblyjs/helper-module-context@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz#d874d722e51e62ac202476935d649c802fa0e209"
   integrity sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==
 
+"@webassemblyjs/helper-module-context@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz#def4b9927b0101dc8cbbd8d1edb5b7b9c82eb245"
+  integrity sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    mamacro "^0.0.3"
+
 "@webassemblyjs/helper-wasm-bytecode@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz#dd9a1e817f1c2eb105b4cf1013093cb9f3c9cb06"
   integrity sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==
+
+"@webassemblyjs/helper-wasm-bytecode@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz#537a750eddf5c1e932f3744206551c91c1b93e61"
+  integrity sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==
 
 "@webassemblyjs/helper-wasm-section@1.7.11":
   version "1.7.11"
@@ -3322,10 +3983,27 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
     "@webassemblyjs/wasm-gen" "1.7.11"
 
+"@webassemblyjs/helper-wasm-section@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz#74ca6a6bcbe19e50a3b6b462847e69503e6bfcbf"
+  integrity sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-buffer" "1.8.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
+    "@webassemblyjs/wasm-gen" "1.8.5"
+
 "@webassemblyjs/ieee754@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz#c95839eb63757a31880aaec7b6512d4191ac640b"
   integrity sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/ieee754@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz#712329dbef240f36bf57bd2f7b8fb9bf4154421e"
+  integrity sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
@@ -3336,10 +4014,22 @@
   dependencies:
     "@xtuc/long" "4.2.1"
 
+"@webassemblyjs/leb128@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.8.5.tgz#044edeb34ea679f3e04cd4fd9824d5e35767ae10"
+  integrity sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
 "@webassemblyjs/utf8@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.7.11.tgz#06d7218ea9fdc94a6793aa92208160db3d26ee82"
   integrity sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==
+
+"@webassemblyjs/utf8@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.8.5.tgz#a8bf3b5d8ffe986c7c1e373ccbdc2a0915f0cedc"
+  integrity sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==
 
 "@webassemblyjs/wasm-edit@1.7.11":
   version "1.7.11"
@@ -3355,6 +4045,20 @@
     "@webassemblyjs/wasm-parser" "1.7.11"
     "@webassemblyjs/wast-printer" "1.7.11"
 
+"@webassemblyjs/wasm-edit@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz#962da12aa5acc1c131c81c4232991c82ce56e01a"
+  integrity sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-buffer" "1.8.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
+    "@webassemblyjs/helper-wasm-section" "1.8.5"
+    "@webassemblyjs/wasm-gen" "1.8.5"
+    "@webassemblyjs/wasm-opt" "1.8.5"
+    "@webassemblyjs/wasm-parser" "1.8.5"
+    "@webassemblyjs/wast-printer" "1.8.5"
+
 "@webassemblyjs/wasm-gen@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz#9bbba942f22375686a6fb759afcd7ac9c45da1a8"
@@ -3366,6 +4070,17 @@
     "@webassemblyjs/leb128" "1.7.11"
     "@webassemblyjs/utf8" "1.7.11"
 
+"@webassemblyjs/wasm-gen@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz#54840766c2c1002eb64ed1abe720aded714f98bc"
+  integrity sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
+    "@webassemblyjs/ieee754" "1.8.5"
+    "@webassemblyjs/leb128" "1.8.5"
+    "@webassemblyjs/utf8" "1.8.5"
+
 "@webassemblyjs/wasm-opt@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz#b331e8e7cef8f8e2f007d42c3a36a0580a7d6ca7"
@@ -3375,6 +4090,16 @@
     "@webassemblyjs/helper-buffer" "1.7.11"
     "@webassemblyjs/wasm-gen" "1.7.11"
     "@webassemblyjs/wasm-parser" "1.7.11"
+
+"@webassemblyjs/wasm-opt@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz#b24d9f6ba50394af1349f510afa8ffcb8a63d264"
+  integrity sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-buffer" "1.8.5"
+    "@webassemblyjs/wasm-gen" "1.8.5"
+    "@webassemblyjs/wasm-parser" "1.8.5"
 
 "@webassemblyjs/wasm-parser@1.7.11":
   version "1.7.11"
@@ -3388,6 +4113,18 @@
     "@webassemblyjs/leb128" "1.7.11"
     "@webassemblyjs/utf8" "1.7.11"
 
+"@webassemblyjs/wasm-parser@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz#21576f0ec88b91427357b8536383668ef7c66b8d"
+  integrity sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-api-error" "1.8.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
+    "@webassemblyjs/ieee754" "1.8.5"
+    "@webassemblyjs/leb128" "1.8.5"
+    "@webassemblyjs/utf8" "1.8.5"
+
 "@webassemblyjs/wast-parser@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz#25bd117562ca8c002720ff8116ef9072d9ca869c"
@@ -3400,6 +4137,18 @@
     "@webassemblyjs/helper-fsm" "1.7.11"
     "@xtuc/long" "4.2.1"
 
+"@webassemblyjs/wast-parser@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz#e10eecd542d0e7bd394f6827c49f3df6d4eefb8c"
+  integrity sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/floating-point-hex-parser" "1.8.5"
+    "@webassemblyjs/helper-api-error" "1.8.5"
+    "@webassemblyjs/helper-code-frame" "1.8.5"
+    "@webassemblyjs/helper-fsm" "1.8.5"
+    "@xtuc/long" "4.2.2"
+
 "@webassemblyjs/wast-printer@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz#c4245b6de242cb50a2cc950174fdbf65c78d7813"
@@ -3409,6 +4158,15 @@
     "@webassemblyjs/wast-parser" "1.7.11"
     "@xtuc/long" "4.2.1"
 
+"@webassemblyjs/wast-printer@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz#114bbc481fd10ca0e23b3560fa812748b0bae5bc"
+  integrity sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/wast-parser" "1.8.5"
+    "@xtuc/long" "4.2.2"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -3416,6 +4174,11 @@
 "@xtuc/long@4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
+
+"@xtuc/long@4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
+  integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
 "@yarnpkg/lockfile@^1.0.0":
   version "1.0.0"
@@ -3429,6 +4192,7 @@
 "@zeit/next-typescript@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@zeit/next-typescript/-/next-typescript-1.1.1.tgz#0b0ddfbb13ca04cde52ac2718473f1b9c40ba0ee"
+  integrity sha512-EUcHCASftz1Bc80djkf3cKJrFgvFQyODOH1kty7ShVLLdXMaZpRLj+z7RxrCoNo1bP06w0vtXEDU0cKa0HmGgg==
   dependencies:
     "@babel/preset-typescript" "^7.0.0"
 
@@ -3538,6 +4302,11 @@ acorn@^6.0.5, acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
+acorn@^6.2.1:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
+  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+
 address-rfc2822@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/address-rfc2822/-/address-rfc2822-2.0.4.tgz#2dbd3b8d6c2de1e957c1a8549dc012d40bbc3431"
@@ -3588,6 +4357,11 @@ ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
+ajv-keywords@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
+  integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -3601,6 +4375,16 @@ ajv@^6.1.0, ajv@^6.5.3, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.10.0, ajv@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -3637,6 +4421,15 @@ ammo@3.x.x:
   resolved "https://registry.yarnpkg.com/ammo/-/ammo-3.0.1.tgz#c79ceeac36fb4e55085ea3fe0c2f42bfa5f7c914"
   dependencies:
     hoek "5.x.x"
+
+amphtml-validator@1.0.23:
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.23.tgz#dba0c3854289563c0adaac292cd4d6096ee4d7c8"
+  integrity sha1-26DDhUKJVjwK2qwpLNTWCW7k18g=
+  dependencies:
+    colors "1.1.2"
+    commander "2.9.0"
+    promise "7.1.1"
 
 ansi-align@^3.0.0:
   version "3.0.0"
@@ -4240,7 +5033,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async-retry@^1.2.1:
+async-retry@1.2.3, async-retry@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
   integrity sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==
@@ -4253,6 +5046,11 @@ async-sema@2.1.4:
   integrity sha512-NKdMgXT9RfmkscybzytzK/6uGF4cL8Mt3PSeO9QHXYKs3oFWkUwIepnAkzLWkqttOdDDFoED3c8kriS8RzP+ow==
   dependencies:
     double-ended-queue "2.1.0-0"
+
+async-sema@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/async-sema/-/async-sema-3.0.0.tgz#9e22d6783f0ab66a1cf330e21a905e39b3b3a975"
+  integrity sha512-zyCMBDl4m71feawrxYcVbHxv/UUkqm4nKJiLu3+l9lfiQha6jQ/9dxhrXLnzzBXVFqCTDwiUkZOz9XFbdEGQsg==
 
 async@0.2.6:
   version "0.2.6"
@@ -4661,6 +5459,16 @@ babel-loader@8.0.5:
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
 
+babel-loader@8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
+  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    pify "^4.0.1"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -4682,6 +5490,13 @@ babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"
   integrity sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==
+  dependencies:
+    object.assign "^4.1.0"
+
+babel-plugin-dynamic-import-node@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
+  integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   dependencies:
     object.assign "^4.1.0"
 
@@ -4844,6 +5659,7 @@ babel-plugin-react-docgen@^2.0.2:
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
+  integrity sha1-Lk57RJa5OmVKHIAEInbeTk7rIOM=
 
 babel-plugin-require-context-hook@^1.0.0:
   version "1.0.0"
@@ -4923,6 +5739,14 @@ babel-plugin-transform-decorators@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
     babel-types "^6.24.1"
+
+babel-plugin-transform-define@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-define/-/babel-plugin-transform-define-1.3.1.tgz#b21b7bad3b84cf8e3f07cdc8c660b99cbbc01213"
+  integrity sha512-JXZ1xE9jIbKCGYZ4wbSMPSI5mdS4DRLi5+SkTHgZqWn5YIf/EucykkzUsPmzJlpkX8fsMVdLnA5vt/LvT97Zbg==
+  dependencies:
+    lodash "^4.17.11"
+    traverse "0.6.6"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -5143,6 +5967,7 @@ babel-plugin-transform-property-literals@^6.9.4:
 babel-plugin-transform-react-remove-prop-types@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.15.tgz#7ba830e77276a0e788cd58ea527b5f70396e12a7"
+  integrity sha512-bFxxYdkZBwTjTgtZEPTLqu9g8Ajz8x8uEP/O1iVuaZIz2RuxJ2gtx0EXDJRonC++KGsgsW/4Hqvk4KViEtE2nw==
 
 babel-plugin-transform-react-remove-prop-types@0.4.24:
   version "0.4.24"
@@ -5508,6 +6333,11 @@ bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
+bluebird@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -5708,7 +6538,7 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000835"
     electron-to-chromium "^1.3.45"
 
-browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.3.4, browserslist@^4.3.5, browserslist@^4.5.2, browserslist@^4.5.4:
+browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.3.5, browserslist@^4.5.2, browserslist@^4.5.4:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.5.tgz#fe1a352330d2490d5735574c149a85bc18ef9b82"
   integrity sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==
@@ -5716,6 +6546,15 @@ browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.3.4, browserslist@^4.3
     caniuse-lite "^1.0.30000960"
     electron-to-chromium "^1.3.124"
     node-releases "^1.1.14"
+
+browserslist@^4.1.0, browserslist@^4.6.0, browserslist@^4.6.6:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
+  integrity sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==
+  dependencies:
+    caniuse-lite "^1.0.30000989"
+    electron-to-chromium "^1.3.247"
+    node-releases "^1.1.29"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -5815,6 +6654,11 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
 cacache@^11.0.1, cacache@^11.0.2, cacache@^11.3.2:
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
@@ -5831,6 +6675,27 @@ cacache@^11.0.1, cacache@^11.0.2, cacache@^11.3.2:
     move-concurrently "^1.0.1"
     promise-inflight "^1.0.1"
     rimraf "^2.6.2"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
+cacache@^12.0.2:
+  version "12.0.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
+  integrity sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==
+  dependencies:
+    bluebird "^3.5.5"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.4"
+    graceful-fs "^4.1.15"
+    infer-owner "^1.0.3"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.3"
     ssri "^6.0.1"
     unique-filename "^1.1.1"
     y18n "^4.0.0"
@@ -5962,6 +6827,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000835, caniuse-lite@^1.0.30000918, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz#6c10c3ab304b89bea905e66adf98c0905088ee44"
   integrity sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==
 
+caniuse-lite@^1.0.30000989:
+  version "1.0.30000989"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
+  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+
 capture-exit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
@@ -5979,6 +6849,7 @@ capture-exit@^2.0.0:
 case-sensitive-paths-webpack-plugin@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz#c899b52175763689224571dad778742e133f0192"
+  integrity sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg==
 
 case-sensitive-paths-webpack-plugin@2.2.0, case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.2.0"
@@ -6210,6 +7081,25 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.0.4:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
 chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
@@ -6232,14 +7122,21 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
-ci-info@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+chrome-trace-event@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
+  integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
+  dependencies:
+    tslib "^1.9.0"
 
-ci-info@^2.0.0:
+ci-info@2.0.0, ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -6299,6 +7196,11 @@ cli-prompt@^0.3.2:
   resolved "https://registry.yarnpkg.com/cli-prompt/-/cli-prompt-0.3.2.tgz#39282d0224d0352451a00a32f88666ae429a4155"
   dependencies:
     keypress "~0.2.1"
+
+cli-spinners@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
+  integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
 
 cli-table3@0.5.1:
   version "0.5.1"
@@ -6551,6 +7453,11 @@ colors@1.0.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
+colors@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+  integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
+
 colors@^1.1.2, colors@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
@@ -6614,7 +7521,14 @@ commander@2.6.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
   integrity sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=
 
-commander@^2.1.0, commander@^2.11.0, commander@^2.14.1, commander@^2.15.1, commander@^2.19.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+commander@^2.1.0, commander@^2.11.0, commander@^2.14.1, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -6681,6 +7595,26 @@ compressible@~2.0.14:
   dependencies:
     mime-db ">= 1.34.0 < 2"
 
+compressible@~2.0.16:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
+  dependencies:
+    mime-db ">= 1.40.0 < 2"
+
+compression@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
+
 compression@^1.5.2, compression@^1.6.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
@@ -6726,6 +7660,19 @@ concurrently@^3.5.1:
     spawn-command "^0.0.2-1"
     supports-color "^3.2.3"
     tree-kill "^1.1.0"
+
+conf@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-5.0.0.tgz#6530308a36041bf010ab96b05a0f4aff5101c65d"
+  integrity sha512-lRNyt+iRD4plYaOSVTxu1zPWpaH0EOxgFIR1l3mpC/DGZ7XzhoGFMKmbl54LAgXcSu6knqWgOwdINkqm58N85A==
+  dependencies:
+    ajv "^6.10.0"
+    dot-prop "^5.0.0"
+    env-paths "^2.2.0"
+    json-schema-typed "^7.0.0"
+    make-dir "^3.0.0"
+    pkg-up "^3.0.1"
+    write-file-atomic "^3.0.0"
 
 config-chain@^1.1.11, config-chain@^1.1.12:
   version "1.1.12"
@@ -6776,7 +7723,7 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
   integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
 
-content-type@~1.0.4:
+content-type@1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -6886,6 +7833,11 @@ cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+cookie@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
+  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
 cookiejar@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
@@ -6921,6 +7873,14 @@ core-js-compat@^3.0.0:
     core-js "3.0.1"
     core-js-pure "3.0.1"
     semver "^6.0.0"
+
+core-js-compat@^3.1.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.2.1.tgz#0cbdbc2e386e8e00d3b85dc81c848effec5b8150"
+  integrity sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==
+  dependencies:
+    browserslist "^4.6.6"
+    semver "^6.3.0"
 
 core-js-pure@3.0.1:
   version "3.0.1"
@@ -7304,6 +8264,16 @@ css@2.2.3, css@^2.2.1:
     inherits "^2.0.1"
     source-map "^0.1.38"
     source-map-resolve "^0.5.1"
+    urix "^0.1.0"
+
+css@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
     urix "^0.1.0"
 
 cssdb@^4.3.0:
@@ -7867,6 +8837,11 @@ detective@^4.3.1:
     acorn "^5.2.1"
     defined "^1.0.0"
 
+devalue@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/devalue/-/devalue-2.0.0.tgz#2afa0b7c1bb35bebbef792498150663fdcd33c68"
+  integrity sha512-6H2FBD5DPnQS75UWJtQjoVeKZlmXoa765UgYS5RQnx6Ay9LUhUld0w1/D6cYdrY+wnu6XQNlpEBfnJUZK0YyPQ==
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -8056,6 +9031,13 @@ dot-prop@^4.1.1, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.1.0.tgz#bdd8c986a77b83e3fca524e53786df916cabbd8a"
+  integrity sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==
+  dependencies:
+    is-obj "^2.0.0"
+
 dotenv-defaults@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz#441cf5f067653fca4bbdce9dd3b803f6f84c585d"
@@ -8183,6 +9165,11 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.103, electron-to-chromium
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz#dbde0e95e64ebe322db0eca764d951f885a5aff2"
   integrity sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==
 
+electron-to-chromium@^1.3.247:
+  version "1.3.262"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.262.tgz#8022933e46e5a2c7b0fd1565d215872326520a7c"
+  integrity sha512-YFr53qZWr2pWkiTUorWEhAweujdf0ALiUp8VkNa0WGtbMVR+kZ8jNy3VTCemLsA4sT6+srCqehNn8TEAD0Ngrw==
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -8206,6 +9193,7 @@ email-addresses@^3.0.0:
 emitter-mixin@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/emitter-mixin/-/emitter-mixin-0.0.3.tgz#5948cb286f2e48edc3b251a7cfc1f7883396d65c"
+  integrity sha1-WUjLKG8uSO3DslGnz8H3iDOW1lw=
 
 emittery@^0.4.1:
   version "0.4.1"
@@ -8326,6 +9314,11 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
+env-paths@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
+  integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
+
 env-variable@0.0.x:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.5.tgz#913dd830bef11e96a039c038d4130604eba37f88"
@@ -8386,7 +9379,7 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
 
-errno@^0.1.2, errno@^0.1.3, errno@^0.1.4, errno@~0.1.1:
+errno@^0.1.2, errno@^0.1.3, errno@^0.1.4, errno@~0.1.1, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -8760,6 +9753,7 @@ etag@1.8.1, etag@~1.8.1:
 event-source-polyfill@0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-0.0.12.tgz#e539cd67fdef2760a16aa5262fa98134df52e3af"
+  integrity sha1-5TnNZ/3vJ2ChaqUmL6mBNN9S468=
 
 event-stream@=3.3.4, event-stream@^3.1.0:
   version "3.3.4"
@@ -8780,6 +9774,11 @@ eventemitter3@^3.0.0, eventemitter3@^3.1.0:
 events@1.1.1, events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
 
 eventsource@^1.0.7:
   version "1.0.7"
@@ -9298,6 +10297,15 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-cache-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-index@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
@@ -9321,6 +10329,13 @@ find-up@3.0.0, find-up@^3.0.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
   dependencies:
     locate-path "^3.0.0"
+
+find-up@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.0.0.tgz#c367f8024de92efb75f2d4906536d24682065c3a"
+  integrity sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==
+  dependencies:
+    locate-path "^5.0.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -9474,6 +10489,20 @@ fork-ts-checker-webpack-plugin@1.0.0-alpha.6:
     minimatch "^3.0.4"
     semver "^5.6.0"
     tapable "^1.0.0"
+
+fork-ts-checker-webpack-plugin@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.3.4.tgz#a75b6fe8d3db0089555f083c4f77372227704244"
+  integrity sha512-2QDXnI2mbbly/OHx/ivtspi2l4K2g+IB0LTQ3AwsBfxyHtMFXtojlsJqGyhUggX08BC+F02CoCG0hRSPOLU2dQ==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
 
 form-data@^2.3.1, form-data@^2.3.3, form-data@~2.3.2:
   version "2.3.3"
@@ -9922,6 +10951,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
 glob-watcher@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-0.0.6.tgz#b95b4a8df74b39c83298b0c05c978b4d9a3b710b"
@@ -9978,6 +11012,18 @@ glob@^5.0.15, glob@^5.0.3:
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -10147,14 +11193,24 @@ graceful-fs@^3.0.0, graceful-fs@~3.0.2:
   dependencies:
     natives "^1.1.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+graceful-fs@^4.1.4:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+
 graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 graphlib@^2.1.5:
   version "2.1.5"
@@ -10760,10 +11816,6 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-home-or-tmp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
-
 homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
@@ -10926,13 +11978,24 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
-http-errors@^1.7.2:
+http-errors@1.7.2, http-errors@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
   integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
   dependencies:
     depd "~1.1.2"
     inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
+http-errors@~1.7.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
+  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
@@ -11204,6 +12267,11 @@ inert@^5.1.0:
     joi "13.x.x"
     lru-cache "4.1.x"
 
+infer-owner@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -11223,6 +12291,11 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, i
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
@@ -11513,6 +12586,11 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
+is-docker@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-docker@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-1.1.0.tgz#f04374d4eee5310e9a8e113bf1495411e46176a1"
@@ -11643,6 +12721,11 @@ is-number@^4.0.0:
 is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-observable@^1.1.0:
   version "1.1.0"
@@ -12661,6 +13744,14 @@ jest-watcher@^24.8.0:
     jest-util "^24.8.0"
     string-length "^2.0.0"
 
+jest-worker@24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
+  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
+  dependencies:
+    merge-stream "^2.0.0"
+    supports-color "^6.1.0"
+
 jest-worker@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
@@ -12823,6 +13914,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-typed@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-7.0.1.tgz#5e56564b5a0950423e22b285a30ade219e38084d"
+  integrity sha512-IqUK+Cqc8/MqHsCvv1TMccbKdBzoATOLHXZAF5UDu70/CCxo648cHUig24hc+XTK53TyeNk1UeVTlc2Haovtsw==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -12929,6 +14025,7 @@ juice@^4.1.0:
 junk@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
+  integrity sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=
 
 just-extend@^3.0.0:
   version "3.0.0"
@@ -13416,6 +14513,11 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
+loader-runner@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
+  integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
 loader-utils@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
@@ -13447,6 +14549,13 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
 
 lodash-es@^4.17.11:
   version "4.17.11"
@@ -14092,6 +15201,11 @@ lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.5, lodash@^4.2.1, l
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -14221,6 +15335,21 @@ make-dir@^1.0.0, make-dir@^1.3.0:
   dependencies:
     pify "^3.0.0"
 
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
+
 make-error-cause@^1.1.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/make-error-cause/-/make-error-cause-1.2.2.tgz#df0388fcd0b37816dff0a5fb8108939777dcbc9d"
@@ -14259,6 +15388,11 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+mamacro@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
+  integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
 map-age-cleaner@^0.1.1:
   version "0.1.2"
@@ -14348,6 +15482,7 @@ max-component@^1.0.0:
 maximatch@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/maximatch/-/maximatch-0.1.0.tgz#86cd8d6b04c9f307c05a6b9419906d0360fb13a2"
+  integrity sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=
   dependencies:
     array-differ "^1.0.0"
     array-union "^1.0.1"
@@ -14466,6 +15601,11 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.1.tgz#271d2516ff52d4af7f7b710b8bf3e16e183fef66"
@@ -14523,6 +15663,11 @@ methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
+microevent.ts@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
+  integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -14571,6 +15716,11 @@ mime-db@1.40.0, mime-db@1.x.x, "mime-db@>= 1.34.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
+"mime-db@>= 1.40.0 < 2":
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.41.0.tgz#9110408e1f6aa1b34aef51f2c9df3caddf46b6a0"
+  integrity sha512-B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw==
+
 mime-types@^2.1.12, mime-types@^2.1.14, mime-types@^2.1.20, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
@@ -14583,10 +15733,20 @@ mime@1.4.1, mime@^1.4.1, mime@~1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
 mime@^2.0.3, mime@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
   integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
+
+mime@^2.4.2:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimer@^0.3.2:
   version "0.3.2"
@@ -15062,6 +16222,7 @@ mjml@^4.3.1:
 mkdirp-then@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mkdirp-then/-/mkdirp-then-1.2.0.tgz#a492c879ca4d873f5ee45008f8f55fd0150de3c5"
+  integrity sha1-pJLIecpNhz9e5FAI+PVf0BUN48U=
   dependencies:
     any-promise "^1.1.0"
     mkdirp "^0.5.0"
@@ -15340,6 +16501,11 @@ neo-async@^2.5.0, neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
 
+neo-async@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
 netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
@@ -15426,6 +16592,71 @@ next@8.0.3:
     webpack-sources "1.3.0"
     worker-farm "1.5.2"
 
+next@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/next/-/next-9.0.6.tgz#cf6e84fdae20699033cb4603863a4dc297f5d002"
+  integrity sha512-kXq+AbgB/Pi5UtMkEkJbDW1ObdsrTKhcP48Bw8BQP4GNzWI9icDRqTQoa7hf+7SKCu1IMshDKan60T6UnZpJ+w==
+  dependencies:
+    "@ampproject/toolbox-optimizer" "1.0.1"
+    "@babel/core" "7.4.5"
+    "@babel/plugin-proposal-class-properties" "7.4.4"
+    "@babel/plugin-proposal-object-rest-spread" "7.4.4"
+    "@babel/plugin-syntax-dynamic-import" "7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "7.4.4"
+    "@babel/plugin-transform-runtime" "7.4.4"
+    "@babel/preset-env" "7.4.5"
+    "@babel/preset-react" "7.0.0"
+    "@babel/preset-typescript" "7.3.3"
+    "@babel/runtime" "7.4.5"
+    "@babel/runtime-corejs2" "7.4.5"
+    amphtml-validator "1.0.23"
+    async-retry "1.2.3"
+    async-sema "3.0.0"
+    autodll-webpack-plugin "0.4.2"
+    babel-core "7.0.0-bridge.0"
+    babel-loader "8.0.6"
+    babel-plugin-syntax-jsx "6.18.0"
+    babel-plugin-transform-define "1.3.1"
+    babel-plugin-transform-react-remove-prop-types "0.4.24"
+    chalk "2.4.2"
+    ci-info "2.0.0"
+    compression "1.7.4"
+    conf "5.0.0"
+    content-type "1.0.4"
+    cookie "0.4.0"
+    devalue "2.0.0"
+    etag "1.8.1"
+    find-up "4.0.0"
+    fork-ts-checker-webpack-plugin "1.3.4"
+    fresh "0.5.2"
+    is-docker "2.0.0"
+    jest-worker "24.9.0"
+    launch-editor "2.2.1"
+    loader-utils "1.2.3"
+    mkdirp "0.5.1"
+    node-fetch "2.6.0"
+    ora "3.4.0"
+    path-to-regexp "2.1.0"
+    pnp-webpack-plugin "1.5.0"
+    prop-types "15.7.2"
+    prop-types-exact "1.2.0"
+    raw-body "2.4.0"
+    react-error-overlay "5.1.6"
+    react-is "16.8.6"
+    send "0.17.1"
+    source-map "0.6.1"
+    string-hash "1.1.3"
+    strip-ansi "5.2.0"
+    styled-jsx "3.2.2"
+    terser "4.0.0"
+    unfetch "4.1.0"
+    url "0.11.0"
+    watchpack "2.0.0-beta.5"
+    webpack "4.39.0"
+    webpack-dev-middleware "3.7.0"
+    webpack-hot-middleware "2.25.0"
+    webpack-sources "1.3.0"
+
 ngrok@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ngrok/-/ngrok-3.1.0.tgz#a148b7567d1bae918ee7b0f461bd8f58411016fd"
@@ -15489,6 +16720,14 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-environment-flags@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
+  integrity sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==
+  dependencies:
+    object.getownpropertydescriptors "^2.0.3"
+    semver "^5.7.0"
+
 node-fetch-npm@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
@@ -15500,6 +16739,11 @@ node-fetch-npm@^2.0.2:
 node-fetch@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0.tgz#982bba43ecd4f2922a29cc186a6bbb0bb73fcba6"
+
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@^1.0.1, node-fetch@^1.3.3, node-fetch@^1.6.9:
   version "1.7.3"
@@ -15572,6 +16816,35 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
+node-libs-browser@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
+  dependencies:
+    assert "^1.1.1"
+    browserify-zlib "^0.2.0"
+    buffer "^4.3.0"
+    console-browserify "^1.1.0"
+    constants-browserify "^1.0.0"
+    crypto-browserify "^3.11.0"
+    domain-browser "^1.1.1"
+    events "^3.0.0"
+    https-browserify "^1.0.0"
+    os-browserify "^0.3.0"
+    path-browserify "0.0.1"
+    process "^0.11.10"
+    punycode "^1.2.4"
+    querystring-es3 "^0.2.0"
+    readable-stream "^2.3.3"
+    stream-browserify "^2.0.1"
+    stream-http "^2.7.2"
+    string_decoder "^1.0.0"
+    timers-browserify "^2.0.4"
+    tty-browserify "0.0.0"
+    url "^0.11.0"
+    util "^0.11.0"
+    vm-browserify "^1.0.1"
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -15620,6 +16893,13 @@ node-releases@^1.1.14, node-releases@^1.1.3:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.15.tgz#9e76a73b0eca3bf7801addaa0e6ce90c795f2b9a"
   integrity sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==
+  dependencies:
+    semver "^5.3.0"
+
+node-releases@^1.1.29:
+  version "1.1.32"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.32.tgz#485b35c1bf9b4d8baa105d782f8ca731e518276e"
+  integrity sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==
   dependencies:
     semver "^5.3.0"
 
@@ -15973,6 +17253,11 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
 once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -16052,6 +17337,18 @@ optionator@^0.8.1, optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+ora@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
+  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
+  dependencies:
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-spinners "^2.0.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
 
 orchestrator@^0.3.0:
   version "0.3.8"
@@ -16175,6 +17472,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
+  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -16187,6 +17491,13 @@ p-locate@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -16403,6 +17714,13 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5-htmlparser2-tree-adapter@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.0.tgz#a8244ee12bbd6b8937ad2a16ea43fe348aebcc86"
+  integrity sha512-OrI4DNmghGcwDB3XN8FKKN7g5vBmau91uqj+VYuwuj/r6GhFBMBNymsM+Z9z+Z1p4HHgI0UuQirQRgh3W5d88g==
+  dependencies:
+    parse5 "^5.1.0"
+
 parse5@2.2.3, parse5@^2.1.5:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
@@ -16410,6 +17728,11 @@ parse5@2.2.3, parse5@^2.1.5:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
+parse5@5.1.0, parse5@^5.0.0, parse5@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
 parse5@^1.5.0:
   version "1.5.1"
@@ -16420,11 +17743,6 @@ parse5@^3.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   dependencies:
     "@types/node" "*"
-
-parse5@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
-  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
 parseurl@~1.3.2:
   version "1.3.3"
@@ -16438,6 +17756,11 @@ pascalcase@^0.1.1:
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+
+path-browserify@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -16608,6 +17931,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-1.0.0.tgz#d1da67f5482563bb7cf57f286ae2822ecfbf3670"
@@ -16660,6 +17988,13 @@ pkg-up@2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 pkginfo@0.3.x, pkginfo@0.x.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
@@ -16708,6 +18043,13 @@ pnp-webpack-plugin@1.2.1:
   integrity sha512-W6GctK7K2qQiVR+gYSv/Gyt6jwwIH4vwdviFqx+Y2jAtVf5eZyYIDf5Ac2NCDMBiX5yWscBLZElPTsyA1UtVVA==
   dependencies:
     ts-pnp "^1.0.0"
+
+pnp-webpack-plugin@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz#62a1cd3068f46d564bb33c56eb250e4d586676eb"
+  integrity sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==
+  dependencies:
+    ts-pnp "^1.1.2"
 
 podium@3.x.x:
   version "3.1.2"
@@ -17545,6 +18887,13 @@ promise.prototype.finally@^3.1.0:
     es-abstract "^1.9.0"
     function-bind "^1.1.1"
 
+promise@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  integrity sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=
+  dependencies:
+    asap "~2.0.3"
+
 promise@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.2.tgz#9dcd0672192c589477d56891271bdc27547ae9f0"
@@ -17637,11 +18986,12 @@ prop-types-exact@1.2.0:
 prop-types@15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -17883,6 +19233,11 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+range-parser@^1.2.1, range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
 raw-body@2.3.3, raw-body@^2.2.0, raw-body@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
@@ -17890,6 +19245,16 @@ raw-body@2.3.3, raw-body@^2.2.0, raw-body@^2.3.3:
     bytes "3.0.0"
     http-errors "1.6.3"
     iconv-lite "0.4.23"
+    unpipe "1.0.0"
+
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
     unpipe "1.0.0"
 
 raw-loader@^0.5.1:
@@ -18068,6 +19433,12 @@ react-dropzone@^8.1.0:
 react-error-overlay@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+  integrity sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==
+
+react-error-overlay@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
+  integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
 react-error-overlay@^5.1.4:
   version "5.1.4"
@@ -18131,10 +19502,15 @@ react-is@16.6.3:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
-react-is@^16.3.2, react-is@^16.4.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.5:
+react-is@16.8.6, react-is@^16.4.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.5:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-is@^16.3.2:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -18576,6 +19952,7 @@ recompose@^0.30.0:
 recursive-copy@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/recursive-copy/-/recursive-copy-2.0.6.tgz#d590f9eb5f165b96a1b80bc8f9cbcb5c6f9c89e9"
+  integrity sha1-1ZD5618WW5ahuAvI+cvLXG+ciek=
   dependencies:
     del "^2.2.0"
     emitter-mixin "0.0.3"
@@ -18662,7 +20039,7 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -18692,6 +20069,13 @@ regenerator-transform@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
   integrity sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==
+  dependencies:
+    private "^0.1.6"
+
+regenerator-transform@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
+  integrity sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
   dependencies:
     private "^0.1.6"
 
@@ -18725,6 +20109,11 @@ regexp-tree@^0.1.0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.5.tgz#7cd71fca17198d04b4176efd79713f2998009397"
   integrity sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==
+
+regexp-tree@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.13.tgz#5b19ab9377edc68bc3679256840bb29afc158d7f"
+  integrity sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==
 
 regexp.prototype.flags@^1.2.0:
   version "1.2.0"
@@ -19015,6 +20404,7 @@ resolve@1.10.0, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2,
 resolve@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  integrity sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==
   dependencies:
     path-parse "^1.0.5"
 
@@ -19065,6 +20455,13 @@ rimraf@2, rimraf@2.6.3, rimraf@2.x.x, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.5.
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -19320,10 +20717,20 @@ semver@^4.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
+semver@^5.7.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
 semver@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
   integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
+
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -19368,6 +20775,25 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
+send@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
+  integrity sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.7.2"
+    mime "1.6.0"
+    ms "2.1.1"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
 sequencify@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/sequencify/-/sequencify-0.0.7.tgz#90cff19d02e07027fd767f5ead3e7b95d1e7380c"
@@ -19382,6 +20808,11 @@ serialize-javascript@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
   integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
+
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
 serve-favicon@^2.5.0:
   version "2.5.0"
@@ -19822,7 +21253,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.1, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
@@ -19844,6 +21275,14 @@ source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@^0.5.9,
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
   integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.10, source-map-support@~0.5.12:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -20084,7 +21523,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2":
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -20311,6 +21750,13 @@ strip-ansi@5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
+strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
 strip-ansi@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
@@ -20324,13 +21770,6 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
 
 strip-ansi@~0.1.0:
   version "0.1.1"
@@ -20443,6 +21882,20 @@ styled-jsx@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.1.tgz#452051fe50df5e9c7c7f3dd20fa46c3060ac65b0"
   integrity sha512-gM/WOrWYRpWReivzQqetEGohUc/TJSvUoZ5T/UJxJZIsVIPlRQLnp7R8Oue4q49sI08EBRQjQl2oBL3sfdrw2g==
+  dependencies:
+    babel-plugin-syntax-jsx "6.18.0"
+    babel-types "6.26.0"
+    convert-source-map "1.6.0"
+    loader-utils "1.2.3"
+    source-map "0.7.3"
+    string-hash "1.1.3"
+    stylis "3.5.4"
+    stylis-rule-sheet "0.0.10"
+
+styled-jsx@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.2.tgz#03d02d26725195d17b6a979eb8d7c34761a16bf8"
+  integrity sha512-Xb9TPFY2REShznvHt/fw78wk+nxejTr8poepDeS5fRvkQ7lW49CDIWWGLzzALCLcKBIRFK/1Wi4PDZNetpig4w==
   dependencies:
     babel-plugin-syntax-jsx "6.18.0"
     babel-types "6.26.0"
@@ -20659,7 +22112,7 @@ table@^5.0.2, table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tapable@^1.0.0, tapable@^1.1.0:
+tapable@^1.0.0, tapable@^1.1.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
@@ -20772,6 +22225,21 @@ terser-webpack-plugin@1.2.2, terser-webpack-plugin@^1.1.0, terser-webpack-plugin
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+terser-webpack-plugin@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz#61b18e40eaee5be97e771cdbb10ed1280888c2b4"
+  integrity sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
+  dependencies:
+    cacache "^12.0.2"
+    find-cache-dir "^2.1.0"
+    is-wsl "^1.1.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    source-map "^0.6.1"
+    terser "^4.1.2"
+    webpack-sources "^1.4.0"
+    worker-farm "^1.7.0"
+
 terser@3.16.1, terser@^3.16.1:
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.16.1.tgz#5b0dd4fa1ffd0b0b43c2493b2c364fd179160493"
@@ -20780,6 +22248,24 @@ terser@3.16.1, terser@^3.16.1:
     commander "~2.17.1"
     source-map "~0.6.1"
     source-map-support "~0.5.9"
+
+terser@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.0.0.tgz#ef356f6f359a963e2cc675517f21c1c382877374"
+  integrity sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==
+  dependencies:
+    commander "^2.19.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.10"
+
+terser@^4.1.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.1.tgz#09820bcb3398299c4b48d9a86aefc65127d0ed65"
+  integrity sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 test-exclude@^4.2.1:
   version "4.2.3"
@@ -21343,6 +22829,11 @@ traverse-chain@~0.1.0:
   resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
   integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
 
+traverse@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
@@ -21445,6 +22936,11 @@ ts-pnp@^1.0.0:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
+ts-pnp@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.4.tgz#ae27126960ebaefb874c6d7fa4729729ab200d90"
+  integrity sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw==
+
 ts2gql@CityOfBoston/ts2gql#4f10fcce:
   version "2.0.1"
   resolved "https://codeload.github.com/CityOfBoston/ts2gql/tar.gz/4f10fcce30d74c95201ff3630569f5840622701b"
@@ -21527,7 +23023,7 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typedarray-to-buffer@~3.1.5:
+typedarray-to-buffer@^3.1.5, typedarray-to-buffer@~3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
@@ -21640,6 +23136,11 @@ unfetch@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-3.0.0.tgz#8d1e0513a4ecd0e5ff2d41a6ba77771aae8b6482"
   integrity sha1-jR4FE6Ts0OX/LUGmund3Gq6LZII=
+
+unfetch@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -21899,6 +23400,13 @@ util@0.10.3, util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
+  dependencies:
+    inherits "2.0.3"
+
 utila@~0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.3.3.tgz#d7e8e7d7e309107092b05f8d9688824d633a4226"
@@ -22139,6 +23647,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vm-browserify@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
+  integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
@@ -22189,7 +23702,16 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0:
+watchpack@2.0.0-beta.5:
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.0-beta.5.tgz#c005db39570d81d9d34334870abc0f548901b880"
+  integrity sha512-HGqh9e9QZFhow8JYX+1+E+kIYK0uTTsk6rCOkI0ff0f9kMO0wX783yW8saQC9WDx7qHpVGPXsRnld9nY7iwzQA==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
+
+watchpack@^1.5.0, watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   integrity sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
@@ -22205,7 +23727,7 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-wcwidth@^1.0.0:
+wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
@@ -22250,6 +23772,16 @@ webpack-dev-middleware@3.4.0:
     memory-fs "~0.4.1"
     mime "^2.3.1"
     range-parser "^1.0.3"
+    webpack-log "^2.0.0"
+
+webpack-dev-middleware@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz#ef751d25f4e9a5c8a35da600c5fda3582b5c6cff"
+  integrity sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==
+  dependencies:
+    memory-fs "^0.4.1"
+    mime "^2.4.2"
+    range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
 webpack-dev-middleware@^3.5.1:
@@ -22308,6 +23840,16 @@ webpack-hot-middleware@2.24.3, webpack-hot-middleware@^2.24.3:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
+webpack-hot-middleware@2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz#4528a0a63ec37f8f8ef565cf9e534d57d09fe706"
+  integrity sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==
+  dependencies:
+    ansi-html "0.0.7"
+    html-entities "^1.2.0"
+    querystring "^0.2.0"
+    strip-ansi "^3.0.0"
+
 webpack-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f"
@@ -22336,6 +23878,14 @@ webpack-sources@1.3.0, webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-s
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
   integrity sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
+webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
+  integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
@@ -22399,6 +23949,35 @@ webpack@4.29.0, webpack@^4.29.0:
     terser-webpack-plugin "^1.1.0"
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
+
+webpack@4.39.0:
+  version "4.39.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.39.0.tgz#1d511308c3dd8f9fe3152c9447ce30f1814a620c"
+  integrity sha512-nrxFNSEKm4T1C/EsgOgN50skt//Pl4X7kgJC1MrlE47M292LSCVmMOC47iTGL0CGxbdwhKGgeThrJcw0bstEfA==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-module-context" "1.8.5"
+    "@webassemblyjs/wasm-edit" "1.8.5"
+    "@webassemblyjs/wasm-parser" "1.8.5"
+    acorn "^6.2.1"
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.3"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.4.0"
+    loader-utils "^1.2.3"
+    memory-fs "^0.4.1"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.1"
+    node-libs-browser "^2.2.1"
+    schema-utils "^1.0.0"
+    tapable "^1.1.3"
+    terser-webpack-plugin "^1.4.1"
+    watchpack "^1.6.0"
+    webpack-sources "^1.4.1"
 
 websocket-driver@>=0.5.1:
   version "0.7.0"
@@ -22708,6 +24287,20 @@ worker-farm@1.5.2, worker-farm@^1.5.2:
     errno "^0.1.4"
     xtend "^4.0.1"
 
+worker-farm@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
+  integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
+  dependencies:
+    errno "~0.1.7"
+
+worker-rpc@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/worker-rpc/-/worker-rpc-0.1.1.tgz#cb565bd6d7071a8f16660686051e969ad32f54d5"
+  integrity sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==
+  dependencies:
+    microevent.ts "~0.1.1"
+
 wrap-ansi@^2.0.0, wrap-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -22760,6 +24353,16 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.0.tgz#1b64dbbf77cb58fd09056963d63e62667ab4fb21"
+  integrity sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-json-file@^2.2.0, write-json-file@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This PR is based on https://github.com/CityOfBoston/digital/pull/458/ and upgrades Next.js to latest across all apps **except** for 311; after upgrading (along with Babel from 7.1.x to 7.6.x), running Jest throws

```
[mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[RecentRequestRow#3350.render()] { Invariant Violation: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
```

Since 311 is not currently in production and it’s unknown whether it ever _will_ be, it was decided to leave it as-is for the time being rather than spend more time troubleshooting.