### PR TITLE
Handles correct path for either D7 or D8

### DIFF
--- a/services-js/commissions-search/src/index.js
+++ b/services-js/commissions-search/src/index.js
@@ -11,9 +11,14 @@ import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { createHttpLink } from 'apollo-link-http';
 
-// Outside of a Drupal environment create a mock Drupal object
+let inferredVersion = 'd7';
+
+// Outside of a Drupal environment, create a mock Drupal object
 // eslint-disable-next-line no-use-before-define
-if (typeof window.Drupal === 'undefined') {
+if (
+  typeof window.Drupal === 'undefined' &&
+  typeof window.drupalSettings === 'undefined'
+) {
   window.Drupal = {
     settings: {
       bos_commissions_search: {
@@ -25,23 +30,48 @@ if (typeof window.Drupal === 'undefined') {
   };
 }
 
-const client = new ApolloClient({
-  link: new createHttpLink({
-    uri:
-      window.Drupal.settings.bos_commissions_search
-        .bos_commissions_search_graphql_endpoint,
+if (window.drupalSettings) {
+  inferredVersion = 'd8';
+}
+
+/**
+ * Returns an options object with the correct paths to Drupal’s settings,
+ * based on the current version.
+ * https://github.com/CityOfBoston/digital/issues/222
+ *
+ * @param {'d7' | 'd8'} drupalVersion
+ * @returns {{headers: {'x-api-key': *, 'content-type': string, accept: string}, uri: *}}
+ */
+function httpLinkOptions(drupalVersion) {
+  const endpoint =
+    drupalVersion === 'd8'
+      ? window.drupalSettings.bos_commissions.bos_commissions_search
+          .graphql_endpoint
+      : window.Drupal.settings.bos_commissions_search
+          .bos_commissions_search_graphql_endpoint;
+
+  const apiKey =
+    drupalVersion === 'd8'
+      ? window.drupalSettings.bos_commissions.bos_commissions_search.api_key
+      : window.Drupal.settings.bos_commissions_search
+          .bos_commissions_search_graphql_api_key;
+
+  return {
+    uri: endpoint,
     headers: {
       accept: '*/*',
       'content-type': 'application/json',
-      'x-api-key':
-        window.Drupal.settings.bos_commissions_search
-          .bos_commissions_search_graphql_api_key,
+      'x-api-key': apiKey,
     },
-  }),
-  cache: new InMemoryCache(),
-});
+  };
+}
 
 function ApolloWrapperComponent() {
+  const client = new ApolloClient({
+    link: new createHttpLink(httpLinkOptions(inferredVersion)),
+    cache: new InMemoryCache(),
+  });
+
   return (
     <ApolloProvider client={client}>
       <App />


### PR DESCRIPTION
Adds a function to infer the version of Drupal and use the correct path for its settings in the commissions-search app, as described in https://github.com/CityOfBoston/digital/issues/222

**todo/note:** this change was committed with `--no-verify`, as there seems to be an issue with eslint not understanding jsx in this one case; I presume this has to do with the fact that this app was created with create-react-app and has a very different build than the rest of our webapps. Resolving this now is proving to be a time sink, but ought to be revisited in the near future.