### PR TITLE
Issue #548: Add message when adding user if user is already in group

### DIFF
--- a/services-js/access-boston/src/client/group-management/Index.tsx
+++ b/services-js/access-boston/src/client/group-management/Index.tsx
@@ -209,7 +209,11 @@ export default function Index(props: Props) {
   }, [state.selected]);
 
   const handleToggleItem = (item: Group | Person) => {
-    dispatchList({ type: 'LIST/TOGGLE_ITEM_STATUS', item });
+    if (item.action && item.action === 'new') {
+      dispatchList({ type: 'LIST/DELETE_ITEM', item });
+    } else {
+      dispatchList({ type: 'LIST/TOGGLE_ITEM_STATUS', item });
+    }
   };
 
   const handleAddToList = (item: Group | Person) =>
@@ -223,6 +227,13 @@ export default function Index(props: Props) {
       return 'person';
     }
   };
+
+  let cnEntries = [];
+  if (state.selected.members || state.selected.groups) {
+    cnEntries = state.selected.members
+      ? state.selected.members
+      : state.selected.groups;
+  }
 
   switch (state.view) {
     case 'management':
@@ -247,6 +258,8 @@ export default function Index(props: Props) {
                 handleSelectClick={handleAddToList}
                 selectedItem={state.selected}
                 dns={groups}
+                cnArray={cnEntries}
+                currentlist={list}
               />
             }
             editableList={
@@ -278,6 +291,7 @@ export default function Index(props: Props) {
             resetAll={resetAll}
             items={list}
             dns={groups}
+            getAdminMinGroups={getAdminMinGroups}
           />
         </div>
       );

--- a/services-js/access-boston/src/client/group-management/ManagementView.tsx
+++ b/services-js/access-boston/src/client/group-management/ManagementView.tsx
@@ -31,9 +31,14 @@ interface Props {
 export default function ManagementView(props: Props) {
   const { mode, selected, list } = props;
 
-  const addedItems = list.filter(item => item.status === 'add') || [];
-  const removedItems = list.filter(item => item.status === 'remove') || [];
+  const addedItems =
+    list.filter(item => item.status === 'add' || item.action === 'new') || [];
+  // console.log('addedItems: ', addedItems);
+  const removedItems =
+    list.filter(item => item.status === 'remove' && item.action === '') || [];
+  // console.log('removedItems: ', removedItems);
   const canProceed: boolean = addedItems.length > 0 || removedItems.length > 0;
+  // console.log('canProceed: ', canProceed, '\n-------');
 
   return (
     <>

--- a/services-js/access-boston/src/client/group-management/ManagementView.tsx
+++ b/services-js/access-boston/src/client/group-management/ManagementView.tsx
@@ -30,15 +30,11 @@ interface Props {
  */
 export default function ManagementView(props: Props) {
   const { mode, selected, list } = props;
-
   const addedItems =
     list.filter(item => item.status === 'add' || item.action === 'new') || [];
-  // console.log('addedItems: ', addedItems);
   const removedItems =
     list.filter(item => item.status === 'remove' && item.action === '') || [];
-  // console.log('removedItems: ', removedItems);
   const canProceed: boolean = addedItems.length > 0 || removedItems.length > 0;
-  // console.log('canProceed: ', canProceed, '\n-------');
 
   return (
     <>

--- a/services-js/access-boston/src/client/group-management/ReviewChangesView.tsx
+++ b/services-js/access-boston/src/client/group-management/ReviewChangesView.tsx
@@ -23,13 +23,14 @@ interface Props {
   items: Array<Group | Person>;
   submitting?: boolean;
   dns?: [String];
+  getAdminMinGroups?: () => void | {};
 }
 
 export default function ReviewChangesView(props: Props) {
   const [submitting, setSubmitting] = useState<boolean>(
     props.submitting || false
   );
-  const { items, mode, selected, dns } = props;
+  const { items, mode, selected, dns, getAdminMinGroups } = props;
   const internalMode = mode === 'person' ? 'group' : 'person';
   const addedItems = items.filter(item => item.status === 'add') || [];
   const removedItems = items.filter(item => item.status === 'remove') || [];
@@ -39,6 +40,10 @@ export default function ReviewChangesView(props: Props) {
         <div css={MODAL_STYLING}>Submitting changes...</div>
       </StatusModal>
     );
+  };
+
+  const getAdmin_MinGroups = () => {
+    getAdminMinGroups ? getAdminMinGroups() : () => {};
   };
 
   const handleSubmit = async () => {
@@ -58,6 +63,7 @@ export default function ReviewChangesView(props: Props) {
         return updateGroup(updateParams.dn, operation, updateParams.cn, dns);
       });
       await Promise.all(promises).then(() => {
+        getAdmin_MinGroups();
         setTimeout(() => {
           setSubmitting(false);
           props.changeView('confirmation');

--- a/services-js/access-boston/src/client/group-management/data-fetching/fetch-group-data.ts
+++ b/services-js/access-boston/src/client/group-management/data-fetching/fetch-group-data.ts
@@ -157,6 +157,7 @@ export async function fetchPersonsGroups(
           displayName: '',
           members: [],
           status: 'current',
+          action: '',
         };
         return retgroup;
       })

--- a/services-js/access-boston/src/client/group-management/list-components/EditableList.tsx
+++ b/services-js/access-boston/src/client/group-management/list-components/EditableList.tsx
@@ -51,15 +51,11 @@ export default function EditableList(props: Props) {
     changePage(pageNum);
   };
   const handleNextPage = (currentPage, pageCount, changePage) => {
-    // eslint-disable-next-line no-console
-    // console.log('handleNextPage > dir: ', currentPage);
     if (currentPage < pageCount - 1) {
       changePage(currentPage + 1);
     }
   };
   const handlePrevPage = (currentPage, changePage) => {
-    // eslint-disable-next-line no-console
-    // console.log('handlePrevPage > dir: ', currentPage);
     if (currentPage > 0) {
       changePage(currentPage - 1);
     }
@@ -70,8 +66,6 @@ export default function EditableList(props: Props) {
       ? 'This group has no members'
       : 'This person hasn’t been added to any groups';
 
-  // const page_count = props.pageCount;
-
   if (props.loading === true) {
     return (
       <div css={LOADER_STYLING}>
@@ -79,14 +73,6 @@ export default function EditableList(props: Props) {
       </div>
     );
   } else {
-    // eslint-disable-next-line no-console
-    // console.log(
-    //   'pageCount: ', pageCount,
-    //   ' | currentPage: ', currentPage,
-    //   ' | pageSize: ', pageSize, props
-    // );
-    // const { pageCount } = props;
-    // const page_count = props.pageCount;
     return (
       <>
         <ul css={LIST_STYLING}>
@@ -105,12 +91,6 @@ export default function EditableList(props: Props) {
             <div css={NO_RESULTS_STYLING}>{noResultsText}</div>
           )}
         </ul>
-
-        {/* {console.log(
-          'EditableList .... pageCount: ', pageCount,
-          ' | pageSize: ', pageSize,
-          ' | items: ', props.items.length
-        )} */}
 
         {props.pageCount > 1 && (
           <>
@@ -142,8 +122,3 @@ const NO_RESULTS_STYLING = css({
   fontFamily: SANS,
   color: FREEDOM_RED_DARK,
 });
-
-// const BUTTON_CONTAINER_STYLING = css({
-//   display: 'flex',
-//   justifyContent: 'space-between',
-// });

--- a/services-js/access-boston/src/client/group-management/list-components/ListItemComponent.stories.tsx
+++ b/services-js/access-boston/src/client/group-management/list-components/ListItemComponent.stories.tsx
@@ -14,6 +14,7 @@ const person: Person = {
   sn: 'Roberts',
   mail: 'bob.roberts@boton.gov',
   groups: [],
+  action: '',
 };
 
 function Wrapper(props) {

--- a/services-js/access-boston/src/client/group-management/search-component/SearchComponent.tsx
+++ b/services-js/access-boston/src/client/group-management/search-component/SearchComponent.tsx
@@ -82,7 +82,6 @@ export default function SearchComponent(props: Props) {
       const isDup = isSelectionDuplication(newArr, selection.cn);
       if (!isDup.duplication) {
         selection.action = 'new';
-        // selection.state = 'add';
         props.handleSelectClick(selection);
         dispatch({ type: 'SEARCH/SUBMIT_SELECTION' });
       } else {

--- a/services-js/access-boston/src/client/group-management/search-component/SearchComponent.tsx
+++ b/services-js/access-boston/src/client/group-management/search-component/SearchComponent.tsx
@@ -35,6 +35,8 @@ interface Props {
   handleSelectClick: (selection: any) => void;
   currentStatus?: Status; // solely for Storybook
   dns: String[];
+  cnArray?: Array<string>;
+  currentlist?: Array<any>;
 }
 
 /**
@@ -54,8 +56,7 @@ export default function SearchComponent(props: Props) {
 
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const { currentStatus, mode, view, dns } = props;
-  // console.log('SearchComponent > Props dns: ', dns);
+  const { currentStatus, mode, view, dns, cnArray, currentlist } = props;
   const { searchStatus, searchText, searchResults, selection } = state;
 
   // Associate label with search field.
@@ -72,9 +73,22 @@ export default function SearchComponent(props: Props) {
   const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
     event.preventDefault();
 
-    props.handleSelectClick(selection);
-
-    dispatch({ type: 'SEARCH/SUBMIT_SELECTION' });
+    if (cnArray && cnArray.length > 1 && state.searchStatus === 'duplicate') {
+      handleChange('');
+    } else {
+      const new_currentlist =
+        currentlist && currentlist.length > 0 ? currentlist : [{ cn: '' }];
+      const newArr = new_currentlist.map(entry => entry.cn);
+      const isDup = isSelectionDuplication(newArr, selection.cn);
+      if (!isDup.duplication) {
+        selection.action = 'new';
+        // selection.state = 'add';
+        props.handleSelectClick(selection);
+        dispatch({ type: 'SEARCH/SUBMIT_SELECTION' });
+      } else {
+        handleChange('');
+      }
+    }
   };
 
   const handleChange = (text: string): void => {
@@ -94,11 +108,8 @@ export default function SearchComponent(props: Props) {
 
   const handleFetch = (): void => {
     dispatch({ type: 'SEARCH/UPDATE_STATUS', searchStatus: 'searching' });
-    // console.log('SearchComponent > handleFetch dns: ', dns);
 
     if (view === 'initial') {
-      // console.log('SearchComponent > handleFetch view > initial');
-      // console.log('SearchComponent > handleFetch view > initial: ', dns);
       props
         .handleFetch(searchText, null, dns)
         .then(result => updateSuggestions(result))
@@ -106,8 +117,6 @@ export default function SearchComponent(props: Props) {
           dispatch({ type: 'SEARCH/UPDATE_STATUS', searchStatus: 'fetchError' })
         );
     } else {
-      // console.log('SearchComponent > handleFetch view > else');
-      // console.log('SearchComponent > handleFetch view > else: ', dns);
       props
         .handleFetch(searchText, props.selectedItem as Person | Group, dns)
         .then(result => updateSuggestions(result));
@@ -131,6 +140,52 @@ export default function SearchComponent(props: Props) {
 
     return null;
   }
+
+  const isSelectionDuplication = (cnArray: Array<string>, cn: string) => {
+    let warningLabel = '';
+    let duplication = false;
+
+    if (cnArray && cnArray.length > 0) {
+      const newArr = cnArray.map(entry => {
+        if (entry && entry.indexOf('=') > -1) {
+          return entry.split('=')[1];
+        } else {
+          return entry;
+        }
+      });
+
+      if (newArr && newArr.indexOf(cn) > -1) {
+        warningLabel = 'Already Added';
+        duplication = true;
+      }
+    }
+
+    return { duplication, warningLabel };
+  };
+
+  const buttonLabel = () => {
+    if (cnArray && cnArray.length > 0 && state.searchStatus === 'duplicate') {
+      return textCopy[view][mode].clear;
+    } else {
+      return textCopy[view][mode].button;
+    }
+  };
+
+  const buttonDisabled = () => {
+    if (cnArray && cnArray.length > 0 && state.searchStatus === 'duplicate') {
+      return false;
+    } else {
+      return !selection.cn;
+    }
+  };
+
+  const defaultSearchText = (_newText: any = 0) => {
+    if (_newText && typeof _newText === 'string') {
+      return _newText;
+    } else {
+      return searchText;
+    }
+  };
 
   // used solely for Storybook; ensures specified status state is displayed.
   useEffect(() => {
@@ -182,9 +237,11 @@ export default function SearchComponent(props: Props) {
                   mode === 'person' ? 'name or ID' : 'group name'
                 }`}
                 onChange={handleChange}
-                searchText={searchText}
+                searchText={defaultSearchText()}
                 searchResults={searchResults}
                 onSuggestionSelected={handleSelection}
+                cnArray={cnArray}
+                isSelectionDuplication={isSelectionDuplication}
               />
 
               {statusIndicator()}
@@ -194,9 +251,9 @@ export default function SearchComponent(props: Props) {
               type="submit"
               className="btn"
               onClick={handleClick}
-              disabled={!selection.cn}
+              disabled={buttonDisabled()}
             >
-              {textCopy[view][mode].button}
+              {buttonLabel()}
             </button>
           </div>
         </div>
@@ -211,11 +268,13 @@ const textCopy = {
       title: 'Person search',
       label: 'Find a person',
       button: 'Select',
+      clear: 'Clear',
     },
     group: {
       title: 'Group search',
       label: 'Find a group',
       button: 'Select',
+      clear: 'Clear',
     },
   },
   management: {
@@ -223,11 +282,13 @@ const textCopy = {
       title: 'Add a new member',
       label: 'Find a person to add',
       button: 'Add member',
+      clear: 'Clear',
     },
     group: {
       title: 'Add to a group',
       label: 'Find a group to add',
       button: 'Add group',
+      clear: 'Clear',
     },
   },
 };

--- a/services-js/access-boston/src/client/group-management/state/data-helpers.ts
+++ b/services-js/access-boston/src/client/group-management/state/data-helpers.ts
@@ -4,6 +4,7 @@ import {
   ItemStatus,
   Person,
   pageSize,
+  Action,
 } from '../types';
 import { chunkArray } from '../fixtures/helpers';
 
@@ -112,6 +113,7 @@ function commonAttributes(dataObject): CommonAttributes {
     dn: dataObject.dn || '',
     displayName: dataObject.displayname || dataObject.cn,
     status: 'current' as ItemStatus,
+    action: '' as Action,
   };
 }
 

--- a/services-js/access-boston/src/client/group-management/state/list.ts
+++ b/services-js/access-boston/src/client/group-management/state/list.ts
@@ -9,7 +9,8 @@ export type ActionTypes =
   | 'LIST/ADD_ITEM'
   | 'LIST/REMOVE_ITEM'
   | 'LIST/TOGGLE_ITEM_STATUS'
-  | 'LIST/RETURN_ITEM';
+  | 'LIST/RETURN_ITEM'
+  | 'LIST/DELETE_ITEM';
 
 interface Action {
   type: ActionTypes;
@@ -44,6 +45,14 @@ export const reducer = (list, action: Partial<Action>) => {
         },
         ...list,
       ];
+
+    case 'LIST/DELETE_ITEM':
+      return list.filter(item => {
+        const action_item: any = action.item;
+        if (item.cn !== action_item.cn) {
+          return { ...item };
+        }
+      });
 
     case 'LIST/REMOVE_ITEM':
       return list.map(item => {

--- a/services-js/access-boston/src/client/group-management/state/search.ts
+++ b/services-js/access-boston/src/client/group-management/state/search.ts
@@ -3,7 +3,12 @@
 
 import { Group, Person } from '../types';
 
-export type Status = 'searching' | 'idle' | 'noResults' | 'fetchError';
+export type Status =
+  | 'searching'
+  | 'idle'
+  | 'noResults'
+  | 'fetchError'
+  | 'duplicate';
 
 type ActionTypes =
   | 'SEARCH/UPDATE_STATUS'
@@ -48,7 +53,9 @@ export const reducer = (state, action: Partial<Action>) => {
         ...state,
         searchResults: action.searchResults,
         searchStatus:
-          action.searchResults && action.searchResults.length > 0
+          state.searchText.indexOf('Already Added') > -1
+            ? 'duplicate'
+            : action.searchResults && action.searchResults.length > 0
             ? 'idle'
             : 'noResults',
       };

--- a/services-js/access-boston/src/client/group-management/types.ts
+++ b/services-js/access-boston/src/client/group-management/types.ts
@@ -1,6 +1,7 @@
 export type View = 'initial' | 'management' | 'review' | 'confirmation';
 export type Mode = 'person' | 'group';
-export type ItemStatus = 'current' | 'add' | 'remove';
+export type ItemStatus = 'current' | 'add' | 'remove' | 'new';
+export type Action = '' | 'new';
 export type ShowLabel = true | false;
 export type CurrentPage = number;
 export type PageCount = number;
@@ -17,6 +18,7 @@ export interface CommonAttributes {
   displayName: string;
 
   status: ItemStatus;
+  action: Action;
 
   // A group is available if the user is an app owner and may add/remove users;
   // a person is available if they are not set as “inactive”.


### PR DESCRIPTION
Main change: Add message when adding user if user is already in group

- UI rework that removes added items from the list when you uncheck them.
- Fixed Admin Group, groups gets updated whenever an update happens.
- Fix review changes on unselected