### PR TITLE
Access-Boston: (PROD) - Fix Sceris groups, uppercase

### DIFF
--- a/services-js/access-boston/README.md
+++ b/services-js/access-boston/README.md
@@ -104,3 +104,4 @@ We also need to generate keys.
 - 2021.03.29: PROD deploy - ScerIS tile 2nd try
 - 2021.03.29: PROD deploy - ScerIS tile 3rd try
 - 2021.04.14: PROD deploy - Boston Gives Back (United Way)
+- 2021.04.15: PROD deploy - ScerIS tile fix, uppercase groups


### PR DESCRIPTION
Groups need to always be uppercase