### PR TITLE
Access-Boston: Setting Notice text from Config

### DIFF
--- a/services-js/access-boston/fixtures/apps.yaml
+++ b/services-js/access-boston/fixtures/apps.yaml
@@ -1,3 +1,7 @@
+notice:
+  label: 'Notice'
+  pretext: 'Beacon, the new HR self-service portal, is now live!'
+  text: 'Look for the lighthouse icon below.'
 categories:
   - title: Applications
     show_request_access_link: false

--- a/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
@@ -7,11 +7,6 @@ import {
 export type Account = FetchAccountAndApps['account'];
 export type Apps = FetchAccountAndApps['apps'];
 export type Notice = FetchAccountAndApps['notice'];
-// export type Notice = {
-//   title: string;
-//   url: string;
-// };
-// export type Notice = FetchAccountAndApps['notice'];
 export type CategoryApps = Array<FetchAccountAndApps_apps_categories_apps>;
 
 const QUERY = gql`

--- a/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
@@ -6,6 +6,12 @@ import {
 
 export type Account = FetchAccountAndApps['account'];
 export type Apps = FetchAccountAndApps['apps'];
+export type Notice = FetchAccountAndApps['notice'];
+// export type Notice = {
+//   title: string;
+//   url: string;
+// };
+// export type Notice = FetchAccountAndApps['notice'];
 export type CategoryApps = Array<FetchAccountAndApps_apps_categories_apps>;
 
 const QUERY = gql`
@@ -21,6 +27,12 @@ const QUERY = gql`
       mfaRequiredDate
       groups
       email
+    }
+
+    notice {
+      label
+      pretext
+      text
     }
 
     apps {

--- a/services-js/access-boston/src/client/graphql/queries.ts
+++ b/services-js/access-boston/src/client/graphql/queries.ts
@@ -70,6 +70,12 @@ export interface FetchAccountAndApps_account {
   email: string;
 }
 
+export interface FetchAccountAndApps_notice {
+  label: string;
+  pretext: string;
+  text: string;
+}
+
 export interface FetchAccountAndApps_apps_categories_apps {
   title: string;
   url: string;
@@ -91,6 +97,7 @@ export interface FetchAccountAndApps_apps {
 
 export interface FetchAccountAndApps {
   account: FetchAccountAndApps_account;
+  notice: FetchAccountAndApps_notice;
   apps: FetchAccountAndApps_apps;
 }
 

--- a/services-js/access-boston/src/lib/AppsRegistry.ts
+++ b/services-js/access-boston/src/lib/AppsRegistry.ts
@@ -1,5 +1,11 @@
 import yaml from 'js-yaml';
 
+export interface Notice {
+  label: string;
+  pretext: string;
+  text: string;
+}
+
 export interface AppsCategory {
   title: string;
   showRequestAccessLink: boolean;
@@ -20,6 +26,30 @@ export interface App {
   target: string;
 }
 
+export class NoticeClass implements Notice {
+  label: string = '';
+  pretext: string = '';
+  text: string = '';
+
+  constructor(opts: { label?: any; pretext?: any; text?: any }) {
+    (this.label = opts.label ? opts.label : ''),
+      (this.pretext = opts.pretext ? opts.pretext : ''),
+      (this.text = opts.text ? opts.text : '');
+  }
+}
+
+// export class ResponseClass implements Response {
+//   message: string = '';
+//   code: string = '200';
+//   body: any;
+
+//   constructor(opts: { message?: any; code?: any; body?: any }) {
+//     (this.message = opts.message ? opts.message : '200 Ok'),
+//       (this.code = opts.code ? opts.code : '200'),
+//       (this.body = opts.body ? opts.body : { error: '', data: '' });
+//   }
+// }
+
 /**
  * This class is in lib rather than server just so we can use it in Storybook
  * stories. It doesn’t actually get used by the client app.
@@ -27,14 +57,18 @@ export interface App {
 export default class AppsRegistry {
   showAll: boolean;
   allCategories: AppsCategory[];
+  noticeMsg: Notice[];
 
   constructor(appsYaml: any, showAll = false) {
     this.showAll = showAll;
     const yamlCategories = appsYaml.categories;
+    const yamlNotice = appsYaml.notice;
 
     if (!yamlCategories || !Array.isArray(yamlCategories)) {
       throw new Error('Missing categories array');
     }
+
+    this.noticeMsg = yamlNotice ? yamlNotice : new NoticeClass({});
 
     this.allCategories = yamlCategories.map(c => {
       const { title, apps: yamlApps, show_request_access_link, icons } = c;
@@ -93,6 +127,10 @@ export default class AppsRegistry {
         icons: !!icons,
       };
     });
+  }
+
+  appsForNotice(): Notice[] {
+    return this.noticeMsg;
   }
 
   appsForGroups(

--- a/services-js/access-boston/src/lib/AppsRegistry.ts
+++ b/services-js/access-boston/src/lib/AppsRegistry.ts
@@ -38,18 +38,6 @@ export class NoticeClass implements Notice {
   }
 }
 
-// export class ResponseClass implements Response {
-//   message: string = '';
-//   code: string = '200';
-//   body: any;
-
-//   constructor(opts: { message?: any; code?: any; body?: any }) {
-//     (this.message = opts.message ? opts.message : '200 Ok'),
-//       (this.code = opts.code ? opts.code : '200'),
-//       (this.body = opts.body ? opts.body : { error: '', data: '' });
-//   }
-// }
-
 /**
  * This class is in lib rather than server just so we can use it in Storybook
  * stories. It doesn’t actually get used by the client app.

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -27,6 +27,8 @@ import { requireRegistration } from '../client/auth-helpers';
 
 import AppWrapper from '../client/common/AppWrapper';
 
+import { Notice } from '../server/graphql/schema';
+
 export enum FlashMessage {
   CHANGE_PASSWORD_SUCCESS = 'password',
 }
@@ -40,6 +42,7 @@ interface Props {
   apps: Apps;
   flashMessage?: FlashMessage;
   daysUntilMfa: number | null;
+  notice: Notice;
 }
 
 export default class IndexPage extends React.Component<Props> {
@@ -47,7 +50,7 @@ export default class IndexPage extends React.Component<Props> {
     { query },
     { fetchGraphql }: GetInitialPropsDependencies
   ): Promise<Props> => {
-    const { account, apps } = await fetchAccountAndApps(fetchGraphql);
+    const { account, apps, notice } = await fetchAccountAndApps(fetchGraphql);
 
     requireRegistration(account);
 
@@ -61,6 +64,7 @@ export default class IndexPage extends React.Component<Props> {
       daysUntilMfa,
       account,
       apps,
+      notice,
     };
   };
 
@@ -70,9 +74,14 @@ export default class IndexPage extends React.Component<Props> {
       flashMessage,
       apps: { categories },
       daysUntilMfa,
+      notice,
     } = this.props;
     const iconCategories = categories.filter(({ showIcons }) => showIcons);
     const listCategories = categories.filter(({ showIcons }) => !showIcons);
+    const noticeLabel =
+      notice.text.length > 0 && notice.label.length > 0
+        ? notice.label
+        : 'Notice';
 
     return (
       <>
@@ -126,13 +135,15 @@ export default class IndexPage extends React.Component<Props> {
                 key={title}
                 aria-labelledby={SectionHeader.makeId(title)}
               >
-                <div css={APP_ALERT_MSG}>
-                  <label className="notice">NOTICE: </label>
-                  <span>
-                    Beacon, the new HR self-service portal, is now live!
-                  </span>{' '}
-                  Look for the lighthouse icon below.
-                </div>
+                {notice.text.length > 0 && (
+                  <div css={APP_ALERT_MSG}>
+                    {notice.label.length > 0 && (
+                      <label className="notice">{noticeLabel}: </label>
+                    )}
+                    {notice.pretext.length > 0 && <span>{notice.pretext}</span>}
+                    {notice.text}
+                  </div>
+                )}
                 <SectionHeader title={title} />
 
                 {requestAccessUrl && (

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -140,7 +140,9 @@ export default class IndexPage extends React.Component<Props> {
                     {notice.label.length > 0 && (
                       <label className="notice">{noticeLabel}: </label>
                     )}
-                    {notice.pretext.length > 0 && <span>{notice.pretext}</span>}
+                    {notice.pretext.length > 0 && (
+                      <span>{notice.pretext} </span>
+                    )}
                     {notice.text}
                   </div>
                 )}
@@ -277,6 +279,7 @@ const APP_ALERT_MSG = css({
     color: 'red',
     fontWeight: 'bold',
     marginBottom: '0.5em',
+    textTransform: 'uppercase',
   },
   span: {
     fontWeight: 'bold',

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -42,6 +42,7 @@ export interface Schema {
 }
 
 export interface Query {
+  notice: Notice;
   account: Account;
   apps: Apps;
   workflow(args: { caseId: string }): Workflow;
@@ -110,6 +111,12 @@ export interface App {
   target: string | null;
 }
 
+export interface Notice {
+  label: string;
+  pretext: string;
+  text: string;
+}
+
 // This file is built by the "generate-graphql-schema" script from
 // the above interfaces.
 const schemaGraphql = fs.readFileSync(
@@ -128,6 +135,16 @@ export type QueryRootResolvers = Resolvers<Query, Context>;
 export type MutationResolvers = Resolvers<Mutation, Context>;
 
 const queryRootResolvers: QueryRootResolvers = {
+  notice: (_root, _arg, { appsRegistry }) => {
+    const notice = appsRegistry.appsForNotice();
+
+    return {
+      label: notice['label'],
+      pretext: notice['pretext'],
+      text: notice['text'],
+    };
+  },
+
   account: (_root, _args, { session }) => {
     const { loginAuth, forgotPasswordAuth, loginSession } = session;
 

--- a/services-js/access-boston/src/stories/IndexPage.stories.tsx
+++ b/services-js/access-boston/src/stories/IndexPage.stories.tsx
@@ -7,6 +7,7 @@ import { makeAppsRegistry } from '../lib/AppsRegistry';
 
 // @ts-ignore
 import APPS_YAML from '../../fixtures/apps.yaml';
+import { NoticeClass } from '../lib/AppsRegistry';
 
 const ACCOUNT: Account = {
   employeeId: 'CON01234',
@@ -34,7 +35,12 @@ const APPS: Apps = {
 
 storiesOf('IndexPage', module)
   .add('default', () => (
-    <IndexPage account={ACCOUNT} apps={APPS} daysUntilMfa={null} />
+    <IndexPage
+      account={ACCOUNT}
+      apps={APPS}
+      daysUntilMfa={null}
+      notice={new NoticeClass({})}
+    />
   ))
   .add('change password success', () => (
     <IndexPage
@@ -42,6 +48,7 @@ storiesOf('IndexPage', module)
       apps={APPS}
       flashMessage={FlashMessage.CHANGE_PASSWORD_SUCCESS}
       daysUntilMfa={null}
+      notice={new NoticeClass({})}
     />
   ))
   .add('hasn’t registered MFA', () => (
@@ -52,5 +59,6 @@ storiesOf('IndexPage', module)
       }}
       apps={APPS}
       daysUntilMfa={28}
+      notice={new NoticeClass({})}
     />
   ));

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -6737,20 +6737,6 @@ exports[`Storyshots IndexPage change password success 1`] = `
         className="m-b500"
       >
         <div
-          className="css-1rggak7"
-        >
-          <label
-            className="notice"
-          >
-            NOTICE: 
-          </label>
-          <span>
-            Beacon, the new HR self-service portal, is now live!
-          </span>
-           
-          Look for the lighthouse icon below.
-        </div>
-        <div
           className="sh m-b300 "
         >
           <h2
@@ -7748,20 +7734,6 @@ exports[`Storyshots IndexPage default 1`] = `
         aria-labelledby="sh-1322116428"
         className="m-b500"
       >
-        <div
-          className="css-1rggak7"
-        >
-          <label
-            className="notice"
-          >
-            NOTICE: 
-          </label>
-          <span>
-            Beacon, the new HR self-service portal, is now live!
-          </span>
-           
-          Look for the lighthouse icon below.
-        </div>
         <div
           className="sh m-b300 "
         >
@@ -8814,20 +8786,6 @@ exports[`Storyshots IndexPage hasn’t registered MFA 1`] = `
         aria-labelledby="sh-1322116428"
         className="m-b500"
       >
-        <div
-          className="css-1rggak7"
-        >
-          <label
-            className="notice"
-          >
-            NOTICE: 
-          </label>
-          <span>
-            Beacon, the new HR self-service portal, is now live!
-          </span>
-           
-          Look for the lighthouse icon below.
-        </div>
         <div
           className="sh m-b300 "
         >


### PR DESCRIPTION
Setting up banner message area (`Notice`) to be populated via configs. Previously, this was hardcoded, now whether the `notice` is shown can be set by including a `notice` node in the config file for the [environments](https://github.com/CityOfBoston/access-boston-config/tree/master/src/configs). If the node below is missing from the top level of the config file then the `notice` header will not be shown.

```yaml
notice:
  label: 'Notice'
  pretext: 'Beacon, the new HR self-service portal, is now live!'
  text: 'Look for the lighthouse icon below.'
```