### PR TITLE
DIG-3264: Online Birth Certificate Date Validation

### DIFF
--- a/services-js/registry-certs/Dockerfile
+++ b/services-js/registry-certs/Dockerfile
@@ -78,7 +78,7 @@ CMD ["yarn", "start"]
 #   To use this file:
 #       [a] clone the digital repo
 #       [b] from a terminal, in the registry-certs folder, run
-#           DOCKER_BUILDKIT=1 docker build --pull --cache-from local-dev/registry-certs:latest -f ./Dockerfile -t local-dev/registry-certs:latest --secret id=aws,src=$HOME/.aws/credentials ../..
+#           DOCKER_BUILDKIT=1 docker build --pull --cache-from local-dev/registry-certs:latest -f ./Dockerfile -t local-dev/registry-certs:latest --secret id=aws,src=$HOME/.aws/credentials --platform linux/arm64 ../..
 #           -> this will create an image tagged local-dev/registry-certs:latest on the local machine
 #       [c] from a terminal, in the registry-certs folder, run
 #           docker-compose up --no-build -d registry-certs
@@ -96,8 +96,9 @@ CMD ["yarn", "start"]
 #       [1] Check your code into github
 #       [2] Close down any shells into the container and stop the container:
 #           docker stop registry-certs
+#       [2.5] Re-login into ECR with this command --> aws ecr get-login-password --region us-east-1 --profile=cityofboston | docker login --username AWS --password-stdin 251803681989.dkr.ecr.us-east-1.amazonaws.com
 #       [3] Rebuild the container and apps by running:
-#           DOCKER_BUILDKIT=1 docker build --pull --cache-from local-dev/registry-certs:latest -f ./Dockerfile -t 251803681989.dkr.ecr.us-east-1.amazonaws.com/cob-digital-apps-staging/registry-certs:deploy-new-stage --secret id=aws,src=$HOME/.aws/credentials ../..
+#           DOCKER_BUILDKIT=1 docker build --pull --cache-from local-dev/registry-certs:latest -f ./Dockerfile -t 251803681989.dkr.ecr.us-east-1.amazonaws.com/cob-digital-apps-staging/registry-certs:deploy-new-stage --secret id=aws,src=$HOME/.aws/credentials --platform linux/amd64 ../..
 #           -> this is essentially the same command as in [b] above, just uses a different tag and ensures the /app folder
 #              is physically there and not mounted (using the docker-compose command in [c] above mounts the repo over
 #              whatever was added into the the image's /app folder during the docker build command)

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -10090,17 +10090,23 @@ exports[`Storyshots Birth/Question Components/PersonalInformation birth too rece
         <h2
           className="h3 tt-u"
         >
-          We might not have the birth certificate yet
+          Birth Certificate is Being Processed
         </h2>
         <p>
-          <strong>
-            We recommend waiting at least two weeks before you request a birth certificate.
-          </strong>
+          Birth information takes up to two weeks to arrive from a hospital to the City of Boston. Please submit an order after
            
-          It generally takes two weeks for us to receive paperwork from the hospital.
-        </p>
-        <p>
-          If you order too early, we can only hold your request for seven days while we wait for the hospital record. If we don’t receive the record in time, your request will be canceled automatically and your card will not be charged. You’ll have to resubmit your request.
+          12/12/2023
+          . We apologize for the inconvenience. If you
+           
+          have any questions or concerns, please
+           
+          <a
+            href="https://www.boston.gov/still-have-questions-registry"
+            target="_blank"
+          >
+            contact us online
+          </a>
+          , by phone at 617-635-4175, or visit City Hall in person Monday Friday, from 9 a.m. - 4 p.m.
         </p>
       </div>
     </div>

--- a/services-js/registry-certs/client/birth/questions/PersonalInformation.tsx
+++ b/services-js/registry-certs/client/birth/questions/PersonalInformation.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx, css } from '@emotion/core';
 
 import { ChangeEvent, Component, MouseEvent, ReactChild } from 'react';
 import { observer } from 'mobx-react';
@@ -36,7 +36,12 @@ export default class PersonalInformation extends Component<Props> {
   }: BirthCertificateRequest): boolean {
     const { firstName, lastName, birthDate } = requestInformation;
 
-    return !!(firstName && lastName && birthDate);
+    return !!(
+      firstName &&
+      lastName &&
+      birthDate &&
+      !isDateWithinPastFourteenDays(birthDate)
+    );
   }
 
   private handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -128,7 +133,7 @@ export default class PersonalInformation extends Component<Props> {
         </div>
 
         {birthDate &&
-          (isDateWithinPastTenDays(birthDate) ||
+          (isDateWithinPastFourteenDays(birthDate) ||
             this.props.showRecentBirthWarning) &&
           this.renderRecentBirthWarningText()}
       </QuestionComponent>
@@ -136,33 +141,50 @@ export default class PersonalInformation extends Component<Props> {
   }
 
   private renderRecentBirthWarningText(): ReactChild {
+    const { birthCertificateRequest } = this.props;
+    const { birthDate } = birthCertificateRequest.requestInformation;
     return (
       <div className={NOTE_BOX_CLASSNAME} style={{ paddingBottom: 0 }}>
-        <h2 className="h3 tt-u">We might not have the birth certificate yet</h2>
-
+        <h2 className="h3 tt-u">Birth Certificate is Being Processed</h2>
         <p>
-          <strong>
-            We recommend waiting at least two weeks before you request a birth
-            certificate.
-          </strong>{' '}
-          It generally takes two weeks for us to receive paperwork from the
-          hospital.
-        </p>
-
-        <p>
-          If you order too early, we can only hold your request for seven days
-          while we wait for the hospital record. If we don’t receive the record
-          in time, your request will be canceled automatically and your card
-          will not be charged. You’ll have to resubmit your request.
+          Birth information takes up to two weeks to arrive from a hospital to
+          the City of Boston. Please submit an order after{' '}
+          <span css={PICKUP_DATE_STYLE}>{getPickUpDate(birthDate)}</span>. We
+          apologize for the inconvenience. If you have any questions or
+          concerns, please{' '}
+          <a
+            href="https://www.boston.gov/still-have-questions-registry"
+            target="_blank"
+          >
+            contact us online
+          </a>
+          , by phone at 617-635-4175, or visit City Hall in person Monday
+          Friday, from 9 a.m. - 4 p.m.
         </p>
       </div>
     );
   }
 }
 
-function isDateWithinPastTenDays(date: Date): boolean {
+function isDateWithinPastFourteenDays(date: Date): boolean {
   const dayInMs = 8.64e7;
-  const tenDaysAgo = new Date(Date.now() - 10 * dayInMs);
+  const daysAgo = new Date(Date.now() - 14 * dayInMs);
 
-  return tenDaysAgo < date;
+  return daysAgo < date;
 }
+
+function getPickUpDate(date: Date | null | undefined): string {
+  if (date && typeof date === 'object' && typeof date.getDate === 'function') {
+    const pickUpDate = new Date(
+      new Date(Date.now() - 14 * 8.64e7).setDate(date.getDate() + 14)
+    );
+    return `${pickUpDate.getMonth() +
+      1}/${pickUpDate.getDate()}/${pickUpDate.getFullYear()}`;
+  } else {
+    return '';
+  }
+}
+
+const PICKUP_DATE_STYLE = css({
+  fontWeight: 'bold',
+});


### PR DESCRIPTION
Description: Users cannot order Birth Certificates within 14 days of the DOB of the child. When a user is using the online ordering form and they enter a date within the 14 days of birth on the When were they born? question they will see a pop up message stating the registry may not have the birth certificate yet. The user still has the ability to click the next question button and go through the payment process. 

Use Case: As a user I want clear language stating the registry will not have my new born child’s birth certificate and do not want the ability to move forward in the form workflow to the payment screen. 



Updated Messaging for user who enters a date within 14 days of DOB :

BIRTH CERTIFICATE IS BEING PROCESSED

Birth information takes up to two weeks to arrive from a hospital to the City of Boston. Please submit an order after XXXXXX date. We apologize for the inconvenience. If you have any questions or concerns, please [contact us online](https://www.boston.gov/still-have-questions-registry), by phone at 617-635-4175, or visit City Hall in person Monday through Friday, from 9 a.m. - 4 p.m. 

_____________________________________________________________

![f786fe8a-6148-4afe-a8fb-b94285fd3e2a](https://github.com/CityOfBoston/digital/assets/2627273/c5fa35ef-0ef4-4f3f-a731-17979037a862)
![b3a42275-3903-425a-bfa0-d199bfc08b17](https://github.com/CityOfBoston/digital/assets/2627273/9ae60901-4e97-4ff7-8dc4-f004c33d8440)
