### PR TITLE
DIG-4058: Text Box treatments for data entry states and required fields

### DIFF
--- a/modules-js/react-fleet/.storybook/preview-head.html
+++ b/modules-js/react-fleet/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <!--[if !IE]><!-->
 <link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" />
-<!-- <link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" /> -->
+<!-- <link rel="stylesheet" type="text/css" href="http://localhost:3030/css/public.css" /> -->
 <!-- <link rel="stylesheet" type="text/css" href="http://10.0.0.172:8080/css/public.css" /> -->
 <!--<![endif]-->
 <!--[if lt IE 10]>

--- a/modules-js/react-fleet/.storybook/preview-head.html
+++ b/modules-js/react-fleet/.storybook/preview-head.html
@@ -1,5 +1,6 @@
 <!--[if !IE]><!-->
-<link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" />
+<!-- <link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" /> -->
+<link type="text/css" rel="stylesheet" href="https://patterns-stg.boston.gov/css/public.css" />
 <!-- <link rel="stylesheet" type="text/css" href="http://localhost:3030/css/public.css" /> -->
 <!-- <link rel="stylesheet" type="text/css" href="http://10.0.0.172:8080/css/public.css" /> -->
 <!--<![endif]-->

--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -3235,7 +3235,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput default 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       disabled={false}
       id="input-362326901"
       placeholder=""
@@ -3284,7 +3284,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput error 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  txt-f--err"
+      className="txt-f  txt-f--err "
       id="input-2348632648"
       type="text"
     />
@@ -3318,7 +3318,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput error 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  txt-f--err"
+      className="txt-f  txt-f--err "
       id="input-3077581017"
       type="text"
     />
@@ -3364,7 +3364,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput interactive states 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       disabled={false}
       id="input-2715199497"
       placeholder=""
@@ -3401,7 +3401,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput interactive states 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f    txt-f--focused"
       disabled={false}
       id="input-3647184142"
       placeholder=""
@@ -3450,7 +3450,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput interactive states 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       disabled={false}
       id="input-680647510"
       placeholder=""
@@ -3484,20 +3484,32 @@ exports[`Storyshots Form Elements|Inputs/TextInput interactive states 1`] = `
       >
         State - Error
       </span>
+      <span
+        aria-hidden="true"
+        className="t--req"
+        style={
+          Object {
+            "display": "flex",
+            "flexGrow": 1,
+          }
+        }
+      >
+        Required
+      </span>
     </label>
     <input
       aria-label=""
-      className="txt-f  txt-f--err"
+      className="txt-f  txt-f--err "
       disabled={false}
       id="input-2490219431"
       placeholder=""
-      required={false}
+      required={true}
       type="text"
     />
     <div
       className="t--subinfo t--err m-b100 m-t100"
     >
-       
+      Error Message ...
     </div>
   </div>
 </div>
@@ -3548,7 +3560,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput variations 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       id="input-1357588218"
       required={true}
       type="text"
@@ -3583,7 +3595,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput variations 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       id="input-3174958747"
       placeholder="Placeholder Text"
       type="text"
@@ -3619,7 +3631,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput variations 1`] = `
       </label>
       <input
         aria-label=""
-        className="txt-f  "
+        className="txt-f   "
         id="input-423803610"
         onChange={[Function]}
         type="password"
@@ -3666,7 +3678,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput variations 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       id="input-5381"
       type="text"
     />
@@ -3700,7 +3712,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput variations 1`] = `
     </label>
     <input
       aria-label=""
-      className="txt-f txt-f--sm "
+      className="txt-f  txt-f--sm  "
       id="input-472033325"
       placeholder="Placeholder Text"
       type="text"
@@ -3833,7 +3845,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f    txt-f--sr"
       disabled={false}
       id="input-362326901"
       placeholder=""
@@ -3854,7 +3866,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </div>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f    txt-f--sr"
       disabled={false}
       id="input-362326901"
       placeholder=""
@@ -3957,7 +3969,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       disabled={false}
       id="input-362326901"
       placeholder=""

--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -3845,7 +3845,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </label>
     <input
       aria-label=""
-      className="txt-f    txt-f--sr"
+      className="txt-f   "
       disabled={false}
       id="input-362326901"
       placeholder=""
@@ -3866,7 +3866,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </div>
     <input
       aria-label=""
-      className="txt-f    txt-f--sr"
+      className="txt-f   "
       disabled={false}
       id="input-362326901"
       placeholder=""

--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -3331,6 +3331,178 @@ exports[`Storyshots Form Elements|Inputs/TextInput error 1`] = `
 </div>
 `;
 
+exports[`Storyshots Form Elements|Inputs/TextInput interactive states 1`] = `
+<div
+  style={
+    Object {
+      "margin": "2rem auto",
+      "maxWidth": "768px",
+    }
+  }
+>
+  <div>
+    <label
+      className="txt-l "
+      htmlFor="input-2715199497"
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <span
+        style={
+          Object {
+            "display": "flex",
+            "marginRight": "0.5em",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Default (non-active, unvalidated or required
+      </span>
+    </label>
+    <input
+      aria-label=""
+      className="txt-f  "
+      disabled={false}
+      id="input-2715199497"
+      placeholder=""
+      required={false}
+      type="text"
+    />
+    <div
+      className="t--subinfo t--err m-b100 m-t100"
+    >
+       
+    </div>
+  </div>
+  <div>
+    <label
+      className="txt-l "
+      htmlFor="input-3647184142"
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <span
+        style={
+          Object {
+            "display": "flex",
+            "marginRight": "0.5em",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        State - Focus - Click into field
+      </span>
+    </label>
+    <input
+      aria-label=""
+      className="txt-f  "
+      disabled={false}
+      id="input-3647184142"
+      placeholder=""
+      required={false}
+      type="text"
+    />
+    <div
+      className="t--subinfo t--err m-b100 m-t100"
+    >
+       
+    </div>
+  </div>
+  <div>
+    <label
+      className="txt-l "
+      htmlFor="input-680647510"
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <span
+        style={
+          Object {
+            "display": "flex",
+            "marginRight": "0.5em",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        State - Required
+      </span>
+      <span
+        aria-hidden="true"
+        className="t--req"
+        style={
+          Object {
+            "display": "flex",
+            "flexGrow": 1,
+          }
+        }
+      >
+        Required
+      </span>
+    </label>
+    <input
+      aria-label=""
+      className="txt-f  "
+      disabled={false}
+      id="input-680647510"
+      placeholder=""
+      required={true}
+      type="text"
+    />
+    <div
+      className="t--subinfo t--err m-b100 m-t100"
+    >
+       
+    </div>
+  </div>
+  <div>
+    <label
+      className="txt-l "
+      htmlFor="input-2490219431"
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <span
+        style={
+          Object {
+            "display": "flex",
+            "marginRight": "0.5em",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        State - Error
+      </span>
+    </label>
+    <input
+      aria-label=""
+      className="txt-f  txt-f--err"
+      disabled={false}
+      id="input-2490219431"
+      placeholder=""
+      required={false}
+      type="text"
+    />
+    <div
+      className="t--subinfo t--err m-b100 m-t100"
+    >
+       
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Form Elements|Inputs/TextInput variations 1`] = `
 <div
   style={
@@ -3661,7 +3833,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       disabled={false}
       id="input-362326901"
       placeholder=""
@@ -3682,7 +3854,7 @@ exports[`Storyshots Form Elements|Inputs/TextInput w/Tool Tip: Short & Long 1`] 
     </div>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       disabled={false}
       id="input-362326901"
       placeholder=""

--- a/modules-js/react-fleet/src/form-elements/UploadPhoto.stories.tsx
+++ b/modules-js/react-fleet/src/form-elements/UploadPhoto.stories.tsx
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 
-import { storiesOf } from '@storybook/react';
-
 import { css, jsx } from '@emotion/core';
+
+import { storiesOf } from '@storybook/react';
 
 import { BLACK, OPTIMISTIC_BLUE_LIGHT, WHITE } from '../utilities/constants';
 

--- a/modules-js/react-fleet/src/form-elements/inputs/TextInput.stories.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/TextInput.stories.tsx
@@ -144,6 +144,7 @@ storiesOf('Form Elements|Inputs/TextInput', module)
           required={boolean('Required', false)}
           disabled={boolean('Disabled', false)}
           error={boolean('Error', false)}
+          focused={true}
         />
 
         <TextInput
@@ -159,9 +160,9 @@ storiesOf('Form Elements|Inputs/TextInput', module)
           label={text('Label text', 'State - Error')}
           placeholder={text('Placeholder text', '')}
           small={boolean('Small variant', false)}
-          required={boolean('Required', false)}
+          required={boolean('Required', true)}
           disabled={boolean('Disabled', false)}
-          error={boolean('Error', true)}
+          error={`Error Message ...`}
         />
       </>
     );

--- a/modules-js/react-fleet/src/form-elements/inputs/TextInput.stories.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/TextInput.stories.tsx
@@ -121,4 +121,48 @@ storiesOf('Form Elements|Inputs/TextInput', module)
         />
       </>
     );
+  })
+  .add('interactive states', () => {
+    return (
+      <>
+        <TextInput
+          label={text(
+            'Label text',
+            'Default (non-active, unvalidated or required'
+          )}
+          placeholder={text('Placeholder text', '')}
+          small={boolean('Small variant', false)}
+          required={boolean('Required', false)}
+          disabled={boolean('Disabled', false)}
+          error={boolean('Error', false)}
+        />
+
+        <TextInput
+          label={text('Label text', 'State - Focus - Click into field')}
+          placeholder={text('Placeholder text', '')}
+          small={boolean('Small variant', false)}
+          required={boolean('Required', false)}
+          disabled={boolean('Disabled', false)}
+          error={boolean('Error', false)}
+        />
+
+        <TextInput
+          label={text('Label text', 'State - Required')}
+          placeholder={text('Placeholder text', '')}
+          small={boolean('Small variant', false)}
+          required={boolean('Required', true)}
+          disabled={boolean('Disabled', false)}
+          error={boolean('Error', false)}
+        />
+
+        <TextInput
+          label={text('Label text', 'State - Error')}
+          placeholder={text('Placeholder text', '')}
+          small={boolean('Small variant', false)}
+          required={boolean('Required', false)}
+          disabled={boolean('Disabled', false)}
+          error={boolean('Error', true)}
+        />
+      </>
+    );
   });

--- a/modules-js/react-fleet/src/form-elements/inputs/TextInput.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/TextInput.tsx
@@ -41,11 +41,13 @@ type Props = {
   optionalDescription?: string;
 
   required?: boolean;
-  softRequired?: boolean;
-  toolTip?: { icon: string; msg: string };
   inputMode?: string;
   maxLength?: number;
   minLength?: number;
+
+  softRequired?: boolean;
+  toolTip?: { icon: string; msg: string };
+  focused?: boolean;
 
   value?: string;
   disabled?: boolean;
@@ -68,15 +70,17 @@ type Props = {
 import { ToolTip } from '../ToolTip';
 
 export default function TextInput(props: Props): JSX.Element {
-  const { toolTip } = props;
+  const { toolTip, focused } = props;
 
   const id = props.id || `input-${hash(props.label)}`;
 
   const classNames = {
     label: `txt-l ${props.small ? 'txt-l--sm' : ''}`,
-    input: `txt-f ${props.small ? 'txt-f--sm' : ''} ${
+    input: `txt-f ${props.small ? ' txt-f--sm' : ''} ${
       props.error ? 'txt-f--err' : ''
-    }${props.softRequired ? ' txt-f--sr' : ''}`,
+    } ${focused ? ' txt-f--focused' : ''}${
+      props.softRequired ? ' txt-f--sr' : ''
+    }`,
   };
 
   const labelText = (label): React.ReactChild => {

--- a/modules-js/react-fleet/src/form-elements/inputs/TextInput.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/TextInput.tsx
@@ -79,7 +79,12 @@ export default function TextInput(props: Props): JSX.Element {
     input: `txt-f ${props.small ? ' txt-f--sm' : ''} ${
       props.error ? 'txt-f--err' : ''
     } ${focused ? ' txt-f--focused' : ''}${
-      props.softRequired ? ' txt-f--sr' : ''
+      props.softRequired &&
+      props.error &&
+      typeof props.error === 'string' &&
+      props.error.length > 0
+        ? ' txt-f--sr'
+        : ''
     }`,
   };
 

--- a/modules-js/react-fleet/src/form-elements/inputs/TextInput.tsx
+++ b/modules-js/react-fleet/src/form-elements/inputs/TextInput.tsx
@@ -76,7 +76,7 @@ export default function TextInput(props: Props): JSX.Element {
     label: `txt-l ${props.small ? 'txt-l--sm' : ''}`,
     input: `txt-f ${props.small ? 'txt-f--sm' : ''} ${
       props.error ? 'txt-f--err' : ''
-    }`,
+    }${props.softRequired ? ' txt-f--sr' : ''}`,
   };
 
   const labelText = (label): React.ReactChild => {

--- a/modules-js/react-fleet/src/utilities/constants.ts
+++ b/modules-js/react-fleet/src/utilities/constants.ts
@@ -1,4 +1,5 @@
 export const PUBLIC_CSS_URL = 'https://patterns.boston.gov/css/public.css';
+// export const PUBLIC_CSS_URL = 'http://localhost:3030/css/public.css';
 export const WHITE = '#fff';
 export const BLACK = '#000';
 export const YELLOW = '#fcb61a';

--- a/modules-js/react-fleet/src/utilities/constants.ts
+++ b/modules-js/react-fleet/src/utilities/constants.ts
@@ -1,5 +1,6 @@
-export const PUBLIC_CSS_URL = 'https://patterns.boston.gov/css/public.css';
+// export const PUBLIC_CSS_URL = 'https://patterns.boston.gov/css/public.css';
 // export const PUBLIC_CSS_URL = 'http://localhost:3030/css/public.css';
+export const PUBLIC_CSS_URL = 'https://patterns-stg.boston.gov/css/public.css';
 export const WHITE = '#fff';
 export const BLACK = '#000';
 export const YELLOW = '#fcb61a';

--- a/modules-js/react-fleet/templates/stylesheets.json
+++ b/modules-js/react-fleet/templates/stylesheets.json
@@ -1,3 +1,3 @@
 [
-  "https://patterns.boston.gov/css/public.css"
+  "https://patterns-stg.boston.gov/css/public.css"
 ]

--- a/modules-js/storybook-common/.storybook/preview-head.html
+++ b/modules-js/storybook-common/.storybook/preview-head.html
@@ -1,10 +1,10 @@
 <!--[if !IE]><!-->
-  <link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" />
+  <!-- <link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" /> -->
 <!-- <link rel="stylesheet" type="text/css" href="https://cob-patterns-staging.herokuapp.com/css/public.css" /> -->
+<link type="text/css" rel="stylesheet" href="https://patterns-stg.boston.gov/css/public.css" />
 <!-- <link rel="stylesheet" type="text/css" href="http://localhost:3030/css/public.css" /> -->
 <!-- <link rel="stylesheet" type="text/css" href="http://10.0.0.172:8080/css/public.css" /> -->
 <!--<![endif]-->
 <!--[if lt IE 10]>
   <link media="all" rel="stylesheet" href="https://patterns.boston.gov/css/ie.css">
 <![endif]-->
-  

--- a/modules-js/storybook-common/.storybook/preview-head.html
+++ b/modules-js/storybook-common/.storybook/preview-head.html
@@ -1,6 +1,7 @@
 <!--[if !IE]><!-->
+  <link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" />
 <!-- <link rel="stylesheet" type="text/css" href="https://cob-patterns-staging.herokuapp.com/css/public.css" /> -->
-<link rel="stylesheet" type="text/css" href="https://patterns.boston.gov/css/public.css" />
+<!-- <link rel="stylesheet" type="text/css" href="http://localhost:3030/css/public.css" /> -->
 <!-- <link rel="stylesheet" type="text/css" href="http://10.0.0.172:8080/css/public.css" /> -->
 <!--<![endif]-->
 <!--[if lt IE 10]>

--- a/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/commissions-app/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -82,7 +82,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-firstName"
               maxLength={25}
               name="firstName"
@@ -123,7 +123,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-middleName"
               maxLength={50}
               name="middleName"
@@ -175,7 +175,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-lastName"
             maxLength={50}
             name="lastName"
@@ -232,7 +232,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-streetAddress"
             maxLength={50}
             name="streetAddress"
@@ -273,7 +273,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-unit"
             maxLength={50}
             name="unit"
@@ -329,7 +329,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-city"
             maxLength={50}
             name="city"
@@ -385,7 +385,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-state"
               maxLength={50}
               name="state"
@@ -438,7 +438,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-zip"
               maxLength={5}
               name="zip"
@@ -481,7 +481,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-phone"
           maxLength={50}
           name="phone"
@@ -533,7 +533,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-email"
           maxLength={50}
           name="email"
@@ -586,7 +586,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-confirmEmail"
           maxLength={50}
           name="confirmEmail"
@@ -645,7 +645,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-degreeAttained"
           maxLength={100}
           name="degreeAttained"
@@ -685,7 +685,7 @@ exports[`Storyshots ApplicationForm blank 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-educationalInstitution"
           maxLength={100}
           name="educationalInstitution"
@@ -1148,7 +1148,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm txt-f--err"
+              className="txt-f  txt-f--sm txt-f--err "
               id="ApplicationForm-firstName"
               maxLength={25}
               name="firstName"
@@ -1189,7 +1189,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-middleName"
               maxLength={50}
               name="middleName"
@@ -1241,7 +1241,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm txt-f--err"
+            className="txt-f  txt-f--sm txt-f--err "
             id="ApplicationForm-lastName"
             maxLength={50}
             name="lastName"
@@ -1298,7 +1298,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-streetAddress"
             maxLength={50}
             name="streetAddress"
@@ -1339,7 +1339,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-unit"
             maxLength={50}
             name="unit"
@@ -1395,7 +1395,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-city"
             maxLength={50}
             name="city"
@@ -1451,7 +1451,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-state"
               maxLength={50}
               name="state"
@@ -1504,7 +1504,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-zip"
               maxLength={5}
               name="zip"
@@ -1547,7 +1547,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-phone"
           maxLength={50}
           name="phone"
@@ -1599,7 +1599,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-email"
           maxLength={50}
           name="email"
@@ -1652,7 +1652,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-confirmEmail"
           maxLength={50}
           name="confirmEmail"
@@ -1711,7 +1711,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-degreeAttained"
           maxLength={100}
           name="degreeAttained"
@@ -1751,7 +1751,7 @@ exports[`Storyshots ApplicationForm errors 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-educationalInstitution"
           maxLength={100}
           name="educationalInstitution"
@@ -2214,7 +2214,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-firstName"
               maxLength={25}
               name="firstName"
@@ -2255,7 +2255,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-middleName"
               maxLength={50}
               name="middleName"
@@ -2307,7 +2307,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-lastName"
             maxLength={50}
             name="lastName"
@@ -2364,7 +2364,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-streetAddress"
             maxLength={50}
             name="streetAddress"
@@ -2405,7 +2405,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-unit"
             maxLength={50}
             name="unit"
@@ -2461,7 +2461,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-city"
             maxLength={50}
             name="city"
@@ -2517,7 +2517,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-state"
               maxLength={50}
               name="state"
@@ -2570,7 +2570,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-zip"
               maxLength={5}
               name="zip"
@@ -2613,7 +2613,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-phone"
           maxLength={50}
           name="phone"
@@ -2665,7 +2665,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-email"
           maxLength={50}
           name="email"
@@ -2718,7 +2718,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-confirmEmail"
           maxLength={50}
           name="confirmEmail"
@@ -2777,7 +2777,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-degreeAttained"
           maxLength={100}
           name="degreeAttained"
@@ -2817,7 +2817,7 @@ exports[`Storyshots ApplicationForm filled in 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-educationalInstitution"
           maxLength={100}
           name="educationalInstitution"
@@ -3315,7 +3315,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-firstName"
               maxLength={25}
               name="firstName"
@@ -3356,7 +3356,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-middleName"
               maxLength={50}
               name="middleName"
@@ -3408,7 +3408,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-lastName"
             maxLength={50}
             name="lastName"
@@ -3465,7 +3465,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-streetAddress"
             maxLength={50}
             name="streetAddress"
@@ -3506,7 +3506,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-unit"
             maxLength={50}
             name="unit"
@@ -3562,7 +3562,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-city"
             maxLength={50}
             name="city"
@@ -3618,7 +3618,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-state"
               maxLength={50}
               name="state"
@@ -3671,7 +3671,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-zip"
               maxLength={5}
               name="zip"
@@ -3714,7 +3714,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-phone"
           maxLength={50}
           name="phone"
@@ -3766,7 +3766,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-email"
           maxLength={50}
           name="email"
@@ -3819,7 +3819,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-confirmEmail"
           maxLength={50}
           name="confirmEmail"
@@ -3878,7 +3878,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-degreeAttained"
           maxLength={100}
           name="degreeAttained"
@@ -3918,7 +3918,7 @@ exports[`Storyshots ApplicationForm submission error 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-educationalInstitution"
           maxLength={100}
           name="educationalInstitution"
@@ -4422,7 +4422,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-firstName"
               maxLength={25}
               name="firstName"
@@ -4463,7 +4463,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-middleName"
               maxLength={50}
               name="middleName"
@@ -4515,7 +4515,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-lastName"
             maxLength={50}
             name="lastName"
@@ -4572,7 +4572,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-streetAddress"
             maxLength={50}
             name="streetAddress"
@@ -4613,7 +4613,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-unit"
             maxLength={50}
             name="unit"
@@ -4669,7 +4669,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
           </label>
           <input
             aria-label=""
-            className="txt-f txt-f--sm "
+            className="txt-f  txt-f--sm  "
             id="ApplicationForm-city"
             maxLength={50}
             name="city"
@@ -4725,7 +4725,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-state"
               maxLength={50}
               name="state"
@@ -4778,7 +4778,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
             </label>
             <input
               aria-label=""
-              className="txt-f txt-f--sm "
+              className="txt-f  txt-f--sm  "
               id="ApplicationForm-zip"
               maxLength={5}
               name="zip"
@@ -4821,7 +4821,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-phone"
           maxLength={50}
           name="phone"
@@ -4873,7 +4873,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-email"
           maxLength={50}
           name="email"
@@ -4926,7 +4926,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-confirmEmail"
           maxLength={50}
           name="confirmEmail"
@@ -4985,7 +4985,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-degreeAttained"
           maxLength={100}
           name="degreeAttained"
@@ -5025,7 +5025,7 @@ exports[`Storyshots ApplicationForm submitting 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f txt-f--sm "
+          className="txt-f  txt-f--sm  "
           id="ApplicationForm-educationalInstitution"
           maxLength={100}
           name="educationalInstitution"
@@ -5665,7 +5665,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f txt-f--sm "
+                        className="txt-f  txt-f--sm  "
                         id="ApplicationForm-firstName"
                         maxLength={25}
                         name="firstName"
@@ -5706,7 +5706,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f txt-f--sm "
+                        className="txt-f  txt-f--sm  "
                         id="ApplicationForm-middleName"
                         maxLength={50}
                         name="middleName"
@@ -5758,7 +5758,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f txt-f--sm "
+                      className="txt-f  txt-f--sm  "
                       id="ApplicationForm-lastName"
                       maxLength={50}
                       name="lastName"
@@ -5815,7 +5815,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f txt-f--sm "
+                      className="txt-f  txt-f--sm  "
                       id="ApplicationForm-streetAddress"
                       maxLength={50}
                       name="streetAddress"
@@ -5856,7 +5856,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f txt-f--sm "
+                      className="txt-f  txt-f--sm  "
                       id="ApplicationForm-unit"
                       maxLength={50}
                       name="unit"
@@ -5912,7 +5912,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f txt-f--sm "
+                      className="txt-f  txt-f--sm  "
                       id="ApplicationForm-city"
                       maxLength={50}
                       name="city"
@@ -5968,7 +5968,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f txt-f--sm "
+                        className="txt-f  txt-f--sm  "
                         id="ApplicationForm-state"
                         maxLength={50}
                         name="state"
@@ -6021,7 +6021,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f txt-f--sm "
+                        className="txt-f  txt-f--sm  "
                         id="ApplicationForm-zip"
                         maxLength={5}
                         name="zip"
@@ -6064,7 +6064,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f txt-f--sm "
+                    className="txt-f  txt-f--sm  "
                     id="ApplicationForm-phone"
                     maxLength={50}
                     name="phone"
@@ -6116,7 +6116,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f txt-f--sm "
+                    className="txt-f  txt-f--sm  "
                     id="ApplicationForm-email"
                     maxLength={50}
                     name="email"
@@ -6169,7 +6169,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f txt-f--sm "
+                    className="txt-f  txt-f--sm  "
                     id="ApplicationForm-confirmEmail"
                     maxLength={50}
                     name="confirmEmail"
@@ -6228,7 +6228,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f txt-f--sm "
+                    className="txt-f  txt-f--sm  "
                     id="ApplicationForm-degreeAttained"
                     maxLength={100}
                     name="degreeAttained"
@@ -6268,7 +6268,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f txt-f--sm "
+                    className="txt-f  txt-f--sm  "
                     id="ApplicationForm-educationalInstitution"
                     maxLength={100}
                     name="educationalInstitution"

--- a/services-js/registry-certs/.storybook/preview-head.html
+++ b/services-js/registry-certs/.storybook/preview-head.html
@@ -4,5 +4,6 @@
   prod, where this tag is written by _document.tsx.
 -->
 <link href="https://patterns.boston.gov/css/public.css" type="text/css" rel="stylesheet" />
+<!-- <link href="http://localhost:3030/css/public.css" type="text/css" rel="stylesheet" /> -->
 
 <script src="https://js.stripe.com/v3/"></script>

--- a/services-js/registry-certs/.storybook/preview-head.html
+++ b/services-js/registry-certs/.storybook/preview-head.html
@@ -3,7 +3,8 @@
   That way Emotion can override the default styles. This matches the behavior in
   prod, where this tag is written by _document.tsx.
 -->
-<link href="https://patterns.boston.gov/css/public.css" type="text/css" rel="stylesheet" />
+<!-- <link href="https://patterns.boston.gov/css/public.css" type="text/css" rel="stylesheet" /> -->
+<link type="text/css" rel="stylesheet" href="https://patterns-stg.boston.gov/css/public.css" />
 <!-- <link href="http://localhost:3030/css/public.css" type="text/css" rel="stylesheet" /> -->
 
 <script src="https://js.stripe.com/v3/"></script>

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -70692,7 +70692,6 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       maxLength={100}
       name="partner1_firstName"
       onChange={[Function]}
-      required={true}
       type="text"
       value="Peter"
     />
@@ -70784,7 +70783,6 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       maxLength={100}
       name="partner1_lastName"
       onChange={[Function]}
-      required={true}
       type="text"
       value="Pan"
     />
@@ -71424,7 +71422,6 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       maxLength={100}
       name="partner1_firstName"
       onChange={[Function]}
-      required={true}
       type="text"
       value="Peter"
     />
@@ -71516,7 +71513,6 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       maxLength={100}
       name="partner1_lastName"
       onChange={[Function]}
-      required={true}
       type="text"
       value="Pan"
     />
@@ -75260,7 +75256,6 @@ Array [
                         maxLength={100}
                         name="partnerA_firstName"
                         onChange={[Function]}
-                        required={true}
                         type="text"
                         value=""
                       />
@@ -75352,7 +75347,6 @@ Array [
                         maxLength={100}
                         name="partnerA_lastName"
                         onChange={[Function]}
-                        required={true}
                         type="text"
                         value=""
                       />
@@ -80315,7 +80309,6 @@ Array [
                         maxLength={100}
                         name="partnerB_firstName"
                         onChange={[Function]}
-                        required={true}
                         type="text"
                         value=""
                       />
@@ -80407,7 +80400,6 @@ Array [
                         maxLength={100}
                         name="partnerB_lastName"
                         onChange={[Function]}
-                        required={true}
                         type="text"
                         value=""
                       />

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -7955,7 +7955,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation default 1`] = 
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-2048906072"
               name="parent1FirstName"
               onChange={[Function]}
@@ -8001,7 +8001,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation default 1`] = 
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-5381"
               name="parent1LastName"
               onChange={[Function]}
@@ -8053,7 +8053,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation default 1`] = 
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-2048906072"
               name="parent2FirstName"
               onChange={[Function]}
@@ -8099,7 +8099,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation default 1`] = 
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-5381"
               name="parent2LastName"
               onChange={[Function]}
@@ -8680,7 +8680,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-2048906072"
               name="parent1FirstName"
               onChange={[Function]}
@@ -8726,7 +8726,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-5381"
               name="parent1LastName"
               onChange={[Function]}
@@ -8778,7 +8778,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-2048906072"
               name="parent2FirstName"
               onChange={[Function]}
@@ -8824,7 +8824,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-5381"
               name="parent2LastName"
               onChange={[Function]}
@@ -9433,7 +9433,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-2048906072"
               name="parent1FirstName"
               onChange={[Function]}
@@ -9479,7 +9479,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-5381"
               name="parent1LastName"
               onChange={[Function]}
@@ -9531,7 +9531,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-2048906072"
               name="parent2FirstName"
               onChange={[Function]}
@@ -9577,7 +9577,7 @@ exports[`Storyshots Birth/Question Components/ParentalInformation may be restric
             </label>
             <input
               aria-label=""
-              className="txt-f  "
+              className="txt-f   "
               id="input-5381"
               name="parent2LastName"
               onChange={[Function]}
@@ -10054,7 +10054,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation birth too rece
           </label>
           <input
             aria-label=""
-            className="txt-f  "
+            className="txt-f   "
             id="input-2048906072"
             name="firstName"
             onChange={[Function]}
@@ -10091,7 +10091,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation birth too rece
           </label>
           <input
             aria-label=""
-            className="txt-f  "
+            className="txt-f   "
             id="input-1103291528"
             name="lastName"
             onChange={[Function]}
@@ -10132,7 +10132,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation birth too rece
           </label>
           <input
             aria-label=""
-            className="txt-f  "
+            className="txt-f   "
             id="input-2099238988"
             name="altSpelling"
             onChange={[Function]}
@@ -10611,7 +10611,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation default 1`] = 
           </label>
           <input
             aria-label=""
-            className="txt-f  "
+            className="txt-f   "
             id="input-2048906072"
             name="firstName"
             onChange={[Function]}
@@ -10648,7 +10648,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation default 1`] = 
           </label>
           <input
             aria-label=""
-            className="txt-f  "
+            className="txt-f   "
             id="input-1103291528"
             name="lastName"
             onChange={[Function]}
@@ -10689,7 +10689,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation default 1`] = 
           </label>
           <input
             aria-label=""
-            className="txt-f  "
+            className="txt-f   "
             id="input-2099238988"
             name="altSpelling"
             onChange={[Function]}
@@ -14219,7 +14219,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f  "
+                      className="txt-f   "
                       id="input-2048906072"
                       name="firstName"
                       onChange={[Function]}
@@ -14256,7 +14256,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f  "
+                      className="txt-f   "
                       id="input-1103291528"
                       name="lastName"
                       onChange={[Function]}
@@ -14297,7 +14297,7 @@ Array [
                     </label>
                     <input
                       aria-label=""
-                      className="txt-f  "
+                      className="txt-f   "
                       id="input-2099238988"
                       name="altSpelling"
                       onChange={[Function]}
@@ -15258,7 +15258,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   "
                         id="input-2048906072"
                         name="parent1FirstName"
                         onChange={[Function]}
@@ -15304,7 +15304,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   "
                         id="input-5381"
                         name="parent1LastName"
                         onChange={[Function]}
@@ -15356,7 +15356,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   "
                         id="input-2048906072"
                         name="parent2FirstName"
                         onChange={[Function]}
@@ -15402,7 +15402,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   "
                         id="input-5381"
                         name="parent2LastName"
                         onChange={[Function]}
@@ -65831,7 +65831,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Birth Date 
       </label>
       <input
         aria-label=""
-        className="txt-f   txt-f--sr"
+        className="txt-f   "
         id="input-1547104625"
         maxLength={100}
         name="partnerA_birthCity"
@@ -67871,7 +67871,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Birth Date 
       </label>
       <input
         aria-label=""
-        className="txt-f   txt-f--sr"
+        className="txt-f   "
         id="input-1547104625"
         maxLength={100}
         name="partnerA_birthCity"
@@ -70331,10 +70331,22 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Marriage, D
           >
             Partnership State/Country
           </span>
+          <span
+            aria-hidden="true"
+            className="t--req"
+            style={
+              Object {
+                "display": "flex",
+                "flexGrow": 1,
+              }
+            }
+          >
+            Required
+          </span>
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-234553913"
           maxLength={100}
           name="partnerA_partnershipState"
@@ -70687,7 +70699,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f   "
       id="input-2048906072"
       maxLength={100}
       name="partner1_firstName"
@@ -70729,7 +70741,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       id="input-2852212527"
       maxLength={50}
       name="partner1_middleName"
@@ -70778,7 +70790,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f   "
       id="input-1103291528"
       maxLength={100}
       name="partner1_lastName"
@@ -71017,7 +71029,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f   "
       id="input-2786084594"
       maxLength={100}
       name="partner1_occupation"
@@ -71417,7 +71429,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f   "
       id="input-2048906072"
       maxLength={100}
       name="partner1_firstName"
@@ -71459,7 +71471,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   "
       id="input-2852212527"
       maxLength={50}
       name="partner1_middleName"
@@ -71508,7 +71520,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f   "
       id="input-1103291528"
       maxLength={100}
       name="partner1_lastName"
@@ -71659,7 +71671,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       </label>
       <input
         aria-label=""
-        className="txt-f   txt-f--sr"
+        className="txt-f   "
         id="input-546901997"
         maxLength={50}
         name="partner1_surName"
@@ -71818,7 +71830,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f   txt-f--sr"
+      className="txt-f   "
       id="input-2786084594"
       maxLength={100}
       name="partner1_occupation"
@@ -73401,315 +73413,313 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </div>
       </div>
     </div>
-    <div>
-      <div
-        className="emotion-3"
-      >
-        <div>
-          <label
-            className="txt-l "
-            htmlFor="select-496160159"
+    <div
+      className="emotion-3"
+    >
+      <div>
+        <label
+          className="txt-l "
+          htmlFor="select-496160159"
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <span
+            style={
+              Object {
+                "display": "flex",
+                "marginRight": "0.5em",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            State of Residence
+          </span>
+          <span
+            className="t--req"
             style={
               Object {
                 "display": "flex",
               }
             }
           >
-            <span
-              style={
-                Object {
-                  "display": "flex",
-                  "marginRight": "0.5em",
-                  "whiteSpace": "nowrap",
-                }
-              }
-            >
-              State of Residence
-            </span>
-            <span
-              className="t--req"
-              style={
-                Object {
-                  "display": "flex",
-                }
-              }
-            >
-              Required
-            </span>
-          </label>
-          <div
-            className="sel-c  "
+            Required
+          </span>
+        </label>
+        <div
+          className="sel-c  "
+        >
+          <select
+            aria-label=""
+            className="sel-f  "
+            id="select-496160159"
+            name="partnerA_residenceState"
+            onChange={[Function]}
+            value="MA"
           >
-            <select
-              aria-label=""
-              className="sel-f  "
-              id="select-496160159"
-              name="partnerA_residenceState"
-              onChange={[Function]}
+            <option
+              value=""
+            >
+              --
+            </option>
+            <option
+              value="AL"
+            >
+              AL
+            </option>
+            <option
+              value="AK"
+            >
+              AK
+            </option>
+            <option
+              value="AZ"
+            >
+              AZ
+            </option>
+            <option
+              value="AR"
+            >
+              AR
+            </option>
+            <option
+              value="CA"
+            >
+              CA
+            </option>
+            <option
+              value="CO"
+            >
+              CO
+            </option>
+            <option
+              value="CT"
+            >
+              CT
+            </option>
+            <option
+              value="DE"
+            >
+              DE
+            </option>
+            <option
+              value="DC"
+            >
+              DC
+            </option>
+            <option
+              value="FL"
+            >
+              FL
+            </option>
+            <option
+              value="GA"
+            >
+              GA
+            </option>
+            <option
+              value="HI"
+            >
+              HI
+            </option>
+            <option
+              value="ID"
+            >
+              ID
+            </option>
+            <option
+              value="IL"
+            >
+              IL
+            </option>
+            <option
+              value="IN"
+            >
+              IN
+            </option>
+            <option
+              value="IA"
+            >
+              IA
+            </option>
+            <option
+              value="KS"
+            >
+              KS
+            </option>
+            <option
+              value="KY"
+            >
+              KY
+            </option>
+            <option
+              value="LA"
+            >
+              LA
+            </option>
+            <option
+              value="ME"
+            >
+              ME
+            </option>
+            <option
+              value="MD"
+            >
+              MD
+            </option>
+            <option
               value="MA"
             >
-              <option
-                value=""
-              >
-                --
-              </option>
-              <option
-                value="AL"
-              >
-                AL
-              </option>
-              <option
-                value="AK"
-              >
-                AK
-              </option>
-              <option
-                value="AZ"
-              >
-                AZ
-              </option>
-              <option
-                value="AR"
-              >
-                AR
-              </option>
-              <option
-                value="CA"
-              >
-                CA
-              </option>
-              <option
-                value="CO"
-              >
-                CO
-              </option>
-              <option
-                value="CT"
-              >
-                CT
-              </option>
-              <option
-                value="DE"
-              >
-                DE
-              </option>
-              <option
-                value="DC"
-              >
-                DC
-              </option>
-              <option
-                value="FL"
-              >
-                FL
-              </option>
-              <option
-                value="GA"
-              >
-                GA
-              </option>
-              <option
-                value="HI"
-              >
-                HI
-              </option>
-              <option
-                value="ID"
-              >
-                ID
-              </option>
-              <option
-                value="IL"
-              >
-                IL
-              </option>
-              <option
-                value="IN"
-              >
-                IN
-              </option>
-              <option
-                value="IA"
-              >
-                IA
-              </option>
-              <option
-                value="KS"
-              >
-                KS
-              </option>
-              <option
-                value="KY"
-              >
-                KY
-              </option>
-              <option
-                value="LA"
-              >
-                LA
-              </option>
-              <option
-                value="ME"
-              >
-                ME
-              </option>
-              <option
-                value="MD"
-              >
-                MD
-              </option>
-              <option
-                value="MA"
-              >
-                MA
-              </option>
-              <option
-                value="MI"
-              >
-                MI
-              </option>
-              <option
-                value="MN"
-              >
-                MN
-              </option>
-              <option
-                value="MS"
-              >
-                MS
-              </option>
-              <option
-                value="MO"
-              >
-                MO
-              </option>
-              <option
-                value="MT"
-              >
-                MT
-              </option>
-              <option
-                value="NE"
-              >
-                NE
-              </option>
-              <option
-                value="NV"
-              >
-                NV
-              </option>
-              <option
-                value="NH"
-              >
-                NH
-              </option>
-              <option
-                value="NJ"
-              >
-                NJ
-              </option>
-              <option
-                value="NM"
-              >
-                NM
-              </option>
-              <option
-                value="NY"
-              >
-                NY
-              </option>
-              <option
-                value="NC"
-              >
-                NC
-              </option>
-              <option
-                value="ND"
-              >
-                ND
-              </option>
-              <option
-                value="OH"
-              >
-                OH
-              </option>
-              <option
-                value="OK"
-              >
-                OK
-              </option>
-              <option
-                value="OR"
-              >
-                OR
-              </option>
-              <option
-                value="PA"
-              >
-                PA
-              </option>
-              <option
-                value="RI"
-              >
-                RI
-              </option>
-              <option
-                value="SC"
-              >
-                SC
-              </option>
-              <option
-                value="SD"
-              >
-                SD
-              </option>
-              <option
-                value="TN"
-              >
-                TN
-              </option>
-              <option
-                value="TX"
-              >
-                TX
-              </option>
-              <option
-                value="UT"
-              >
-                UT
-              </option>
-              <option
-                value="VT"
-              >
-                VT
-              </option>
-              <option
-                value="VA"
-              >
-                VA
-              </option>
-              <option
-                value="WA"
-              >
-                WA
-              </option>
-              <option
-                value="WV"
-              >
-                WV
-              </option>
-              <option
-                value="WI"
-              >
-                WI
-              </option>
-              <option
-                value="WY"
-              >
-                WY
-              </option>
-            </select>
-          </div>
+              MA
+            </option>
+            <option
+              value="MI"
+            >
+              MI
+            </option>
+            <option
+              value="MN"
+            >
+              MN
+            </option>
+            <option
+              value="MS"
+            >
+              MS
+            </option>
+            <option
+              value="MO"
+            >
+              MO
+            </option>
+            <option
+              value="MT"
+            >
+              MT
+            </option>
+            <option
+              value="NE"
+            >
+              NE
+            </option>
+            <option
+              value="NV"
+            >
+              NV
+            </option>
+            <option
+              value="NH"
+            >
+              NH
+            </option>
+            <option
+              value="NJ"
+            >
+              NJ
+            </option>
+            <option
+              value="NM"
+            >
+              NM
+            </option>
+            <option
+              value="NY"
+            >
+              NY
+            </option>
+            <option
+              value="NC"
+            >
+              NC
+            </option>
+            <option
+              value="ND"
+            >
+              ND
+            </option>
+            <option
+              value="OH"
+            >
+              OH
+            </option>
+            <option
+              value="OK"
+            >
+              OK
+            </option>
+            <option
+              value="OR"
+            >
+              OR
+            </option>
+            <option
+              value="PA"
+            >
+              PA
+            </option>
+            <option
+              value="RI"
+            >
+              RI
+            </option>
+            <option
+              value="SC"
+            >
+              SC
+            </option>
+            <option
+              value="SD"
+            >
+              SD
+            </option>
+            <option
+              value="TN"
+            >
+              TN
+            </option>
+            <option
+              value="TX"
+            >
+              TX
+            </option>
+            <option
+              value="UT"
+            >
+              UT
+            </option>
+            <option
+              value="VT"
+            >
+              VT
+            </option>
+            <option
+              value="VA"
+            >
+              VA
+            </option>
+            <option
+              value="WA"
+            >
+              WA
+            </option>
+            <option
+              value="WV"
+            >
+              WV
+            </option>
+            <option
+              value="WI"
+            >
+              WI
+            </option>
+            <option
+              value="WY"
+            >
+              WY
+            </option>
+          </select>
         </div>
       </div>
     </div>
@@ -73754,7 +73764,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </label>
         <input
           aria-label=""
-          className="txt-f   txt-f--sr"
+          className="txt-f   "
           id="input-2580217931"
           maxLength={100}
           name="partnerA_residenceCity"
@@ -73809,7 +73819,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </label>
         <input
           aria-label=""
-          className="txt-f   txt-f--sr"
+          className="txt-f   "
           id="input-770365431"
           maxLength={100}
           name="partnerA_residenceAddress"
@@ -73860,7 +73870,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </label>
         <input
           aria-label=""
-          className="txt-f   txt-f--sr"
+          className="txt-f   "
           id="input-2413436367"
           maxLength={10}
           minLength={5}
@@ -75251,7 +75261,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f   txt-f--sr"
+                        className="txt-f   "
                         id="input-2048906072"
                         maxLength={100}
                         name="partnerA_firstName"
@@ -75293,7 +75303,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   "
                         id="input-2852212527"
                         maxLength={50}
                         name="partnerA_middleName"
@@ -75342,7 +75352,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f   txt-f--sr"
+                        className="txt-f   "
                         id="input-1103291528"
                         maxLength={100}
                         name="partnerA_lastName"
@@ -75579,7 +75589,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f   txt-f--sr"
+                        className="txt-f   "
                         id="input-2786084594"
                         maxLength={100}
                         name="partnerA_occupation"
@@ -78583,7 +78593,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f   txt-f--sr"
+                          className="txt-f   "
                           id="input-507056287"
                           maxLength={38}
                           name="partnerA_parentA_Name"
@@ -78637,7 +78647,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f   txt-f--sr"
+                          className="txt-f   "
                           id="input-4196106810"
                           maxLength={38}
                           name="partnerA_parentA_Surname"
@@ -80304,7 +80314,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f   txt-f--sr"
+                        className="txt-f   "
                         id="input-2048906072"
                         maxLength={100}
                         name="partnerB_firstName"
@@ -80346,7 +80356,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   "
                         id="input-2852212527"
                         maxLength={50}
                         name="partnerB_middleName"
@@ -80395,7 +80405,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f   txt-f--sr"
+                        className="txt-f   "
                         id="input-1103291528"
                         maxLength={100}
                         name="partnerB_lastName"
@@ -80632,7 +80642,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f   txt-f--sr"
+                        className="txt-f   "
                         id="input-2786084594"
                         maxLength={100}
                         name="partnerB_occupation"
@@ -83636,7 +83646,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f   txt-f--sr"
+                          className="txt-f   "
                           id="input-507056287"
                           maxLength={38}
                           name="partnerB_parentA_Name"
@@ -83690,7 +83700,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f   txt-f--sr"
+                          className="txt-f   "
                           id="input-4196106810"
                           maxLength={38}
                           name="partnerB_parentA_Surname"
@@ -84900,7 +84910,7 @@ Array [
                           </label>
                           <input
                             aria-label=""
-                            className="txt-f  "
+                            className="txt-f   "
                             id="input-2778663327"
                             name="email"
                             onChange={[Function]}
@@ -84952,7 +84962,7 @@ Array [
                           </label>
                           <input
                             aria-label=""
-                            className="txt-f  "
+                            className="txt-f   "
                             id="input-1813726221"
                             name="emailConfirm"
                             onChange={[Function]}
@@ -85009,7 +85019,7 @@ Array [
                           </label>
                           <input
                             aria-label=""
-                            className="txt-f  "
+                            className="txt-f   "
                             id="input-1267882554"
                             maxLength={14}
                             minLength={10}
@@ -99179,7 +99189,7 @@ exports[`Storyshots Marriage/Question Components/PersonOnRecord person 1 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-1103008209"
           name="fullName1"
           onChange={[Function]}
@@ -99217,7 +99227,7 @@ exports[`Storyshots Marriage/Question Components/PersonOnRecord person 1 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-5381"
           name="maidenName1"
           onChange={[Function]}
@@ -99857,7 +99867,7 @@ exports[`Storyshots Marriage/Question Components/PersonOnRecord person 2 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-1103008209"
           name="fullName2"
           onChange={[Function]}
@@ -99895,7 +99905,7 @@ exports[`Storyshots Marriage/Question Components/PersonOnRecord person 2 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-5381"
           name="maidenName2"
           onChange={[Function]}
@@ -100535,7 +100545,7 @@ exports[`Storyshots Marriage/Question Components/PersonOnRecord self 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-1103008209"
           name="fullName1"
           onChange={[Function]}
@@ -100573,7 +100583,7 @@ exports[`Storyshots Marriage/Question Components/PersonOnRecord self 1`] = `
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   "
           id="input-5381"
           name="maidenName1"
           onChange={[Function]}
@@ -105105,7 +105115,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f  "
+                    className="txt-f   "
                     id="input-1103008209"
                     name="fullName1"
                     onChange={[Function]}
@@ -105143,7 +105153,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f  "
+                    className="txt-f   "
                     id="input-5381"
                     name="maidenName1"
                     onChange={[Function]}
@@ -106164,7 +106174,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f  "
+                    className="txt-f   "
                     id="input-1103008209"
                     name="fullName2"
                     onChange={[Function]}
@@ -106202,7 +106212,7 @@ Array [
                   </label>
                   <input
                     aria-label=""
-                    className="txt-f  "
+                    className="txt-f   "
                     id="input-5381"
                     name="maidenName2"
                     onChange={[Function]}

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -65831,7 +65831,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Birth Date 
       </label>
       <input
         aria-label=""
-        className="txt-f  "
+        className="txt-f   txt-f--sr"
         id="input-1547104625"
         maxLength={100}
         name="partnerA_birthCity"
@@ -67871,7 +67871,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Birth Date 
       </label>
       <input
         aria-label=""
-        className="txt-f  "
+        className="txt-f   txt-f--sr"
         id="input-1547104625"
         maxLength={100}
         name="partnerA_birthCity"
@@ -70687,11 +70687,12 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       id="input-2048906072"
       maxLength={100}
       name="partner1_firstName"
       onChange={[Function]}
+      required={true}
       type="text"
       value="Peter"
     />
@@ -70763,14 +70764,27 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       >
         Last Name
       </span>
+      <span
+        aria-hidden="true"
+        className="t--req"
+        style={
+          Object {
+            "display": "flex",
+            "flexGrow": 1,
+          }
+        }
+      >
+        Required
+      </span>
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       id="input-1103291528"
       maxLength={100}
       name="partner1_lastName"
       onChange={[Function]}
+      required={true}
       type="text"
       value="Pan"
     />
@@ -71005,7 +71019,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       id="input-2786084594"
       maxLength={100}
       name="partner1_occupation"
@@ -71405,11 +71419,12 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       id="input-2048906072"
       maxLength={100}
       name="partner1_firstName"
       onChange={[Function]}
+      required={true}
       type="text"
       value="Peter"
     />
@@ -71481,14 +71496,27 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       >
         Last Name
       </span>
+      <span
+        aria-hidden="true"
+        className="t--req"
+        style={
+          Object {
+            "display": "flex",
+            "flexGrow": 1,
+          }
+        }
+      >
+        Required
+      </span>
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       id="input-1103291528"
       maxLength={100}
       name="partner1_lastName"
       onChange={[Function]}
+      required={true}
       type="text"
       value="Pan"
     />
@@ -71635,11 +71663,12 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
       </label>
       <input
         aria-label=""
-        className="txt-f  "
+        className="txt-f   txt-f--sr"
         id="input-546901997"
         maxLength={50}
         name="partner1_surName"
         onChange={[Function]}
+        required={true}
         type="text"
         value="Neverland"
       />
@@ -71793,7 +71822,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Naming Fiel
     </label>
     <input
       aria-label=""
-      className="txt-f  "
+      className="txt-f   txt-f--sr"
       id="input-2786084594"
       maxLength={100}
       name="partner1_occupation"
@@ -73729,7 +73758,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   txt-f--sr"
           id="input-2580217931"
           maxLength={100}
           name="partnerA_residenceCity"
@@ -73784,7 +73813,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   txt-f--sr"
           id="input-770365431"
           maxLength={100}
           name="partnerA_residenceAddress"
@@ -73835,7 +73864,7 @@ exports[`Storyshots Marriage Intention/Form Pages Step 2. Person 1 - Residende, 
         </label>
         <input
           aria-label=""
-          className="txt-f  "
+          className="txt-f   txt-f--sr"
           id="input-2413436367"
           maxLength={10}
           minLength={5}
@@ -75226,11 +75255,12 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   txt-f--sr"
                         id="input-2048906072"
                         maxLength={100}
                         name="partnerA_firstName"
                         onChange={[Function]}
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -75302,14 +75332,27 @@ Array [
                         >
                           Last Name
                         </span>
+                        <span
+                          aria-hidden="true"
+                          className="t--req"
+                          style={
+                            Object {
+                              "display": "flex",
+                              "flexGrow": 1,
+                            }
+                          }
+                        >
+                          Required
+                        </span>
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   txt-f--sr"
                         id="input-1103291528"
                         maxLength={100}
                         name="partnerA_lastName"
                         onChange={[Function]}
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -75542,7 +75585,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   txt-f--sr"
                         id="input-2786084594"
                         maxLength={100}
                         name="partnerA_occupation"
@@ -78546,7 +78589,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f  "
+                          className="txt-f   txt-f--sr"
                           id="input-507056287"
                           maxLength={38}
                           name="partnerA_parentA_Name"
@@ -78600,7 +78643,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f  "
+                          className="txt-f   txt-f--sr"
                           id="input-4196106810"
                           maxLength={38}
                           name="partnerA_parentA_Surname"
@@ -80267,11 +80310,12 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   txt-f--sr"
                         id="input-2048906072"
                         maxLength={100}
                         name="partnerB_firstName"
                         onChange={[Function]}
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -80343,14 +80387,27 @@ Array [
                         >
                           Last Name
                         </span>
+                        <span
+                          aria-hidden="true"
+                          className="t--req"
+                          style={
+                            Object {
+                              "display": "flex",
+                              "flexGrow": 1,
+                            }
+                          }
+                        >
+                          Required
+                        </span>
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   txt-f--sr"
                         id="input-1103291528"
                         maxLength={100}
                         name="partnerB_lastName"
                         onChange={[Function]}
+                        required={true}
                         type="text"
                         value=""
                       />
@@ -80583,7 +80640,7 @@ Array [
                       </label>
                       <input
                         aria-label=""
-                        className="txt-f  "
+                        className="txt-f   txt-f--sr"
                         id="input-2786084594"
                         maxLength={100}
                         name="partnerB_occupation"
@@ -83587,7 +83644,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f  "
+                          className="txt-f   txt-f--sr"
                           id="input-507056287"
                           maxLength={38}
                           name="partnerB_parentA_Name"
@@ -83641,7 +83698,7 @@ Array [
                         </label>
                         <input
                           aria-label=""
-                          className="txt-f  "
+                          className="txt-f   txt-f--sr"
                           id="input-4196106810"
                           maxLength={38}
                           name="partnerB_parentA_Surname"

--- a/services-js/registry-certs/client/marriageintention/forms/eventHandlers.ts
+++ b/services-js/registry-certs/client/marriageintention/forms/eventHandlers.ts
@@ -6,18 +6,6 @@ export const handleFormPageComplete$ = (data: {
   val: string;
   certObj: MarriageIntentionCertificateRequest;
 }): void => {
-  // const currValue: boolean =
-  //   data.certObj.requestInformation[
-  //     `partner${data.partnerFlag}_formPageComplete`
-  //   ];
-
-  // console.log(`partnerFlag: ${data.partnerFlag}`, data.certObj.answerQuestion);
-  // console.log(
-  //   `handleFormPageComplete$ > partner${
-  //     data.partnerFlag
-  //   }_formPageComplete: ${currValue} > ${!currValue}`
-  // );
-
   data.certObj.answerQuestion(
     {
       [`partner${data.partnerFlag}_formPageComplete`]: data.val,
@@ -31,7 +19,7 @@ export const handleChange$ = (data: {
   certObj: MarriageIntentionCertificateRequest;
 }) => {
   const { e, certObj } = data;
-  console.log(`certObj: `, certObj);
+
   certObj.answerQuestion(
     {
       [e.target.name]: e.target.value,

--- a/services-js/registry-certs/client/marriageintention/forms/eventHandlers.ts
+++ b/services-js/registry-certs/client/marriageintention/forms/eventHandlers.ts
@@ -1,11 +1,37 @@
 import { ChangeEvent } from 'react';
 import MarriageIntentionCertificateRequest from '../../store/MarriageIntentionCertificateRequest';
 
+export const handleFormPageComplete$ = (data: {
+  partnerFlag: string;
+  val: string;
+  certObj: MarriageIntentionCertificateRequest;
+}): void => {
+  // const currValue: boolean =
+  //   data.certObj.requestInformation[
+  //     `partner${data.partnerFlag}_formPageComplete`
+  //   ];
+
+  // console.log(`partnerFlag: ${data.partnerFlag}`, data.certObj.answerQuestion);
+  // console.log(
+  //   `handleFormPageComplete$ > partner${
+  //     data.partnerFlag
+  //   }_formPageComplete: ${currValue} > ${!currValue}`
+  // );
+
+  data.certObj.answerQuestion(
+    {
+      [`partner${data.partnerFlag}_formPageComplete`]: data.val,
+    },
+    ''
+  );
+};
+
 export const handleChange$ = (data: {
   e: ChangeEvent<HTMLInputElement>;
   certObj: MarriageIntentionCertificateRequest;
 }) => {
   const { e, certObj } = data;
+  console.log(`certObj: `, certObj);
   certObj.answerQuestion(
     {
       [e.target.name]: e.target.value,

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormA.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormA.tsx
@@ -33,6 +33,7 @@ import {
   handleAdditionalParentChange$,
   handleBloodRelDescChange$,
   handleBloodRelChange$,
+  handleFormPageComplete$,
 } from './eventHandlers';
 
 interface Props {
@@ -53,8 +54,8 @@ export default class PartnerForm extends Component<Props> {
     requestInformation,
   }: MarriageIntentionCertificateRequest): boolean {
     const {
-      partnerA_firstName,
       partnerA_lastName,
+      partnerA_firstName,
       partnerA_dob,
       partnerA_age,
       partnerA_surName,
@@ -162,8 +163,8 @@ export default class PartnerForm extends Component<Props> {
     }
 
     const is_Complete = !!(
-      partnerA_firstName &&
       partnerA_lastName &&
+      partnerA_firstName &&
       partnerA_dob &&
       partnerA_age &&
       partnerA_occupation &&
@@ -454,6 +455,15 @@ export default class PartnerForm extends Component<Props> {
     return false;
   };
 
+  private advanceForm = (certObj: any) => {
+    handleFormPageComplete$({
+      partnerFlag: 'A',
+      val: '1',
+      certObj,
+    });
+    this.props.handleProceed(certObj);
+  };
+
   // RENDER ALL UI
   public render() {
     const {
@@ -493,13 +503,17 @@ export default class PartnerForm extends Component<Props> {
       partnerA_partnershipTypeDissolved,
       partnerA_marriedBefore,
       partnerA_additionalParent,
+      partnerA_formPageComplete,
     } = marriageIntentionCertificateRequest.requestInformation;
 
     const partner_num = partnerNum ? partnerNum : partnerLabel;
 
     return (
       <QuestionComponent
-        handleProceed={this.props.handleProceed}
+        handleProceed={this.advanceForm.bind(
+          this,
+          marriageIntentionCertificateRequest
+        )}
         handleStepBack={this.props.handleStepBack}
         allowProceed={PartnerForm.isComplete(
           marriageIntentionCertificateRequest
@@ -513,6 +527,7 @@ export default class PartnerForm extends Component<Props> {
         >
           {nameFields({
             partnerFlag: partnerLabel,
+            formPageComplete: partnerA_formPageComplete,
             handleChange: this.handleChange,
             handleResidenceStateChange: this.handleResidenceStateChange,
             handleUseSurnameChange: this.handleUseSurnameChange,

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormA.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormA.tsx
@@ -526,8 +526,8 @@ export default class PartnerForm extends Component<Props> {
           }
         >
           {nameFields({
-            partnerFlag: partnerLabel,
             formPageComplete: partnerA_formPageComplete,
+            partnerFlag: partnerLabel,
             handleChange: this.handleChange,
             handleResidenceStateChange: this.handleResidenceStateChange,
             handleUseSurnameChange: this.handleUseSurnameChange,
@@ -541,6 +541,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {datePlaceOfBirth({
+            formPageComplete: partnerA_formPageComplete,
             partnerFlag: partnerLabel,
             partnerDOB: partnerA_dob,
             birthCountryStr: partnerA_birthCountry,
@@ -553,6 +554,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {residence({
+            formPageComplete: partnerA_formPageComplete,
             partnerFlag: partnerLabel,
             residenceZipStr: partnerA_residenceZip,
             residenceCityStr: partnerA_residenceCity,
@@ -567,6 +569,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {marriageBlock({
+            formPageComplete: partnerA_formPageComplete,
             partnerFlag: partnerLabel,
             bloodRelation: partnerA_bloodRelation,
             bloodRelationDesc: partnerA_bloodRelationDesc,
@@ -585,6 +588,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {parents({
+            formPageComplete: partnerA_formPageComplete,
             partnerFlag: partnerLabel,
             parentA_Name: partnerA_parentA_Name,
             parentA_Surname: partnerA_parentA_Surname,

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormB.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormB.tsx
@@ -33,6 +33,7 @@ import {
   handleAdditionalParentChange$,
   handleBloodRelDescChange$,
   handleBloodRelChange$,
+  handleFormPageComplete$,
 } from './eventHandlers';
 
 interface Props {
@@ -81,6 +82,12 @@ export default class PartnerForm extends Component<Props> {
       partnerB_lastMarriageStatus,
       partnerB_additionalParent,
     } = requestInformation;
+
+    console.log(
+      `partnerFormB ... `,
+      requestInformation.partnerA_formPageComplete,
+      requestInformation.partnerB_formPageComplete
+    );
 
     let bloodRelReq = true;
     let useSurnameReq = true;
@@ -185,6 +192,14 @@ export default class PartnerForm extends Component<Props> {
       marriedBeforeReq &&
       useSurnameReq
     );
+
+    if (is_Complete) {
+      handleFormPageComplete$({
+        partnerFlag: 'A',
+        val: '1',
+        certObj: arguments[0],
+      });
+    }
 
     return is_Complete;
   }
@@ -493,6 +508,7 @@ export default class PartnerForm extends Component<Props> {
       partnerB_partnershipTypeDissolved,
       partnerB_marriedBefore,
       partnerB_additionalParent,
+      partnerB_formPageComplete,
     } = marriageIntentionCertificateRequest.requestInformation;
 
     const partner_num = partnerNum ? partnerNum : partnerLabel;
@@ -513,6 +529,7 @@ export default class PartnerForm extends Component<Props> {
         >
           {nameFields({
             partnerFlag: partnerLabel,
+            formPageComplete: partnerB_formPageComplete,
             handleChange: this.handleChange,
             handleResidenceStateChange: this.handleResidenceStateChange,
             handleUseSurnameChange: this.handleUseSurnameChange,

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormB.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormB.tsx
@@ -526,8 +526,8 @@ export default class PartnerForm extends Component<Props> {
           }
         >
           {nameFields({
-            partnerFlag: partnerLabel,
             formPageComplete: partnerB_formPageComplete,
+            partnerFlag: partnerLabel,
             handleChange: this.handleChange,
             handleResidenceStateChange: this.handleResidenceStateChange,
             handleUseSurnameChange: this.handleUseSurnameChange,
@@ -541,6 +541,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {datePlaceOfBirth({
+            formPageComplete: partnerB_formPageComplete,
             partnerFlag: partnerLabel,
             partnerDOB: partnerB_dob,
             birthCountryStr: partnerB_birthCountry,
@@ -553,6 +554,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {residence({
+            formPageComplete: partnerB_formPageComplete,
             partnerFlag: partnerLabel,
             residenceZipStr: partnerB_residenceZip,
             residenceCityStr: partnerB_residenceCity,
@@ -567,6 +569,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {marriageBlock({
+            formPageComplete: partnerB_formPageComplete,
             partnerFlag: partnerLabel,
             bloodRelation: partnerB_bloodRelation,
             bloodRelationDesc: partnerB_bloodRelationDesc,
@@ -585,6 +588,7 @@ export default class PartnerForm extends Component<Props> {
           })}
 
           {parents({
+            formPageComplete: partnerB_formPageComplete,
             partnerFlag: partnerLabel,
             parentA_Name: partnerB_parentA_Name,
             parentA_Surname: partnerB_parentA_Surname,

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormB.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormB.tsx
@@ -83,12 +83,6 @@ export default class PartnerForm extends Component<Props> {
       partnerB_additionalParent,
     } = requestInformation;
 
-    console.log(
-      `partnerFormB ... `,
-      requestInformation.partnerA_formPageComplete,
-      requestInformation.partnerB_formPageComplete
-    );
-
     let bloodRelReq = true;
     let useSurnameReq = true;
     let additionalParentsReq = true;
@@ -192,14 +186,6 @@ export default class PartnerForm extends Component<Props> {
       marriedBeforeReq &&
       useSurnameReq
     );
-
-    if (is_Complete) {
-      handleFormPageComplete$({
-        partnerFlag: 'A',
-        val: '1',
-        certObj: arguments[0],
-      });
-    }
 
     return is_Complete;
   }
@@ -469,6 +455,15 @@ export default class PartnerForm extends Component<Props> {
     return false;
   };
 
+  private advanceForm = (certObj: any) => {
+    handleFormPageComplete$({
+      partnerFlag: 'B',
+      val: '1',
+      certObj,
+    });
+    this.props.handleProceed(certObj);
+  };
+
   // RENDER ALL UI
   public render() {
     const {
@@ -515,7 +510,10 @@ export default class PartnerForm extends Component<Props> {
 
     return (
       <QuestionComponent
-        handleProceed={this.props.handleProceed}
+        handleProceed={this.advanceForm.bind(
+          this,
+          marriageIntentionCertificateRequest
+        )}
         handleStepBack={this.props.handleStepBack}
         allowProceed={PartnerForm.isComplete(
           marriageIntentionCertificateRequest

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormUI.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormUI.tsx
@@ -150,7 +150,6 @@ export const nameFields = (data: {
         disableLabelNoWrap={true}
         maxLength={100}
         softRequired={true}
-        required
         error={
           formPageComplete && formPageComplete === '1' && firstName === ''
             ? 'Please enter your `First Name`'
@@ -179,7 +178,6 @@ export const nameFields = (data: {
         disableLabelNoWrap={true}
         maxLength={100}
         softRequired={true}
-        required
         error={
           formPageComplete && formPageComplete === '1' && lastName === ''
             ? 'Please enter your `Last Name`'

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormUI.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormUI.tsx
@@ -97,6 +97,7 @@ const MEMORABLEDATEINPUT_STYLING = css(`
 
 export const nameFields = (data: {
   partnerFlag: string;
+  formPageComplete?: string | null;
   handleChange: ((e: any) => void) | undefined;
   handleResidenceStateChange: ((e: any) => void) | undefined;
   handleUseSurnameChange: ((e: any) => void) | undefined;
@@ -110,6 +111,7 @@ export const nameFields = (data: {
 }) => {
   const {
     partnerFlag,
+    formPageComplete,
     firstName,
     lastName,
     middleName,
@@ -121,7 +123,6 @@ export const nameFields = (data: {
     handleResidenceStateChange,
     handleUseSurnameChange,
   } = data;
-  // const partnerNameStr = `partner${partnerFlag}_useSurname`;
   const $CSS_SECTION_WRAPPER = css(`margin-bottom: 1.5em;`);
 
   return (
@@ -149,6 +150,12 @@ export const nameFields = (data: {
         disableLabelNoWrap={true}
         maxLength={100}
         softRequired={true}
+        required
+        error={
+          formPageComplete && formPageComplete === '1' && firstName === ''
+            ? 'Please enter your `First Name`'
+            : ''
+        }
       />
 
       <TextInput
@@ -171,6 +178,13 @@ export const nameFields = (data: {
         onChange={handleChange}
         disableLabelNoWrap={true}
         maxLength={100}
+        softRequired={true}
+        required
+        error={
+          formPageComplete && formPageComplete === '1' && lastName === ''
+            ? 'Please enter your `Last Name`'
+            : ''
+        }
       />
 
       <div css={RADIOGROUP_CONTAINER_STYLING}>
@@ -208,12 +222,18 @@ export const nameFields = (data: {
             disableLabelNoWrap={true}
             optionalDescription={`You can keep your current last name or use a new last name.`}
             maxLength={50}
-            softRequired={true}
             toolTip={{
               icon: '?',
               msg:
                 'Examples: Use your future spouse’s last name, use a two-part last name, or create a new last name.',
             }}
+            softRequired={true}
+            required
+            error={
+              formPageComplete && formPageComplete === '1' && surName === ''
+                ? `Please enter the 'Last Name' you'll use`
+                : ''
+            }
           />
         </div>
       )}

--- a/services-js/registry-certs/client/marriageintention/forms/partnerFormUI.tsx
+++ b/services-js/registry-certs/client/marriageintention/forms/partnerFormUI.tsx
@@ -267,6 +267,11 @@ export const nameFields = (data: {
           msg:
             'This information is collected as required by the Massachusetts State Marriage Intention Form.',
         }}
+        error={
+          formPageComplete && formPageComplete === '1' && occupation === ''
+            ? 'Please enter your `Occupation`'
+            : ''
+        }
       />
     </div>
   );
@@ -274,6 +279,7 @@ export const nameFields = (data: {
 
 export const datePlaceOfBirth = (data: {
   partnerFlag: string;
+  formPageComplete?: string | null;
   partnerDOB: Date | null | undefined;
   birthCityStr: string;
   birthCountryStr: string;
@@ -284,26 +290,29 @@ export const datePlaceOfBirth = (data: {
   handleBirthDateChange: (newDate: Date | null) => void;
 }) => {
   const {
+    formPageComplete,
     partnerFlag,
     partnerDOB,
-    handleBirthDateChange,
     birthCityStr,
     birthCountryStr,
     birthStateStr,
     handleChange,
+    handleBirthDateChange,
     handleBirthplaceCountryChange,
     checkBirthCityForNeighborhood,
   } = data;
 
   const birthCity = (data: {
+    formPageComplete?: string | null;
     partnerFlag: string;
-    birthCity: string;
+    birthCityStr: string;
     handleChange: ((e: any) => void) | undefined;
     checkBirthCityForNeighborhood: ((e: any) => void) | undefined;
   }) => {
     const {
+      formPageComplete,
       partnerFlag,
-      birthCity,
+      birthCityStr,
       handleChange,
       checkBirthCityForNeighborhood,
     } = data;
@@ -313,7 +322,7 @@ export const datePlaceOfBirth = (data: {
         <TextInput
           label="Birthplace City/Town"
           name={`partner${partnerFlag}_birthCity`}
-          value={birthCity}
+          value={birthCityStr}
           onChange={handleChange}
           disableLabelNoWrap={true}
           onBlur={checkBirthCityForNeighborhood}
@@ -322,12 +331,19 @@ export const datePlaceOfBirth = (data: {
           }
           maxLength={100}
           softRequired={true}
+          error={
+            formPageComplete &&
+            formPageComplete === '1' &&
+            birthCityStr.length === 0
+              ? `Please enter your 'Birth City/Town'`
+              : ''
+          }
         />
       </div>
     );
   };
 
-  const birthStateZip = (data: {
+  const birthStateAndZip = (data: {
     partnerFlag: string;
     birthStateStr: string;
     handleChange: ((e: any) => void) | undefined;
@@ -359,13 +375,7 @@ export const datePlaceOfBirth = (data: {
 
   return (
     <div css={[SECTION_WRAPPER_STYLING, NAME_FIELDS_BASIC_CONTAINER_STYLING]}>
-      <h1
-        css={[
-          PARTNERFORM_SECTION_HEADING_STYLING,
-          // SECTION_HEADING_STYLING
-          BOTTOM_BORDER,
-        ]}
-      >
+      <h1 css={[PARTNERFORM_SECTION_HEADING_STYLING, BOTTOM_BORDER]}>
         Date and Place of Birth
       </h1>
 
@@ -395,11 +405,18 @@ export const datePlaceOfBirth = (data: {
           onChange={handleBirthplaceCountryChange}
           onBlur={checkBirthCityForNeighborhood}
           softRequired={true}
+          error={
+            formPageComplete &&
+            formPageComplete === '1' &&
+            birthCountryStr === ''
+              ? 'Please select your `Birthplace Country`'
+              : ''
+          }
         />
       </div>
 
       {birthCountryStr === 'USA' &&
-        birthStateZip({
+        birthStateAndZip({
           partnerFlag,
           birthStateStr: birthStateStr,
           handleChange,
@@ -407,8 +424,9 @@ export const datePlaceOfBirth = (data: {
         })}
       {birthCountryStr &&
         birthCity({
+          formPageComplete,
           partnerFlag,
-          birthCity: birthCityStr,
+          birthCityStr: birthCityStr,
           handleChange,
           checkBirthCityForNeighborhood,
         })}
@@ -417,6 +435,7 @@ export const datePlaceOfBirth = (data: {
 };
 
 export const residence = (data: {
+  formPageComplete?: string | null;
   partnerFlag: string;
   residenceZipStr: string;
   residenceCityStr: string;
@@ -430,6 +449,7 @@ export const residence = (data: {
   handleResidenceCountryChange: ((e: any) => void) | undefined;
 }) => {
   const {
+    formPageComplete,
     partnerFlag,
     residenceZipStr,
     residenceCityStr,
@@ -461,6 +481,13 @@ export const residence = (data: {
           maxLength={10}
           minLength={5}
           softRequired={true}
+          error={
+            formPageComplete &&
+            formPageComplete === '1' &&
+            residenceZipStr === ''
+              ? `Please enter your 'Residence Zip Code'`
+              : ''
+          }
         />
       </div>
     );
@@ -474,7 +501,7 @@ export const residence = (data: {
     const { partnerFlag, residenceStateStr, handleResidenceStateChange } = data;
 
     return (
-      <div>
+      <>
         <div
           css={[
             NAME_FIELDS_CONTAINER_STYLING,
@@ -490,9 +517,16 @@ export const residence = (data: {
             value={residenceStateStr}
             onChange={handleResidenceStateChange}
             softRequired={true}
+            error={
+              formPageComplete &&
+              formPageComplete === '1' &&
+              residenceStateStr === ''
+                ? 'Please select your `Residence Address`'
+                : ''
+            }
           />
         </div>
-      </div>
+      </>
     );
   };
 
@@ -525,6 +559,13 @@ export const residence = (data: {
           }
           maxLength={100}
           softRequired={true}
+          error={
+            formPageComplete &&
+            formPageComplete === '1' &&
+            residenceCityStr === ''
+              ? `Please enter your City/Town of Residence'`
+              : ''
+          }
         />
 
         <TextInput
@@ -538,6 +579,13 @@ export const residence = (data: {
           }
           maxLength={100}
           softRequired={true}
+          error={
+            formPageComplete &&
+            formPageComplete === '1' &&
+            residenceAddressStr === ''
+              ? 'Please enter your `Residence Address`'
+              : ''
+          }
         />
       </div>
     );
@@ -577,6 +625,13 @@ export const residence = (data: {
               msg:
                 'If your mailing address differs from your residential one, you can provide your preferred address with the Registry during your appointment.',
             }}
+            error={
+              formPageComplete &&
+              formPageComplete === '1' &&
+              residenceCountryStr === ''
+                ? 'Please select your `Residence Address`'
+                : ''
+            }
           />
         </div>
 
@@ -609,6 +664,7 @@ export const findMarriageNumb = (val: string) =>
   MARRIAGE_COUNT.find(entry => entry.value === val);
 
 export const marriageBlock = (data: {
+  formPageComplete?: string | null;
   partnerFlag: string;
   bloodRelation: string;
   bloodRelationDesc: string;
@@ -626,6 +682,7 @@ export const marriageBlock = (data: {
   handleMarriedBeforeChange: ((e: any) => void) | undefined;
 }) => {
   const {
+    formPageComplete,
     partnerFlag,
     bloodRelation,
     bloodRelationDesc,
@@ -664,6 +721,11 @@ export const marriageBlock = (data: {
             msg:
               'This information is collected as required by Massachusetts State Law Chapter 46 Section 1.',
           }}
+          error={
+            formPageComplete && formPageComplete === '1' && marriageNumb === ''
+              ? 'Please select your `Marriage Number`'
+              : ''
+          }
         />
       </div>
     );
@@ -729,6 +791,7 @@ export const marriageBlock = (data: {
         })}
 
       {$partnershipType({
+        formPageComplete,
         partnerFlag,
         partnershipType,
         partnershipState,
@@ -771,6 +834,7 @@ export const $lastMarriageStatus = (data: {
 };
 
 export const $partnershipType = (data: {
+  formPageComplete?: string | null;
   partnerFlag: string;
   partnershipType: string;
   partnershipState: string;
@@ -778,6 +842,7 @@ export const $partnershipType = (data: {
   handleChange: ((e: any) => void) | undefined;
 }) => {
   const {
+    formPageComplete,
     partnerFlag,
     partnershipType,
     partnershipState,
@@ -816,6 +881,7 @@ export const $partnershipType = (data: {
       {partnershipType &&
         (partnershipType === 'CIV' || partnershipType === 'DOM') &&
         $dissolved({
+          formPageComplete,
           partnerFlag,
           partnershipState,
           partnershipTypeDissolved,
@@ -826,12 +892,14 @@ export const $partnershipType = (data: {
 };
 
 const $dissolved = (data: {
+  formPageComplete?: string | null;
   partnerFlag: string;
   partnershipState: string;
   partnershipTypeDissolved: string;
   handleChange: ((e: any) => void) | undefined;
 }) => {
   const {
+    formPageComplete,
     partnerFlag,
     partnershipTypeDissolved,
     partnershipState,
@@ -866,6 +934,14 @@ const $dissolved = (data: {
         onChange={handleChange}
         disableLabelNoWrap={true}
         maxLength={100}
+        softRequired={true}
+        error={
+          formPageComplete &&
+          formPageComplete === '1' &&
+          partnershipState === ''
+            ? `Please enter your 'Patnershipt's State/Country'`
+            : ''
+        }
       />
     </div>
   );
@@ -927,6 +1003,7 @@ export const parentsMarried = (data: {
 };
 
 export const parents = (data: {
+  formPageComplete?: string | null;
   partnerFlag: string;
   parentA_Name: string;
   parentA_Surname: string;
@@ -938,6 +1015,7 @@ export const parents = (data: {
   handleAdditionalParentChange: ((e: any) => void) | undefined;
 }) => {
   const {
+    formPageComplete,
     partnerFlag,
     parentA_Name,
     parentA_Surname,
@@ -980,6 +1058,11 @@ export const parents = (data: {
           disableLabelNoWrap={true}
           maxLength={38}
           softRequired={true}
+          error={
+            formPageComplete && formPageComplete === '1' && parentA_Name === ''
+              ? `Please enter your 'Parent 1 - Names'`
+              : ''
+          }
         />
 
         <TextInput
@@ -993,6 +1076,13 @@ export const parents = (data: {
             'This information might be found on your birth certificate.'
           }
           softRequired={true}
+          error={
+            formPageComplete &&
+            formPageComplete === '1' &&
+            parentA_Surname === ''
+              ? `Please enter your 'Parent 1 - Family Name at birth or adoption'`
+              : ''
+          }
         />
 
         <div css={RADIOGROUP_CONTAINER_STYLING}>

--- a/services-js/registry-certs/client/marriageintention/index.tsx
+++ b/services-js/registry-certs/client/marriageintention/index.tsx
@@ -27,6 +27,8 @@ import ReviewForms from './forms/reviewForms';
 import ContactInfo from './forms/contactInfo';
 import Receipt from './forms/receipt';
 
+// import { handleFormPageComplete$ } from '../marriageintention/forms/eventHandlers';
+
 interface InitialProps {
   currentStep: MarriageIntentionStep;
 }
@@ -150,6 +152,7 @@ export default class IndexPage extends React.Component<Props, State> {
 
   private advanceQuestion = (
     modifiedRequest: MarriageIntentionCertificateRequest
+    // partnerFlag?: string
   ) => {
     const { currentStep, marriageIntentionCertificateRequest } = this.props;
 
@@ -178,6 +181,15 @@ export default class IndexPage extends React.Component<Props, State> {
     this.setState({
       completedSteps: new Set([...completedSteps, steps.indexOf(nextStep)]),
     });
+
+    // if (partnerFlag && partnerFlag.length > 0) {
+    //   handleFormPageComplete$({
+    //     partnerFlag,
+    //     val: true,
+    //     certObj: modifiedRequest,
+    //   });
+    // }
+
     Router.push(`/marriageintention?step=${nextStep}`);
   };
 

--- a/services-js/registry-certs/client/store/MarriageIntentionCertificateRequest.ts
+++ b/services-js/registry-certs/client/store/MarriageIntentionCertificateRequest.ts
@@ -57,6 +57,7 @@ export const INITIAL_REQUEST_INFORMATION: Readonly<
   partnerA_lastMarriageStatus: '',
   partnerA_marriedBefore: '',
   partnerA_additionalParent: '',
+  partnerA_formPageComplete: '',
 
   partnerB_fullName: '',
   partnerB_firstMiddleName: '',
@@ -94,6 +95,7 @@ export const INITIAL_REQUEST_INFORMATION: Readonly<
   partnerB_lastMarriageStatus: '',
   partnerB_marriedBefore: '',
   partnerB_additionalParent: '',
+  partnerB_formPageComplete: '',
 
   email: '',
   emailConfirm: '',
@@ -207,6 +209,8 @@ export default class MarriageIntentionCertificateRequest {
       partnerA_marriedBefore: this.requestInformation.partnerA_marriedBefore,
       partnerA_additionalParent: this.requestInformation
         .partnerA_additionalParent,
+      partnerA_formPageComplete: this.requestInformation
+        .partnerA_formPageComplete,
 
       partnerB_fullName: this.requestInformation.partnerB_fullName,
       partnerB_firstMiddleName: this.requestInformation
@@ -259,6 +263,8 @@ export default class MarriageIntentionCertificateRequest {
       partnerB_marriedBefore: this.requestInformation.partnerB_marriedBefore,
       partnerB_additionalParent: this.requestInformation
         .partnerB_additionalParent,
+      partnerB_formPageComplete: this.requestInformation
+        .partnerB_formPageComplete,
 
       email: this.requestInformation.email,
       emailConfirm: this.requestInformation.emailConfirm,
@@ -328,6 +334,8 @@ export default class MarriageIntentionCertificateRequest {
       partnerA_marriedBefore: obj.requestInformation.partnerA_marriedBefore,
       partnerA_additionalParent:
         obj.requestInformation.partnerA_additionalParent,
+      partnerA_formPageComplete:
+        obj.requestInformation.partnerA_formPageComplete,
 
       partnerB_fullName: this.requestInformation.partnerB_fullName,
       partnerB_firstMiddleName: this.requestInformation
@@ -377,6 +385,8 @@ export default class MarriageIntentionCertificateRequest {
       partnerB_marriedBefore: obj.requestInformation.partnerB_marriedBefore,
       partnerB_additionalParent:
         obj.requestInformation.partnerB_additionalParent,
+      partnerB_formPageComplete:
+        obj.requestInformation.partnerB_formPageComplete,
 
       email: obj.requestInformation.email,
       emailConfirm: obj.requestInformation.emailConfirm,

--- a/services-js/registry-certs/client/types.ts
+++ b/services-js/registry-certs/client/types.ts
@@ -189,6 +189,7 @@ export type MarriageIntentionCertificateRequestInformation = {
   partnerA_lastMarriageStatus: string;
   partnerA_marriedBefore: string;
   partnerA_additionalParent: string;
+  partnerA_formPageComplete: string;
 
   partnerB_fullName: string;
   partnerB_firstMiddleName: string;
@@ -226,6 +227,7 @@ export type MarriageIntentionCertificateRequestInformation = {
   partnerB_lastMarriageStatus: string;
   partnerB_marriedBefore: string;
   partnerB_additionalParent: string;
+  partnerB_formPageComplete: string;
 
   email: string;
   emailConfirm: string;

--- a/services-js/registry-certs/templates/stylesheets.json
+++ b/services-js/registry-certs/templates/stylesheets.json
@@ -1,3 +1,3 @@
 [
-  "https://patterns.boston.gov/css/public.css"
+  "https://patterns-stg.boston.gov/css/public.css"
 ]


### PR DESCRIPTION
#### DIG-4058: Text Box treatments for data entry states and required fields 

__Use Case__: As a user I will see a different border states for text fields based on my interaction with a field 

- Dark Blue - Default
- Bright Blue - Focus Field is being filled out 
- Light Red - This indicates this is a required field 
- Bold Red - Error, field value fails validation

![image](https://github.com/CityOfBoston/patterns/assets/2627273/9a8584d9-01df-4290-b19b-777951835748)

QA
- Review `focus` state on input fields on the [Form](https://registry-certs.digital-staging.boston.gov/marriageintention?step=partnerFormA)

##### DevQA
- Review Code (styling + template)
- Visual Check:
-- Spin up local dev and review textbox [test](http://localhost:3030/components/detail/textbox--input-states) (`Input States`)

