### PR TITLE
DIG-5600: Banner Design for ABP - Added Docs & Fix Config Type

### DIFF
--- a/services-js/access-boston/README.md
+++ b/services-js/access-boston/README.md
@@ -105,6 +105,19 @@ https://access-boston.boston.gov/
     - services-js/access-boston/src/client/group-management/ConfirmationView.stories.tsx
     - services-js/access-boston/src/client/group-management/ReviewChangesView.stories.tsx
 
+
+### Banner Notification
+Notification Banner appears as the second UI item, after the header/nav. Its is used to display messages color coded by urgency.
+
+| Example | Type |
+|---|---|
+| <img width="300" src="https://github.com/user-attachments/assets/133b729d-36d7-4c0e-85e2-d288476ba4e7" /> | <p>`type`: *info* (light blue)</p> <p>`type`: *warn* (light yellow)</p> <p>`type`: *success* (light green)</p> <p>`type`: *error* (light red)</p> |
+
+| Info | Warn|
+|---|---|
+| <img title="Info" alt="Info" width="300" src="https://github.com/user-attachments/assets/9ef21cf5-7efc-4d67-afdf-b5f2e04f9e47" /> | <img title="Warn" alt="Warn" width="300" src="https://github.com/user-attachments/assets/ade1d384-0ebe-49f5-a058-e7a84b121e19" /> |
+| <img title="Success" alt="Success" width="300" src="https://github.com/user-attachments/assets/212028b9-c3b3-4757-ae19-948137429c86" /> | <img title="Error" alt="Error" width="300" src="https://github.com/user-attachments/assets/1c183e0c-dac8-4a1a-b550-fe9c94a3154b" /> |
+
 ### Deploys
 
 - 2020.05.27: New App entry, PHIRE
@@ -134,3 +147,4 @@ https://access-boston.boston.gov/
 - 2022.02.26: PROD deploy - Remove 'Boston Gives Back' icon/link from Dashboard
 - 2022.02.28: PROD deploy - New Tile, CyberArk
 - 2022.08.11: PROD deploy - Push-through Docker Image Sizing Fix
+- 2025.02.05: PROD deploy - New APB Banner Design

--- a/services-js/access-boston/fixtures/apps.yaml
+++ b/services-js/access-boston/fixtures/apps.yaml
@@ -1,9 +1,7 @@
 notice:
   label: 'Notice'
-  pretext: ''
   text: 'Make your Access Boston account even more secure by setting up the PingID app. It is faster and easier to use than getting codes via text, email or phone! Directions are [here](https://www.boston.gov/access-boston-portal-help#pingid-app-instructions)'
-  copy: 'Make your Access Boston account even more secure by setting up the PingID app. It is faster and easier to use than getting codes via text, email or phone! Directions are [here](https://www.boston.gov/access-boston-portal-help#pingid-app-instructions)'
-  alert: true
+  copy: 'Make your Access Boston account even more secure by setting up the PingID app. It is faster and easier to use than getting codes via text, email or phone! Directions are [here](https://www.boston.gov/access-boston-portal-help#pingid-app-instructions).'
   type: 'info'
 categories:
   - title: Applications

--- a/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
@@ -27,7 +27,6 @@ const QUERY = gql`
 
     notice {
       label
-      pretext
       text
       type
     }

--- a/services-js/access-boston/src/client/graphql/queries.ts
+++ b/services-js/access-boston/src/client/graphql/queries.ts
@@ -73,7 +73,6 @@ export interface FetchAccountAndApps_account {
 
 export interface FetchAccountAndApps_notice {
   label: string;
-  pretext: string;
   text: string;
   type: string;
 }

--- a/services-js/access-boston/src/lib/AppsRegistry.ts
+++ b/services-js/access-boston/src/lib/AppsRegistry.ts
@@ -2,9 +2,7 @@ import yaml from 'js-yaml';
 
 export interface Notice {
   label: string;
-  pretext: string;
   text: string;
-  // type: 'info' | 'warn' | 'error' | 'success' | string | undefined | null;
   type: string;
 }
 
@@ -31,13 +29,11 @@ export interface App {
 
 export class NoticeClass implements Notice {
   label: string = '';
-  pretext: string = '';
   text: string = '';
   type: string = 'info';
 
-  constructor(opts: { label?: any; pretext?: any; text?: any; type?: string }) {
+  constructor(opts: { label?: any; text?: any; type?: string }) {
     (this.label = opts.label ? opts.label : ''),
-      (this.pretext = opts.pretext ? opts.pretext : ''),
       (this.type = opts.type ? opts.type : 'info'),
       (this.text = opts.text ? opts.text : '');
   }

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -89,6 +89,15 @@ export default class IndexPage extends React.Component<Props> {
     const iconCategories = categories.filter(({ showIcons }) => showIcons);
     const listCategories = categories.filter(({ showIcons }) => !showIcons);
 
+    const canUseBannerType =
+      typeof bannerType === 'string' &&
+      ['info', 'warn', 'success', 'error'].includes(bannerType);
+    const noticeType = canUseBannerType
+      ? bannerType
+      : notice.type
+      ? notice.type
+      : `warn`;
+
     return (
       <>
         <Head>
@@ -98,7 +107,7 @@ export default class IndexPage extends React.Component<Props> {
 
         <AppWrapper account={account}>
           {notice && notice.text && (
-            <NoticeBanner type={bannerType ? bannerType : `warn`}>
+            <NoticeBanner type={noticeType}>
               <label>{notice.label}</label>
               <p>{<Markdown>{notice.text}</Markdown>}</p>
             </NoticeBanner>

--- a/services-js/access-boston/src/pages/notice.tsx
+++ b/services-js/access-boston/src/pages/notice.tsx
@@ -7,13 +7,16 @@ import { BannerIcon, NOTICE_WRAPPER } from './gen-components';
 
 export interface NoticeBannerProps {
   children: ReactNode;
-  type?: 'info' | 'warn' | 'error' | 'success' | undefined;
+  type?: 'info' | 'warn' | 'error' | 'success' | string | undefined;
   classString?: string;
 }
 
 /**
  * @name NoticeBanner
  * @description Notice Banner Elem
+ * @param type 'info' | 'warn' | 'error' | 'success' | string | undefined
+ * @param classString string
+ * @param children ReactNode
  */
 export const NoticeBanner = (props: NoticeBannerProps) => {
   const { children, type, classString } = props;

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -115,7 +115,6 @@ export interface App {
 
 export interface Notice {
   label: string;
-  pretext: string;
   text: string;
   type: string;
 }
@@ -143,7 +142,6 @@ const queryRootResolvers: QueryRootResolvers = {
 
     return {
       label: notice['label'],
-      pretext: notice['pretext'],
       text: notice['text'],
       type: notice['type'] ? notice['type'] : 'info',
     };


### PR DESCRIPTION
## Access-Boston/v2025.1

### Digital Service Release Notes
### Related JIRA Tickets
### [DIG-5600: Banner Design for ABP](https://bostondoit.atlassian.net/browse/DIG-5600)
- We add informational banner on the top of Access Boston Portal for departments who want to reach the wider workforce audience with important information. Traditionally we just add the banner with bold typeface. Our UX team has developed a more accessible design we will like to use moving forward.

| Example | Type |
|---|---|
| <img width="300" src="https://github.com/user-attachments/assets/133b729d-36d7-4c0e-85e2-d288476ba4e7" /> | <p>`type`: *info* (light blue)</p> <p>`type`: *warn* (light yellow)</p> <p>`type`: *success* (light green)</p> <p>`type`: *error* (light red)</p> |

| Info | Warn |
|---|---|
| <img title="Info" alt="Info" width="300" src="https://github.com/user-attachments/assets/9ef21cf5-7efc-4d67-afdf-b5f2e04f9e47" /> | <img title="Warn" alt="Warn" width="300" src="https://github.com/user-attachments/assets/ade1d384-0ebe-49f5-a058-e7a84b121e19" /> |
| Success | Error |
| <img title="Success" alt="Success" width="300" src="https://github.com/user-attachments/assets/212028b9-c3b3-4757-ae19-948137429c86" /> | <img title="Error" alt="Error" width="300" src="https://github.com/user-attachments/assets/1c183e0c-dac8-4a1a-b550-fe9c94a3154b" /> |