### PR TITLE
DIG-5710: Allow banners to have security exclusions

### DIFF
--- a/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
+++ b/modules-js/react-fleet/src/__snapshots__/Storyshots.test.ts.snap
@@ -1825,7 +1825,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture 1`] 
           id="future-year"
           max="9999"
           maxLength={4}
-          min={2024}
+          min={2025}
           name="year"
           onBlur={[Function]}
           onChange={[Function]}
@@ -2016,7 +2016,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture and 
           id="story-year"
           max="9999"
           maxLength={4}
-          min={2024}
+          min={2025}
           name="year"
           onBlur={[Function]}
           onChange={[Function]}
@@ -2207,7 +2207,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture and 
           id="story-year"
           max={2040}
           maxLength={4}
-          min={2024}
+          min={2025}
           name="year"
           onBlur={[Function]}
           onChange={[Function]}
@@ -2398,7 +2398,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowFuture and 
           id="story-year"
           max={2040}
           maxLength={4}
-          min={2024}
+          min={2025}
           name="year"
           onBlur={[Function]}
           onChange={[Function]}
@@ -2587,7 +2587,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput onlyAllowPast 1`] = 
         <input
           className="txt-f"
           id="past-year"
-          max={2024}
+          max={2025}
           maxLength={4}
           min="1000"
           name="year"
@@ -2778,7 +2778,7 @@ exports[`Storyshots Form Elements|Inputs/MemorableDateInput with an initialDate 
         <input
           className="txt-f"
           id="initial-year"
-          max={2024}
+          max={2025}
           maxLength={4}
           min="1000"
           name="year"

--- a/services-js/access-boston/README.md
+++ b/services-js/access-boston/README.md
@@ -118,7 +118,7 @@ Notification Banner appears as the second UI item, after the header/nav. Its is 
 | <img title="Info" alt="Info" width="300" src="https://github.com/user-attachments/assets/9ef21cf5-7efc-4d67-afdf-b5f2e04f9e47" /> | <img title="Warn" alt="Warn" width="300" src="https://github.com/user-attachments/assets/ade1d384-0ebe-49f5-a058-e7a84b121e19" /> |
 | <img title="Success" alt="Success" width="300" src="https://github.com/user-attachments/assets/212028b9-c3b3-4757-ae19-948137429c86" /> | <img title="Error" alt="Error" width="300" src="https://github.com/user-attachments/assets/1c183e0c-dac8-4a1a-b550-fe9c94a3154b" /> |
 
-### Deploys
+### Releases
 
 - 2020.05.27: New App entry, PHIRE
 - 2020.07.10: Adding group to Building Maintenance Form Link
@@ -148,3 +148,4 @@ Notification Banner appears as the second UI item, after the header/nav. Its is 
 - 2022.02.28: PROD deploy - New Tile, CyberArk
 - 2022.08.11: PROD deploy - Push-through Docker Image Sizing Fix
 - 2025.02.05: PROD deploy - New APB Banner Design
+- 2025.02.21: PROD deploy - Allow banners to have security exclusions

--- a/services-js/access-boston/fixtures/apps.yaml
+++ b/services-js/access-boston/fixtures/apps.yaml
@@ -3,6 +3,8 @@ notice:
   text: 'Make your Access Boston account even more secure by setting up the PingID app. It is faster and easier to use than getting codes via text, email or phone! Directions are [here](https://www.boston.gov/access-boston-portal-help#pingid-app-instructions)'
   copy: 'Make your Access Boston account even more secure by setting up the PingID app. It is faster and easier to use than getting codes via text, email or phone! Directions are [here](https://www.boston.gov/access-boston-portal-help#pingid-app-instructions).'
   type: 'info'
+  exclusions:
+    - BPD
 categories:
   - title: Applications
     show_request_access_link: false

--- a/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
+++ b/services-js/access-boston/src/client/graphql/fetch-account-and-apps.ts
@@ -29,6 +29,7 @@ const QUERY = gql`
       label
       text
       type
+      exclusions
     }
 
     apps {

--- a/services-js/access-boston/src/client/graphql/queries.ts
+++ b/services-js/access-boston/src/client/graphql/queries.ts
@@ -75,6 +75,7 @@ export interface FetchAccountAndApps_notice {
   label: string;
   text: string;
   type: string;
+  exclusions: string[];
 }
 
 export interface FetchAccountAndApps_apps_categories_apps {

--- a/services-js/access-boston/src/lib/AppsRegistry.ts
+++ b/services-js/access-boston/src/lib/AppsRegistry.ts
@@ -4,6 +4,7 @@ export interface Notice {
   label: string;
   text: string;
   type: string;
+  exclusions: string[];
 }
 
 export interface AppsCategory {
@@ -31,10 +32,17 @@ export class NoticeClass implements Notice {
   label: string = '';
   text: string = '';
   type: string = 'info';
+  exclusions: string[] = [''];
 
-  constructor(opts: { label?: any; text?: any; type?: string }) {
+  constructor(opts: {
+    label?: any;
+    text?: any;
+    type?: string;
+    exclusions?: string[];
+  }) {
     (this.label = opts.label ? opts.label : ''),
       (this.type = opts.type ? opts.type : 'info'),
+      (this.exclusions = opts.exclusions ? opts.exclusions : ['']),
       (this.text = opts.text ? opts.text : '');
   }
 }

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -98,6 +98,15 @@ export default class IndexPage extends React.Component<Props> {
       ? notice.type
       : `warn`;
 
+    console.log(`notice: `, notice.exclusions);
+    console.log(`account: `, account.cobAgency);
+    if (account['cobAgency']) {
+      console.log(
+        `notice.exclusions.includes(account['cobAgency']): `,
+        notice.exclusions.includes(account['cobAgency'])
+      );
+    }
+
     return (
       <>
         <Head>
@@ -106,12 +115,16 @@ export default class IndexPage extends React.Component<Props> {
         </Head>
 
         <AppWrapper account={account}>
-          {notice && notice.text && (
-            <NoticeBanner type={noticeType}>
-              <label>{notice.label}</label>
-              <p>{<Markdown>{notice.text}</Markdown>}</p>
-            </NoticeBanner>
-          )}
+          {notice &&
+            notice.text &&
+            account['cobAgency'] &&
+            notice['exclusions'] &&
+            !notice.exclusions.includes(account['cobAgency']) && (
+              <NoticeBanner type={noticeType}>
+                <label>{notice.label}</label>
+                <p>{<Markdown>{notice.text}</Markdown>}</p>
+              </NoticeBanner>
+            )}
 
           {flashMessage && (
             <NoticeBanner type={`success`}>

--- a/services-js/access-boston/src/server/graphql/schema.ts
+++ b/services-js/access-boston/src/server/graphql/schema.ts
@@ -117,6 +117,7 @@ export interface Notice {
   label: string;
   text: string;
   type: string;
+  exclusions: string[];
 }
 
 // This file is built by the "generate-graphql-schema" script from
@@ -144,6 +145,7 @@ const queryRootResolvers: QueryRootResolvers = {
       label: notice['label'],
       text: notice['text'],
       type: notice['type'] ? notice['type'] : 'info',
+      exclusions: notice['exclusions'] ? notice['exclusions'] : [''],
     };
   },
 

--- a/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/registry-certs/client/__snapshots__/Storyshots.test.ts.snap
@@ -10296,7 +10296,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation birth too rece
               <input
                 className="txt-f"
                 id="dob-year"
-                max={2024}
+                max={2025}
                 maxLength={4}
                 min={1870}
                 name="year"
@@ -10867,7 +10867,7 @@ exports[`Storyshots Birth/Question Components/PersonalInformation default 1`] = 
               <input
                 className="txt-f"
                 id="dob-year"
-                max={2024}
+                max={2025}
                 maxLength={4}
                 min={1870}
                 name="year"
@@ -14489,7 +14489,7 @@ Array [
                         <input
                           className="txt-f"
                           id="dob-year"
-                          max={2024}
+                          max={2025}
                           maxLength={4}
                           min={1870}
                           name="year"
@@ -39670,7 +39670,7 @@ exports[`Storyshots Common Components/DateRangePicker default 1`] = `
           <input
             className="year-field txt-f "
             id="date1year"
-            max={2024}
+            max={2025}
             min={1870}
             onBlur={[Function]}
             onChange={[Function]}
@@ -39729,7 +39729,7 @@ exports[`Storyshots Common Components/DateRangePicker default 1`] = `
           <input
             className="year-field txt-f "
             id="date2year"
-            max={2024}
+            max={2025}
             min={1870}
             onBlur={[Function]}
             onChange={[Function]}
@@ -39881,7 +39881,7 @@ exports[`Storyshots Common Components/DateRangePicker range too vast 1`] = `
           <input
             className="year-field txt-f "
             id="date1year"
-            max={2024}
+            max={2025}
             min={1870}
             onBlur={[Function]}
             onChange={[Function]}
@@ -39940,7 +39940,7 @@ exports[`Storyshots Common Components/DateRangePicker range too vast 1`] = `
           <input
             className="year-field txt-f "
             id="date2year"
-            max={2024}
+            max={2025}
             min={1870}
             onBlur={[Function]}
             onChange={[Function]}
@@ -40092,7 +40092,7 @@ exports[`Storyshots Common Components/DateRangePicker with values 1`] = `
           <input
             className="year-field txt-f "
             id="date1year"
-            max={2024}
+            max={2025}
             min={1870}
             onBlur={[Function]}
             onChange={[Function]}
@@ -40151,7 +40151,7 @@ exports[`Storyshots Common Components/DateRangePicker with values 1`] = `
           <input
             className="year-field txt-f "
             id="date2year"
-            max={2024}
+            max={2025}
             min={1870}
             onBlur={[Function]}
             onChange={[Function]}
@@ -40253,7 +40253,7 @@ exports[`Storyshots Common Components/DateRangePicker/DateComponent default 1`] 
         <input
           className="year-field txt-f "
           id="date1year"
-          max={2024}
+          max={2025}
           min={1870}
           onBlur={[Function]}
           onChange={[Function]}
@@ -40354,7 +40354,7 @@ exports[`Storyshots Common Components/DateRangePicker/DateComponent with values 
         <input
           className="year-field txt-f "
           id="date2year"
-          max={2024}
+          max={2025}
           min={1870}
           onBlur={[Function]}
           onChange={[Function]}
@@ -63870,7 +63870,7 @@ exports[`Storyshots Marriage Intention/Form Components Step 2. Person 1 - Birth 
           <input
             className="txt-f"
             id="dob-year"
-            max={2024}
+            max={2025}
             maxLength={4}
             min="1000"
             name="year"
@@ -65868,7 +65868,7 @@ exports[`Storyshots Marriage Intention/Form Components Step 2. Person 1 - Birth 
           <input
             className="txt-f"
             id="dob-year"
-            max={2024}
+            max={2025}
             maxLength={4}
             min="1000"
             name="year"
@@ -68162,7 +68162,7 @@ exports[`Storyshots Marriage Intention/Form Components Step 2. Person 1 - Birth 
           <input
             className="txt-f"
             id="dob-year"
-            max={2024}
+            max={2025}
             maxLength={4}
             min="1000"
             name="year"
@@ -77954,7 +77954,7 @@ Array [
                             <input
                               className="txt-f"
                               id="dob-year"
-                              max={2024}
+                              max={2025}
                               maxLength={4}
                               min="1000"
                               name="year"
@@ -83570,7 +83570,7 @@ Array [
                             <input
                               className="txt-f"
                               id="dob-year"
-                              max={2024}
+                              max={2025}
                               maxLength={4}
                               min="1000"
                               name="year"
@@ -88476,7 +88476,7 @@ Array [
                                 id="appointmentDate-year"
                                 max="9999"
                                 maxLength={4}
-                                min={2024}
+                                min={2025}
                                 name="year"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -97044,7 +97044,7 @@ exports[`Storyshots Marriage/Question Components/DateOfMarriage date range too v
               <input
                 className="year-field txt-f "
                 id="date1year"
-                max={2024}
+                max={2025}
                 min={1870}
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -97103,7 +97103,7 @@ exports[`Storyshots Marriage/Question Components/DateOfMarriage date range too v
               <input
                 className="year-field txt-f "
                 id="date2year"
-                max={2024}
+                max={2025}
                 min={1870}
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -98059,7 +98059,7 @@ exports[`Storyshots Marriage/Question Components/DateOfMarriage knows exact date
               <input
                 className="txt-f"
                 id="dateOfMarriageStart-year"
-                max={2024}
+                max={2025}
                 maxLength={4}
                 min={1870}
                 name="year"
@@ -98636,7 +98636,7 @@ exports[`Storyshots Marriage/Question Components/DateOfMarriage marriage too rec
               <input
                 className="txt-f"
                 id="dateOfMarriageStart-year"
-                max={2024}
+                max={2025}
                 maxLength={4}
                 min={1870}
                 name="year"
@@ -99187,7 +99187,7 @@ exports[`Storyshots Marriage/Question Components/DateOfMarriage unsure of date 1
               <input
                 className="year-field txt-f "
                 id="date1year"
-                max={2024}
+                max={2025}
                 min={1870}
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -99246,7 +99246,7 @@ exports[`Storyshots Marriage/Question Components/DateOfMarriage unsure of date 1
               <input
                 className="year-field txt-f "
                 id="date2year"
-                max={2024}
+                max={2025}
                 min={1870}
                 onBlur={[Function]}
                 onChange={[Function]}


### PR DESCRIPTION
### [DIG-5710: Allow banners to have security exclusions](https://bostondoit.atlassian.net/browse/DIG-5710)

**Use Case**: As a user, if I am in a security group or COB Agency that has been excluded from seeing a specific banner on APB, I should not see it when I log into the tool. 

![image](https://github.com/user-attachments/assets/41ea5e16-853a-4ca0-a21b-74186add7f12)

